### PR TITLE
Session userId renewed for the same user (close #345)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -429,26 +429,20 @@ public class Tracker {
 
         // When session context is enabled
         if (this.sessionContext) {
+            Runnable[] callbacks = {null, null, null, null};
             if (sessionCallbacks.length == 4) {
-                this.trackerSession = new Session(
-                        builder.foregroundTimeout,
-                        builder.backgroundTimeout,
-                        builder.timeUnit,
-                        builder.context,
-                        builder.sessionCallbacks[0],
-                        builder.sessionCallbacks[1],
-                        builder.sessionCallbacks[2],
-                        builder.sessionCallbacks[3]
-                );
-            } else {
-                this.trackerSession = new Session(
-                        builder.foregroundTimeout,
-                        builder.backgroundTimeout,
-                        builder.timeUnit,
-                        builder.context
-                );
+                callbacks = sessionCallbacks;
             }
-
+            this.trackerSession = Session.getInstance(
+                    builder.foregroundTimeout,
+                    builder.backgroundTimeout,
+                    builder.timeUnit,
+                    builder.context,
+                    callbacks[0],
+                    callbacks[1],
+                    callbacks[2],
+                    callbacks[3]
+            );
         }
 
         // If lifecycleEvents is True


### PR DESCRIPTION
- Removed session data persisted on internal storage because it could cause exceptions forcing renewing of userId
- Session as singleton in order to avoid concurrent accesses on persisted session values