### PR TITLE
Fix screen context not correctly updated on screenView events (close #350)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/events/ScreenViewTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/events/ScreenViewTest.java
@@ -17,7 +17,10 @@ import android.test.AndroidTestCase;
 
 import com.snowplowanalytics.snowplow.tracker.constants.Parameters;
 
+import org.junit.internal.runners.statements.Fail;
+
 import java.util.Map;
+import java.util.UUID;
 
 public class ScreenViewTest extends AndroidTestCase {
 
@@ -30,38 +33,37 @@ public class ScreenViewTest extends AndroidTestCase {
 
         assertNotNull(data);
         assertEquals("name", data.get(Parameters.SV_NAME));
-        assertFalse(data.containsKey(Parameters.SV_ID));
+        assertTrue(data.containsKey(Parameters.SV_ID));
 
+        String id = UUID.randomUUID().toString();
         screenView = ScreenView.builder()
-                .id("id")
+                .id(id)
                 .build();
 
         data = screenView.getData().getMap();
 
         assertNotNull(data);
-        assertEquals("id", data.get(Parameters.SV_ID));
+        assertEquals(id, data.get(Parameters.SV_ID));
         assertFalse(data.containsKey(Parameters.SV_NAME));
 
         screenView = ScreenView.builder()
                 .name("name")
-                .id("id")
+                .id(id)
                 .build();
 
         data = screenView.getData().getMap();
 
         assertNotNull(data);
         assertEquals("name", data.get(Parameters.SV_NAME));
-        assertEquals("id", data.get(Parameters.SV_ID));
+        assertEquals(id, data.get(Parameters.SV_ID));
     }
 
     public void testBuilderFailures() {
-        boolean exception = false;
         try {
-            ScreenView.builder().build();
+            ScreenView.builder().id("id").build();
+            fail();
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
-            exception = true;
         }
-        assertTrue(exception);
     }
 }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -52,6 +52,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -385,10 +386,11 @@ public class EventSendingTest extends AndroidTestCase {
     }
 
     public void trackScreenView(Tracker tracker) throws Exception {
-        tracker.track(ScreenView.builder().name("screenName").id("screenId").build());
-        tracker.track(ScreenView.builder().name("screenName").id("screenId").customContext(getCustomContext()).build());
-        tracker.track(ScreenView.builder().name("screenName").id("screenId").deviceCreatedTimestamp((long) 1433791172).build());
-        tracker.track(ScreenView.builder().name("screenName").id("screenId").deviceCreatedTimestamp((long) 1433791172).customContext(getCustomContext()).build());
+        String id = UUID.randomUUID().toString();
+        tracker.track(ScreenView.builder().name("screenName").build());
+        tracker.track(ScreenView.builder().name("screenName").customContext(getCustomContext()).build());
+        tracker.track(ScreenView.builder().name("screenName").id(id).deviceCreatedTimestamp((long) 1433791172).build());
+        tracker.track(ScreenView.builder().name("screenName").id(id).deviceCreatedTimestamp((long) 1433791172).customContext(getCustomContext()).build());
     }
 
     public void trackTimings(Tracker tracker) throws Exception {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/utils/UtilTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/utils/UtilTest.java
@@ -5,7 +5,6 @@ import android.test.AndroidTestCase;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameters;
 import com.snowplowanalytics.snowplow.tracker.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
-import com.snowplowanalytics.snowplow.tracker.storage.EventStore;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -23,7 +22,7 @@ public class UtilTest extends AndroidTestCase {
     }
 
     public void testGetEventId() {
-        String eid = Util.getEventId();
+        String eid = Util.getUUIDString();
         assertNotNull(eid);
         assertTrue(eid.matches("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"));
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Session.java
@@ -123,7 +123,7 @@ public class Session {
             @Override
             public Void call() {
                 if (sharedPreferences.contains(Parameters.SESSION_USER_ID)) {
-                    userId = sharedPreferences.getString(Parameters.SESSION_USER_ID, Util.getEventId());
+                    userId = sharedPreferences.getString(Parameters.SESSION_USER_ID, Util.getUUIDString());
                     currentSessionId = sharedPreferences.getString(Parameters.SESSION_ID, null);
                     sessionIndex = sharedPreferences.getInt(Parameters.SESSION_INDEX, 0);
                 } else {
@@ -135,10 +135,10 @@ public class Session {
                             sessionIndex = (int)sessionInfo.get(Parameters.SESSION_INDEX);
                         } catch (Exception e) {
                             Logger.e(TAG, String.format("Exception occurred retrieving session info from file: %s", e));
-                            userId = Util.getEventId();
+                            userId = Util.getUUIDString();
                         }
                     } else {
-                        userId = Util.getEventId();
+                        userId = Util.getUUIDString();
                     }
                 }
                 updateSessionInfo();
@@ -295,7 +295,7 @@ public class Session {
      */
     private synchronized void updateSessionInfo() {
         this.previousSessionId = this.currentSessionId;
-        this.currentSessionId = Util.getEventId();
+        this.currentSessionId = Util.getUUIDString();
         this.sessionIndex++;
 
         Logger.d(TAG, "Session information is updated:");

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -485,6 +485,11 @@ public class Tracker {
             return;
         }
 
+        if (ScreenView.class.isInstance(event) && screenState != null) {
+            ScreenView screenView = (ScreenView) event;
+            screenView.updateScreenState(screenState);
+        }
+
         Executor.execute(new Runnable() {
             @Override
             public void run() {
@@ -888,7 +893,9 @@ public class Tracker {
 
     /**
      * Track a screen with a screen state (many options)
+     * @deprecated Use track(Event) method passing a ScreenView event.
      */
+    @Deprecated
     public void trackScreen(ScreenState screenState) {
         this.screenState = screenState;
         SelfDescribingJson data = screenState.getScreenViewEventJson();
@@ -900,9 +907,11 @@ public class Tracker {
 
     /**
      * Track a screen only by name
+     * @deprecated Use track(Event) method passing a ScreenView event.
      */
+    @Deprecated
     public void trackScreen(String name) {
-        screenState.newScreenState(name, null, null);
+        screenState.updateScreenState(null, name, null, null);
         SelfDescribingJson data = screenState.getScreenViewEventJson();
         track(SelfDescribing.builder()
                 .eventData(data)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/AbstractEvent.java
@@ -41,7 +41,7 @@ public abstract class AbstractEvent implements Event {
     public static abstract class Builder<T extends Builder<T>> {
 
         private List<SelfDescribingJson> context = new LinkedList<>();
-        private String eventId = Util.getEventId();
+        private String eventId = Util.getUUIDString();
         private long deviceCreatedTimestamp = System.currentTimeMillis();
         private Long trueTimestamp = null;
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/ScreenView.java
@@ -13,13 +13,23 @@
 
 package com.snowplowanalytics.snowplow.tracker.events;
 
+import android.app.Activity;
+import android.app.Fragment;
+
 import com.snowplowanalytics.snowplow.tracker.constants.Parameters;
 import com.snowplowanalytics.snowplow.tracker.constants.TrackerConstants;
+import com.snowplowanalytics.snowplow.tracker.tracker.ScreenState;
+import com.snowplowanalytics.snowplow.tracker.utils.Logger;
 import com.snowplowanalytics.snowplow.tracker.utils.Preconditions;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.payload.TrackerPayload;
+import com.snowplowanalytics.snowplow.tracker.utils.Util;
+
+import java.lang.reflect.Field;
 
 public class ScreenView extends AbstractEvent {
+
+    private final static String TAG = ScreenView.class.getSimpleName();
 
     private final String name;
     private final String id;
@@ -28,6 +38,10 @@ public class ScreenView extends AbstractEvent {
     private String previousName;
     private String previousId;
     private String previousType;
+    private String fragmentClassName;
+    private String fragmentTag;
+    private String activityClassName;
+    private String activityTag;
 
     public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
 
@@ -38,6 +52,10 @@ public class ScreenView extends AbstractEvent {
         private String previousName;
         private String previousId;
         private String previousType;
+        private String fragmentClassName;
+        private String fragmentTag;
+        private String activityClassName;
+        private String activityTag;
 
         /**
          * @param name The name of the screen view event
@@ -102,6 +120,26 @@ public class ScreenView extends AbstractEvent {
             return self();
         }
 
+        public T fragmentClassName(String fragmentClassName) {
+            this.fragmentClassName = fragmentClassName;
+            return self();
+        }
+
+        public T fragmentTag(String fragmentTag) {
+            this.fragmentTag = fragmentTag;
+            return self();
+        }
+
+        public T activityClassName(String activityClassName) {
+            this.activityClassName = activityClassName;
+            return self();
+        }
+
+        public T activityTag(String activityTag) {
+            this.activityTag = activityTag;
+            return self();
+        }
+
         public ScreenView build() {
             return new ScreenView(this);
         }
@@ -118,19 +156,66 @@ public class ScreenView extends AbstractEvent {
         return new Builder2();
     }
 
+    public static ScreenView buildWithActivity(Activity activity) {
+        String activityClassName = activity.getLocalClassName();
+        String activityTag = getSnowplowScreenId(activity);
+        String name = getValidName(activityClassName, activityTag);
+        return ScreenView.builder()
+                .activityClassName(activityClassName)
+                .activityTag(activityTag)
+                .fragmentClassName(null)
+                .fragmentTag(null)
+                .name(name)
+                .type(activityClassName)
+                .transitionType(null)
+                .build();
+    }
+
+    public static ScreenView buildWithFragment(Fragment fragment) {
+        String fragmentClassName = fragment.getClass().getSimpleName();
+        String fragmentTag = fragment.getTag();
+        String name = getValidName(fragmentClassName, fragmentTag);
+        return ScreenView.builder()
+                .activityClassName(null)
+                .activityTag(null)
+                .fragmentClassName(fragment.getClass().getSimpleName())
+                .fragmentTag(fragment.getTag())
+                .name(name)
+                .type(fragmentClassName)
+                .transitionType(null)
+                .build();
+    }
+
     protected ScreenView(Builder<?> builder) {
         super(builder);
 
-        // Precondition checks
-        Preconditions.checkArgument(builder.name != null || builder.id != null);
+        if (builder.id != null) {
+            Preconditions.checkArgument(Util.isUUIDString(builder.id));
+            id = builder.id;
+        } else {
+            id = Util.getUUIDString();
+        }
 
         this.name = builder.name;
-        this.id = builder.id;
         this.type = builder.type;
         this.previousId = builder.previousId;
         this.previousName = builder.previousName;
         this.previousType = builder.previousType;
         this.transitionType = builder.transitionType;
+        this.fragmentClassName = builder.fragmentClassName;
+        this.fragmentTag = builder.fragmentTag;
+        this.activityClassName = builder.activityClassName;
+        this.activityTag = builder.activityTag;
+    }
+
+    /**
+     * Update the passed screen state with the data related to
+     * the current ScreenView event.
+     * @param screenState The screen state to update.
+     */
+    public void updateScreenState(ScreenState screenState) {
+        if (screenState == null) return;
+        screenState.updateScreenState(id, name, type, transitionType, fragmentClassName, fragmentTag, activityClassName, activityTag);
     }
 
     /**
@@ -159,4 +244,33 @@ public class ScreenView extends AbstractEvent {
     public SelfDescribingJson getPayload() {
         return new SelfDescribingJson(TrackerConstants.SCHEMA_SCREEN_VIEW, getData());
     }
+
+    private static String getSnowplowScreenId(Activity activity) {
+        Class<? extends Activity> activityClass = activity.getClass();
+        try {
+            Field field = activityClass.getField("snowplowScreenId");
+            Object reflectedValue = field.get(activity);
+            if (reflectedValue instanceof String) {
+                return (String) reflectedValue;
+            } else {
+                Logger.e(TAG,String.format("The value of field `snowplowScreenId` on Activity `%s` has to be a String.", activityClass.getSimpleName()));
+            }
+        } catch (NoSuchFieldException e) {
+            Logger.d(TAG, String.format("Field `snowplowScreenId` not found on Activity `%s`.", activityClass.getSimpleName()), e);
+        } catch (Exception e) {
+            Logger.e(TAG, "Error retrieving value of field `snowplowScreenId`: " + e.getMessage(), e);
+        }
+        return null;
+    }
+
+    private static String getValidName(String s1, String s2) {
+        if (s1 != null && s1.length() > 0) {
+            return s1;
+        }
+        if (s2 != null && s2.length() > 0) {
+            return s2;
+        }
+        return "Unknown";
+    }
+
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/tracker/ActivityLifecycleHandler.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/tracker/ActivityLifecycleHandler.java
@@ -21,6 +21,7 @@ import android.os.Bundle;
 
 
 import com.snowplowanalytics.snowplow.tracker.Tracker;
+import com.snowplowanalytics.snowplow.tracker.events.ScreenView;
 import com.snowplowanalytics.snowplow.tracker.events.SelfDescribing;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.utils.Logger;
@@ -61,15 +62,8 @@ public class ActivityLifecycleHandler implements Application.ActivityLifecycleCa
     public void onActivityResumed(Activity activity) {
         Logger.d(TAG, "Auto screenview occurred - activity has resumed");
         try {
-            Tracker tracker = Tracker.instance();
-            ScreenState screenState = tracker.getScreenState();
-            screenState.updateWithActivity(activity);
-            SelfDescribingJson data = screenState.getScreenViewEventJson();
-            tracker.track(SelfDescribing.builder()
-                    .eventData(data)
-                    .customContext(contexts)
-                    .build()
-            );
+            ScreenView event = ScreenView.buildWithActivity(activity);
+            Tracker.instance().track(event);
         } catch (Exception e) {
             Logger.e(TAG, e.getMessage());
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Util.java
@@ -45,7 +45,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Provides basic Utilities for the Snowplow Tracker.
@@ -80,8 +79,33 @@ public class Util {
      *
      * @return a UUID string
      */
-    public static String getEventId() {
+    public static String getUUIDString() {
         return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Check the passed string is a UUID code.
+     *
+     * @param uuid a UUID code string.
+     * @return true if it's a UUID code.
+     */
+    public static boolean isUUIDString(String uuid) {
+        try {
+            return UUID.fromString(uuid) != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Generates a random UUID for
+     * each event.
+     *
+     * @deprecated  Use `getUUIDString` instead.
+     */
+    @Deprecated
+    public static String getEventId() {
+        return getUUIDString();
     }
 
     /**


### PR DESCRIPTION
Fix #350 
As reported in the linked issue, the screen context wasn't correctly updated when the app send a screenView event. It used to work correctly only with automatic screenView tracking.
The bug is related to the software design so I needed to refactor a bit the logic behind ScreenState updating.