### PR TITLE
Fix crash when lifecycleEvents is enabled on Tracker initialisation

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -18,6 +18,7 @@ import android.app.Application;
 import android.content.Context;
 import android.os.Build;
 import android.arch.lifecycle.ProcessLifecycleOwner;
+import android.os.Handler;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -453,8 +454,10 @@ public class Tracker {
         // If lifecycleEvents is True
         if ((this.lifecycleEvents || this.sessionContext) &&
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            // oddly adding this observer loads a file - needs to be called off main thread
-            Executor.execute(new Runnable() {
+
+            // addObserver must execute on the mainThread
+            Handler mainHandler = new Handler(context.getMainLooper());
+            mainHandler.post(new Runnable() {
                 @Override
                 public void run() {
                     ProcessLifecycleOwner.get().getLifecycle().addObserver(new ProcessObserver());


### PR DESCRIPTION
#339 

Moved the runnable to always run on the Main Thread. There was a previous fix done to this that moved it to run on a background thread (#159) but that appears to have been a bad choice given this issue. This doesn't always cause a crash but it's clear that addObserver is marked as @mainThread and we should ensure we're running these lifecycle handlers as such.