### PR TITLE
IAB enrichment treats Android tracker events as spider-generated (close #359)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -13,7 +13,6 @@
 
 package com.snowplowanalytics.snowplow.tracker;
 
-import android.annotation.TargetApi;
 import android.app.Application;
 import android.content.Context;
 import android.os.Build;


### PR DESCRIPTION
The user-agent header in the okHttp request is set to a default value, otherwise it's overridden by the subject `ua` (user agent) field.
