### PR TITLE
Add support for GDPR context (close #312)

### DIFF
--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
@@ -33,6 +33,7 @@ import android.net.Uri;
 import androidx.test.espresso.IdlingResource;
 
 import com.snowplowanalytics.snowplow.tracker.DevicePlatforms;
+import com.snowplowanalytics.snowplow.tracker.Gdpr;
 import com.snowplowanalytics.snowplow.tracker.Subject;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameters;
 import com.snowplowanalytics.snowplow.tracker.constants.TrackerConstants;
@@ -329,6 +330,7 @@ public class Demo extends Activity {
         addToMap(Parameters.APP_VERSION, "0.3.0", pairs);
         addToMap(Parameters.APP_BUILD, "3", pairs);
         Tracker.instance().addGlobalContext(new SelfDescribingJson(TrackerConstants.SCHEMA_APPLICATION, pairs));
+        Tracker.instance().enableGdprContext(Gdpr.Basis.CONSENT, "someId", "0.1.0", "this is a demo document description");
     }
 
     /**

--- a/snowplow-tracker/build.gradle
+++ b/snowplow-tracker/build.gradle
@@ -61,6 +61,7 @@ android {
 }
 
 dependencies {
+    implementation 'com.android.support:support-annotations:28.0.0'
     implementation "android.arch.lifecycle:extensions:$project.archLifecycleVersion"
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.squareup.okhttp3:okhttp:3.4.1'

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Gdpr.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Gdpr.java
@@ -1,0 +1,45 @@
+package com.snowplowanalytics.snowplow.tracker;
+
+import android.support.annotation.NonNull;
+
+import com.snowplowanalytics.snowplow.tracker.constants.TrackerConstants;
+import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.utils.Preconditions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Gdpr {
+
+    public enum Basis {
+        CONSENT,
+        CONTRACT,
+        LEGAL_OBLIGATION,
+        VITAL_INTERESTS,
+        PUBLIC_TASK,
+        LEGITIMATE_INTERESTS
+    }
+
+    final Basis basisForProcessing;
+    final String documentId;
+    final String documentVersion;
+    final String documentDescription;
+
+    Gdpr(@NonNull Basis basisForProcessing, String documentId, String documentVersion, String documentDescription) {
+        Preconditions.checkArgument(basisForProcessing != null, "GDPR basisForProcessiong can't be null.");
+        this.basisForProcessing = basisForProcessing;
+        this.documentId = documentId;
+        this.documentVersion = documentVersion;
+        this.documentDescription = documentDescription;
+    }
+
+    @NonNull
+    SelfDescribingJson getContext() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("basisForProcessing", basisForProcessing.toString().toLowerCase());
+        map.put("documentId", documentId);
+        map.put("documentVersion", documentVersion);
+        map.put("documentDescription", documentDescription);
+        return new SelfDescribingJson(TrackerConstants.SCHEMA_GDPR, map);
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/TrackerConstants.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/constants/TrackerConstants.java
@@ -38,6 +38,7 @@ public class TrackerConstants {
     public static final String SCHEMA_SCREEN = "iglu:com.snowplowanalytics.mobile/screen/jsonschema/1-0-0";
     public static final String SCHEMA_APPLICATION_INSTALL = "iglu:com.snowplowanalytics.mobile/application_install/jsonschema/1-0-0";
     public static final String SCHEMA_APPLICATION = "iglu:com.snowplowanalytics.mobile/application/jsonschema/1-0-0";
+    public static final String SCHEMA_GDPR = "iglu:com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0";
 
     public static final String POST_CONTENT_TYPE = "application/json; charset=utf-8";
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Util.java
@@ -39,6 +39,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
Suggested section for the documentation (copied by Javascript doc):

--- 

The GDPR context attaches a context with the GDPR basis for processing and the details of a related document (eg. a consent document) to all events which are fired after it is set.

It takes the following arguments:

|      **Name** | **Description**             | **Required?** | **Type** |
|--------------:|:----------------------------|:--------------|:---------|
|`basisForProcessing` | GDPR Basis for processing | Yes           | Enum String   |
|     `documentId` | ID of a GDPR basis document     | No           | String   |
|        `documentVersion` | Version of the document        | No            | String   |
| `documentDescription` | Description of the document | No            | String   |

The required basisForProcessing accepts only the following literals: `consent`, `contract`, `legal_obligation`, `vital_interests`, `public_task`, `legitimate_interests` - in accordance with the [five legal bases for processing](https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing/)

The GDPR context is enabled by calling the `gdprContext` method of the tracker builder or by calling the `enableGdprContext` method once the tracker has been initialised.

Setup on tracker settings:
```
Tracker.TrackerBuilder builder = new Tracker.TrackerBuilder(emitter, namespace, appId, appContext)
    .gdprContext(
        Gdpr.Basis.CONSENT,
        "someId",
        "0.1.0",
        "a demo document description"
    )
    ...
    .build()
Tracker.init(builder);
```

Setup on tracker already initialised:
```
Tracker.instance().enableGdprContext(
    Gdpr.Basis.CONSENT,
    "someId",
    "0.1.0",
    "a demo document description"
);
```