### PR TITLE
Background threads don't report exceptions (close #394)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/ExecutorTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/ExecutorTest.java
@@ -1,0 +1,34 @@
+package com.snowplowanalytics.snowplow.tracker;
+
+import android.test.AndroidTestCase;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ExecutorTest extends AndroidTestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        ExecutorService es = Executor.shutdown();
+        if (es != null) {
+            es.awaitTermination(60, TimeUnit.SECONDS);
+        }
+    }
+
+    public void testExecutorRaisingException() throws InterruptedException {
+        final Object expectation = new Object();
+        AtomicBoolean exceptionRaised = new AtomicBoolean(false);
+        Executor.execute(() -> { throw new NullPointerException(); }, t -> {
+            exceptionRaised.set(t instanceof NullPointerException);
+            synchronized (expectation) {
+                expectation.notify();
+            }
+        });
+        synchronized (expectation) {
+            expectation.wait(10000);
+        }
+        assertTrue(exceptionRaised.get());
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Emitter.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Emitter.java
@@ -355,19 +355,16 @@ public class Emitter {
      *                to be added.
      */
     public void add(final Payload payload) {
-        if (eventStore != null) {
-            Executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    eventStore.add(payload);
-                    if (isRunning.compareAndSet(false, true)) {
-                        attemptEmit();
-                    }
-                }
-            });
-        } else {
+        if (eventStore == null) {
             Logger.d(TAG, "Event store not instantiated.");
+            return;
         }
+        Executor.execute(TAG, () -> {
+            eventStore.add(payload);
+            if (isRunning.compareAndSet(false, true)) {
+                attemptEmit();
+            }
+        });
     }
 
     /**
@@ -375,11 +372,9 @@ public class Emitter {
      * is not currently running.
      */
     public void flush() {
-        Executor.execute(new Runnable() {
-            public void run() {
-                if (isRunning.compareAndSet(false, true)) {
-                    attemptEmit();
-                }
+        Executor.execute(TAG, () -> {
+            if (isRunning.compareAndSet(false, true)) {
+                attemptEmit();
             }
         });
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Executor.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Executor.java
@@ -13,6 +13,8 @@
 
 package com.snowplowanalytics.snowplow.tracker;
 
+import com.snowplowanalytics.snowplow.tracker.utils.Logger;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -42,11 +44,53 @@ public class Executor {
 
     /**
      * Sends a runnable to the executor service.
+     * Errors are logged but not tracked with the diagnostic feature.
      *
+     * @param tag string indicating the source of the runnable for logging purposes in case of
+     *            exceptions raised by the runnable
      * @param runnable the runnable to be queued
      */
-    public static void execute(Runnable runnable) {
-        getExecutor().execute(runnable);
+    public static void execute(String tag, Runnable runnable) {
+        execute(false, tag, runnable);
+    }
+
+    /**
+     * Sends a runnable to the executor service.
+     *
+     * @param reportsOnDiagnostic weather or not the error has to be tracked with diagnostic feature
+     * @param tag string indicating the source of the runnable for logging purposes in case of
+     *            exceptions raised by the runnable
+     * @param runnable the runnable to be queued
+     */
+    public static void execute(boolean reportsOnDiagnostic, String tag, Runnable runnable) {
+        execute(runnable, t -> {
+            if (reportsOnDiagnostic) {
+                Logger.track(tag, t.getLocalizedMessage(), t);
+            } else {
+                Logger.e(tag, t.getLocalizedMessage(), t);
+            }
+        });
+    }
+
+    /**
+     * Sends a runnable to the executor service.
+     *
+     * @param runnable the runnable to be queued
+     * @param exceptionHandler the handler of exception raised by the runnable
+     */
+    public static void execute(Runnable runnable, ExceptionHandler exceptionHandler) {
+        ExecutorService executor = getExecutor();
+        executor.execute(() -> {
+            try {
+                if (runnable != null) {
+                    runnable.run();
+                }
+            } catch (Throwable t) {
+                if (exceptionHandler != null) {
+                    exceptionHandler.handle(t);
+                }
+            }
+        });
     }
 
     /**
@@ -86,5 +130,13 @@ public class Executor {
      */
     public static void setThreadCount(final int count) {
         threadCount = count;
+    }
+
+    /**
+     * Handle exceptions raised by a Runnable
+     */
+    @FunctionalInterface
+    public interface ExceptionHandler {
+        void handle(Throwable t);
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Session.java
@@ -303,18 +303,15 @@ public class Session {
         Logger.d(TAG, " + Previous Session ID: %s", this.previousSessionId);
         Logger.d(TAG, " + Session Index: %s", this.sessionIndex);
 
-        Executor.execute(new Runnable() {
-            @Override
-            public void run() {
-                SharedPreferences.Editor editor = sharedPreferences.edit();
-                editor.putString(Parameters.SESSION_USER_ID, userId);
-                editor.putString(Parameters.SESSION_ID, currentSessionId);
-                editor.putString(Parameters.SESSION_PREVIOUS_ID, previousSessionId);
-                editor.putInt(Parameters.SESSION_INDEX, sessionIndex);
-                editor.putString(Parameters.SESSION_FIRST_ID, firstId);
-                editor.putString(Parameters.SESSION_STORAGE, sessionStorage);
-                editor.apply();
-            }
+        Executor.execute(true, TAG, () -> {
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+            editor.putString(Parameters.SESSION_USER_ID, userId);
+            editor.putString(Parameters.SESSION_ID, currentSessionId);
+            editor.putString(Parameters.SESSION_PREVIOUS_ID, previousSessionId);
+            editor.putInt(Parameters.SESSION_INDEX, sessionIndex);
+            editor.putString(Parameters.SESSION_FIRST_ID, firstId);
+            editor.putString(Parameters.SESSION_STORAGE, sessionStorage);
+            editor.apply();
         });
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -531,7 +531,8 @@ public class Tracker implements DiagnosticLogger {
             screenView.updateScreenState(screenState);
         }
 
-        Executor.execute(() -> {
+        boolean reportsOnDiagnostic = !(event instanceof TrackerError);
+        Executor.execute(reportsOnDiagnostic, TAG, () -> {
             event.beginProcessing(this);
             processEvent(event);
             event.endProcessing(this);


### PR DESCRIPTION
The background threads weren't able to report exceptions correctly. They failed silently and lot of the operations done by the Android tracker happen in background threads.
We need to report those issues in the logs, and eventually with the diagnostic feature, in order to spot in advance anything suspicious in the tracker behaviour.