### PR TITLE
Ensuring the EventStore database cursor is closed

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/storage/EventStore.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/storage/EventStore.java
@@ -175,20 +175,27 @@ public class EventStore {
     private List<Map<String, Object>> queryDatabase(String query, String orderBy) {
         List<Map<String, Object>> res = new ArrayList<>();
         if (isDatabaseOpen()) {
-            Cursor cursor = database.query(EventStoreHelper.TABLE_EVENTS, allColumns, query,
-                    null, null, null, orderBy);
 
-            cursor.moveToFirst();
-            while (!cursor.isAfterLast()) {
-                Map<String, Object> eventMetadata = new HashMap<>();
-                eventMetadata.put(EventStoreHelper.METADATA_ID, cursor.getLong(0));
-                eventMetadata.put(EventStoreHelper.METADATA_EVENT_DATA,
-                        Util.deserializer(cursor.getBlob(1)));
-                eventMetadata.put(EventStoreHelper.METADATA_DATE_CREATED, cursor.getString(2));
-                cursor.moveToNext();
-                res.add(eventMetadata);
+            Cursor cursor = null;
+
+            try {
+                cursor = database.query(EventStoreHelper.TABLE_EVENTS, allColumns, query, null, null, null, orderBy);
+
+                cursor.moveToFirst();
+                while (!cursor.isAfterLast()) {
+                    Map<String, Object> eventMetadata = new HashMap<>();
+                    eventMetadata.put(EventStoreHelper.METADATA_ID, cursor.getLong(0));
+                    eventMetadata.put(EventStoreHelper.METADATA_EVENT_DATA,
+                            Util.deserializer(cursor.getBlob(1)));
+                    eventMetadata.put(EventStoreHelper.METADATA_DATE_CREATED, cursor.getString(2));
+                    cursor.moveToNext();
+                    res.add(eventMetadata);
+                }
+            } finally {
+                if (cursor != null) {
+                    cursor.close();
+                }
             }
-            cursor.close();
         }
         return res;
     }


### PR DESCRIPTION
While working on an app crash caused by a CursorWindowAllocationException I wanted to check if everything was fine in the SnowPlow codebase as we use it.
By adding the try{} finally{} we enforce the cursor to be closed even if there is an early return or an exception raised.
Otherwise the cursor may not be closed properly.
See: http://oteku.blogspot.com/2013/11/how-to-detect-android-cursor-leak-en.html
See too: https://stackoverflow.com/questions/11340257/sqlite-android-database-cursor-window-allocation-of-2048-kb-failed