### PR TITLE
Add snyk monitoring to repository (close #388)

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -18,7 +18,7 @@ jobs:
       uses: snyk/actions/gradle@master
       with:
         command: monitor
-        args: --all-sub-projects --configuration-matching='debugAndroidTestRuntimeClasspath'
+        args: --all-sub-projects --configuration-matching='releaseRuntimeClasspath'
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         COMMAND: cd snowplow-android-tracker

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,24 @@
+
+name: Snyk
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: snowplow-android-tracker
+      
+    - name: Run Snyk to check for vulnerabilities in tracker
+      uses: snyk/actions/gradle@master
+      with:
+        command: monitor
+        args: --all-sub-projects --configuration-matching='debugAndroidTestRuntimeClasspath'
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        COMMAND: cd snowplow-android-tracker


### PR DESCRIPTION
Couple of things to note in this PR:

Snyk gets confused due to the structure and naming of our directories and project structure. To combat this we can specify the particular configuration we want it to scan, in this case I selected 'debugAndroidTestRuntimeClasspath' as this contains all the testing and android dependencies as well as any runtime dependencies too.
If you want to test this configuration works, take OkHttp and mockwebserver back to 3.1.1 which had a vulnerability in them and run `snyk test --all-sub-projects --configuration-matching='debugAndroidTestRuntimeClasspath'` locally.

The Snyk GitHub Action uses Docker and as such ends up mounting the checked out folder into `/github/workspace` inside the container. Snyk then picks up the base name for the project as `workspace` 🤷 So I've checked it out to another subfolder and then used the COMMAND env var to navigate into this folder when Snyk's docker container starts. This means we get `snowplow-android-tracker/snowplow-demo-app` on Snyk rather than `workspace/snowplow-demo-app`.