### PR TITLE
Do not send idfa if tracking is limited

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Util.java
@@ -402,14 +402,19 @@ public class Util {
      * - If called from the UI Thread will throw an Exception
      *
      * @param context the android context
-     * @return the advertising id or null
+     * @return an empty string if limited tracking is on otherwise the advertising id or null
      */
     public static String getAndroidIdfa(Context context) {
         try {
-            Object AdvertisingInfoObject = invokeStaticMethod(
+            Object advertisingInfoObject = invokeStaticMethod(
                     "com.google.android.gms.ads.identifier.AdvertisingIdClient",
                     "getAdvertisingIdInfo", new Class[]{Context.class}, context);
-            return (String) invokeInstanceMethod(AdvertisingInfoObject, "getId", null);
+            Boolean limitedTracking = (Boolean) invokeInstanceMethod(advertisingInfoObject,
+                    "isLimitAdTrackingEnabled", null);
+            if (limitedTracking) {
+                return "";
+            }
+            return (String) invokeInstanceMethod(advertisingInfoObject, "getId", null);
         }
         catch (Exception e) {
             Logger.e(TAG, "Exception getting the Advertising ID: %s", e.toString());


### PR DESCRIPTION
Hello,

We have noticed during our tests that even if tracking is disabled, snowplow still gets the Idfa.
I think snowplow tracker should conform to this, since gathered data may be used for multiple usages including targeted advertising.

Feel free to open a new pull request if my proposed fix is not satisfying.