### PR TITLE
Renew event ID when event object is reused (close #390)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/TrackerTest.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameters;
 import com.snowplowanalytics.snowplow.tracker.emitter.BufferOption;
 import com.snowplowanalytics.snowplow.tracker.events.ScreenView;
+import com.snowplowanalytics.snowplow.tracker.events.Timing;
 import com.snowplowanalytics.snowplow.tracker.tracker.ExceptionHandler;
 import com.snowplowanalytics.snowplow.tracker.tracker.ScreenState;
 import com.snowplowanalytics.snowplow.tracker.utils.LogLevel;
@@ -30,6 +31,7 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.util.Map;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.mockwebserver.MockResponse;
@@ -159,6 +161,17 @@ public class TrackerTest extends AndroidTestCase {
         assertTrue(tracker.getDataCollection());
         tracker.resumeEventTracking();
         assertTrue(tracker.getDataCollection());
+    }
+
+    public void testTrackEventMultipleTimes() {
+        Timing event = Timing.builder()
+                .category("category")
+                .variable("variable")
+                .timing(100)
+                .build();
+        UUID id1 = new TrackerEvent(event).eventId;
+        UUID id2 = new TrackerEvent(event).eventId;
+        assertFalse(id1.equals(id2));
     }
 
     public void testTrackWithNoContext() throws Exception {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/TrackerEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/TrackerEvent.java
@@ -18,6 +18,7 @@ import com.snowplowanalytics.snowplow.tracker.events.AbstractSelfDescribing;
 import com.snowplowanalytics.snowplow.tracker.events.Event;
 import com.snowplowanalytics.snowplow.tracker.events.TrackerError;
 import com.snowplowanalytics.snowplow.tracker.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.utils.Util;
 
 import java.util.List;
 import java.util.Map;
@@ -36,9 +37,14 @@ class TrackerEvent {
     boolean isService;
 
     TrackerEvent(Event event) {
-        eventId = UUID.fromString(event.getEventId());
+        String userEventId = event.getActualEventId();
+        String newEventId = userEventId != null ? userEventId : Util.getUUIDString();
+        eventId = UUID.fromString(newEventId);
+
+        Long userTimestamp = event.getActualDeviceCreatedTimestamp();
+        timestamp = userTimestamp != null ? userTimestamp : System.currentTimeMillis();
+
         contexts = event.getContexts();
-        timestamp = event.getDeviceCreatedTimestamp();
         trueTimestamp = event.getTrueTimestamp();
         payload = event.getDataPayload();
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransaction.java
@@ -225,7 +225,7 @@ public class EcommerceTransaction extends AbstractPrimitive {
     public void endProcessing(Tracker tracker) {
         // Track each item individually
         for(EcommerceTransactionItem item : items) {
-            item.setDeviceCreatedTimestamp(deviceCreatedTimestamp);
+            item.setDeviceCreatedTimestamp(getDeviceCreatedTimestamp());
             tracker.track(item);
         }
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/EcommerceTransactionItem.java
@@ -154,7 +154,9 @@ public class EcommerceTransactionItem extends AbstractPrimitive {
     @Override
     public @NonNull Map<String, Object> getDataPayload() {
         HashMap<String, Object> payload = new HashMap<>();
-        payload.put(Parameters.DEVICE_TIMESTAMP, Long.toString(this.deviceCreatedTimestamp)); // TODO: to remove on v.2.0
+        if (deviceCreatedTimestamp != null) {
+            payload.put(Parameters.DEVICE_TIMESTAMP, Long.toString(deviceCreatedTimestamp)); // TODO: to remove on v.2.0
+        }
         payload.put(Parameters.TI_ITEM_ID, this.itemId);
         payload.put(Parameters.TI_ITEM_SKU, this.sku);
         payload.put(Parameters.TI_ITEM_NAME, this.name);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/events/Event.java
@@ -43,9 +43,22 @@ public interface Event {
     @NonNull List<SelfDescribingJson> getContexts();
 
     /**
+     * Get the timestamp of the event.
+     * @apiNote If the timestamp is not set, it sets one as a side effect.
+     * @deprecated As of release 1.5.0, it will be removed in the version 2.0.0.
      * @return the event timestamp
      */
+    @Deprecated
     long getDeviceCreatedTimestamp();
+
+    /**
+     * Get the actual timestamp of the event.
+     * @apiNote It doesn't have the side effect of {@link #getDeviceCreatedTimestamp()}.
+     * @deprecated As of release 1.5.0, it will be removed in the version 2.0.0.
+     * @return the event timestamp
+     */
+    @Deprecated
+    Long getActualDeviceCreatedTimestamp();
 
     /**
      * @return the optional true events timestamp
@@ -53,9 +66,22 @@ public interface Event {
     Long getTrueTimestamp();
 
     /**
+     * Get the event id of the event.
+     * @apiNote If the eventId is not set, it sets one as a side effect.
+     * @deprecated As of release 1.5.0, it will be removed in the version 2.0.0.
      * @return the event id
      */
+    @Deprecated
     @NonNull String getEventId();
+
+    /**
+     * Get the actual event id of the event.
+     * @apiNote It doesn't have the side effect of {@link #getEventId()}.
+     * @deprecated As of release 1.5.0, it will be removed in the version 2.0.0.
+     * @return the event id if it exist.
+     */
+    @Deprecated
+    String getActualEventId();
 
     /**
      * @deprecated As of release 1.5.0, it will be removed in the version 2.0.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Preconditions.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Preconditions.java
@@ -122,6 +122,17 @@ public final class Preconditions {
     }
 
     /**
+     * Force a failure in the precondition check.
+     *
+     * @param errorMessage the exception message to use; will be converted to a
+     *     string using {@link String#valueOf(Object)}
+     * @throws IllegalArgumentException
+     */
+    public static void fail(Object errorMessage) {
+        throw new IllegalArgumentException(String.valueOf(errorMessage));
+    }
+
+    /**
      * Ensures that an object reference passed as a parameter to the calling method is not null.
      *
      * @param reference an object reference


### PR DESCRIPTION
The event ID is set in the event constructor. We want the event ID  set when the event is tracked. Unless the user has set it programmatically.