### PR TITLE
Report logs to the app (close #407)

### DIFF
--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
@@ -27,6 +27,7 @@ import android.support.annotation.NonNull;
 
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.util.Log;
 import android.widget.EditText;
 import android.widget.Button;
 import android.view.View;
@@ -39,6 +40,7 @@ import android.net.Uri;
 
 import com.snowplowanalytics.snowplow.tracker.DevicePlatforms;
 import com.snowplowanalytics.snowplow.tracker.Gdpr;
+import com.snowplowanalytics.snowplow.tracker.LoggerDelegate;
 import com.snowplowanalytics.snowplow.tracker.Subject;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameters;
 import com.snowplowanalytics.snowplow.tracker.constants.TrackerConstants;
@@ -64,7 +66,7 @@ import static com.snowplowanalytics.snowplow.tracker.utils.Util.addToMap;
  * Classic Demo Activity.
  */
 @SuppressWarnings("FieldCanBeLocal")
-public class Demo extends Activity {
+public class Demo extends Activity implements LoggerDelegate {
 
     private Button _startButton, _tabButton;
     private EditText _uriField;
@@ -353,6 +355,7 @@ public class Demo extends Activity {
 
         Tracker.init(new Tracker.TrackerBuilder(emitter, namespace, appId, this.getApplicationContext())
                 .level(LogLevel.VERBOSE)
+                .loggerDelegate(this)
                 .base64(false)
                 .platform(DevicePlatforms.Mobile)
                 .subject(subject)
@@ -398,5 +401,22 @@ public class Demo extends Activity {
                 updateEventsSent(successCount);
             }
         };
+    }
+
+    /// - Implements LoggerDelegate
+
+    @Override
+    public void error(String tag, String msg) {
+        Log.e("[" + tag + "]", msg);
+    }
+
+    @Override
+    public void debug(String tag, String msg) {
+        Log.d("[" + tag + "]", msg);
+    }
+
+    @Override
+    public void verbose(String tag, String msg) {
+        Log.v("[" + tag + "]", msg);
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/LoggerDelegate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/LoggerDelegate.java
@@ -1,0 +1,28 @@
+package com.snowplowanalytics.snowplow.tracker;
+
+public interface LoggerDelegate {
+
+    /**
+     * Error Level Logging
+     *
+     * @param tag the log tag
+     * @param msg the log message
+     */
+    void error(String tag, String msg);
+
+    /**
+     * Debug Level Logging
+     *
+     * @param tag the log tag
+     * @param msg the log message
+     */
+    void debug(String tag, String msg);
+
+    /**
+     * Verbose Level Logging
+     *
+     * @param tag the log tag
+     * @param msg the log message
+     */
+    void verbose(String tag, String msg);
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/Tracker.java
@@ -36,8 +36,6 @@ import com.snowplowanalytics.snowplow.tracker.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.tracker.constants.Parameters;
 import com.snowplowanalytics.snowplow.tracker.contexts.global.GlobalContext;
 import com.snowplowanalytics.snowplow.tracker.contexts.global.GlobalContextUtils;
-import com.snowplowanalytics.snowplow.tracker.events.AbstractPrimitive;
-import com.snowplowanalytics.snowplow.tracker.events.AbstractSelfDescribing;
 import com.snowplowanalytics.snowplow.tracker.events.Event;
 import com.snowplowanalytics.snowplow.tracker.events.TrackerError;
 import com.snowplowanalytics.snowplow.tracker.payload.Payload;
@@ -240,6 +238,15 @@ public class Tracker implements DiagnosticLogger {
          */
         public TrackerBuilder level(LogLevel log) {
             this.logLevel = log;
+            return this;
+        }
+
+        /**
+         * @param delegate The logger delegate that receive logs from the tracker.
+         * @return itself
+         */
+        public TrackerBuilder loggerDelegate(LoggerDelegate delegate) {
+            Logger.setDelegate(delegate);
             return this;
         }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Logger.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Logger.java
@@ -27,7 +27,7 @@ public class Logger {
 
     private static String TAG = Logger.class.getSimpleName();
     private static DiagnosticLogger errorLogger;
-    private static LoggerDelegate delegate;
+    private static LoggerDelegate delegate = new DefaultLoggerDelegate();
     private static int level = 0;
 
     /**
@@ -54,7 +54,11 @@ public class Logger {
      * @param delegate The app logger delegate.
      */
     public static void setDelegate(LoggerDelegate delegate) {
-        Logger.delegate = delegate;
+        if (delegate != null) {
+            Logger.delegate = delegate;
+        } else {
+            Logger.delegate = new DefaultLoggerDelegate();
+        }
     }
 
     // -- Log methods
@@ -95,11 +99,7 @@ public class Logger {
         if (level >= 1) {
             String source = getTag(tag);
             String message = getMessage(msg, args);
-            if (delegate != null) {
-                delegate.error(source, message);
-            } else {
-                Log.e(source, message);
-            }
+            delegate.error(source, message);
         }
     }
 
@@ -114,11 +114,7 @@ public class Logger {
         if (level >= 2) {
             String source = getTag(tag);
             String message = getMessage(msg, args);
-            if (delegate != null) {
-                delegate.debug(source, message);
-            } else {
-                Log.d(source, message);
-            }
+            delegate.debug(source, message);
         }
     }
 
@@ -133,11 +129,7 @@ public class Logger {
         if (level >= 3) {
             String source = getTag(tag);
             String message = getMessage(msg, args);
-            if (delegate != null) {
-                delegate.verbose(source, message);
-            } else {
-                Log.v(source, message);
-            }
+            delegate.verbose(source, message);
         }
     }
 
@@ -172,4 +164,24 @@ public class Logger {
         return Thread.currentThread().getName();
     }
 
+}
+
+/**
+ * Default internal logger delegate
+ */
+class DefaultLoggerDelegate implements LoggerDelegate {
+    @Override
+    public void error(String tag, String msg) {
+        Log.e(tag, msg);
+    }
+
+    @Override
+    public void debug(String tag, String msg) {
+        Log.d(tag, msg);
+    }
+
+    @Override
+    public void verbose(String tag, String msg) {
+        Log.v(tag, msg);
+    }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Logger.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/utils/Logger.java
@@ -16,6 +16,7 @@ package com.snowplowanalytics.snowplow.tracker.utils;
 import android.util.Log;
 
 import com.snowplowanalytics.snowplow.tracker.DiagnosticLogger;
+import com.snowplowanalytics.snowplow.tracker.LoggerDelegate;
 
 /**
  * Custom logger class to easily manage debug mode and appending
@@ -26,7 +27,37 @@ public class Logger {
 
     private static String TAG = Logger.class.getSimpleName();
     private static DiagnosticLogger errorLogger;
+    private static LoggerDelegate delegate;
     private static int level = 0;
+
+    /**
+     * Updates the logging level.
+     *
+     * @param newLevel The new log-level to use
+     */
+    public static void updateLogLevel(LogLevel newLevel) {
+        level = newLevel.getLevel();
+    }
+
+    /**
+     * Set the error logger used to track internal errors.
+     *
+     * @param errorLogger The error logger delegate in the app.
+     */
+    public static void setErrorLogger(DiagnosticLogger errorLogger) {
+        Logger.errorLogger = errorLogger;
+    }
+
+    /**
+     * Set the logger delegate that receive logs from the tracker.
+     *
+     * @param delegate The app logger delegate.
+     */
+    public static void setDelegate(LoggerDelegate delegate) {
+        Logger.delegate = delegate;
+    }
+
+    // -- Log methods
 
     /**
      * Diagnostic Logging
@@ -62,7 +93,13 @@ public class Logger {
      */
     public static void e(String tag, String msg, Object... args) {
         if (level >= 1) {
-            Log.e(getTag(tag), getMessage(msg, args));
+            String source = getTag(tag);
+            String message = getMessage(msg, args);
+            if (delegate != null) {
+                delegate.error(source, message);
+            } else {
+                Log.e(source, message);
+            }
         }
     }
 
@@ -75,7 +112,13 @@ public class Logger {
      */
     public static void d(String tag, String msg, Object... args) {
         if (level >= 2) {
-            Log.d(getTag(tag), getMessage(msg, args));
+            String source = getTag(tag);
+            String message = getMessage(msg, args);
+            if (delegate != null) {
+                delegate.debug(source, message);
+            } else {
+                Log.d(source, message);
+            }
         }
     }
 
@@ -88,7 +131,13 @@ public class Logger {
      */
     public static void v(String tag, String msg, Object... args) {
         if (level >= 3) {
-            Log.v(getTag(tag), getMessage(msg, args));
+            String source = getTag(tag);
+            String message = getMessage(msg, args);
+            if (delegate != null) {
+                delegate.verbose(source, message);
+            } else {
+                Log.v(source, message);
+            }
         }
     }
 
@@ -123,21 +172,4 @@ public class Logger {
         return Thread.currentThread().getName();
     }
 
-    /**
-     * Updates the logging level.
-     *
-     * @param newLevel The new log-level to use
-     */
-    public static void updateLogLevel(LogLevel newLevel) {
-        level = newLevel.getLevel();
-    }
-
-    /**
-     * Set the error logger used to track internal errors.
-     *
-     * @param errorLogger The error logger delegate in the app.
-     */
-    public static void setErrorLogger(DiagnosticLogger errorLogger) {
-        Logger.errorLogger = errorLogger;
-    }
 }


### PR DESCRIPTION
Allow the app to receive logs (Error, Debug, Verbose) from the tracker.

Here draft of documentation for the [`Tracker diagnostics` section](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/android-tracker/android-1-5-0/#tracker-diagnostics) that will be changed in `Troubleshooting` section:

---

Troubleshooting
---

The tracker is constantly tested with different platforms and versions but there are rare situations where an error can be generated. The tracker will manage the situation to avoid crashes of the app and assuring that the events are not lost.

However, it can be useful to observe logs and errors from the tracker in order to narrow down a possible issue due to a mistake in the instrumentation of the tracker in the app or other unexpected behaviours.

We let the developer to have a full visibility of the tracker logs. *Please, take care to avoid sharing of sensible information through the logs when in production environment*.

At the tracker configuration you can decide which log level you want to filter logs:

```
TrackerBuilder trackerBuilder =
    new TrackerBuilder(emitter, namespace, appId, appContext)
        ...
        .level(LogLevel.VERBOSE)
        ...
        .build();
Tracker.init(trackerBuilder);
```

There are four levels of logging: off (log disabled), error, debug, verbose.

In this way the logs will be sent to the system logs. Usually visible through Logcat, which is a system log module. It contains all the device errors and warnings.

It's also possible to handle the tracker logs directly in the app for troubleshooting purposes. You need to implement the interface `LoggerDelegate` where you will receive all the log messages based on the log level selected.
In the tracker configuration you have to set the log level and register the logger delegate passing the reference of class instance that implement the LoggerDelegate interface.

```
public class MyApp implements LoggerDelegate {

    ...

    private void setupMyTracker() {
        ...
        TrackerBuilder trackerBuilder =
            new TrackerBuilder(emitter, namespace, appId, appContext)
                .level(LogLevel.ERROR)
                .loggerDelegate(this)
                ...
                .build();
        Tracker.init(trackerBuilder);
    }

    ...

    // - LoggerDelegate methods

    @Override
    public void error(String tag, String msg) { ... }

    @Override
    public void debug(String tag, String msg) { ... }

    @Override
    public void verbose(String tag, String msg) { ... }
}
```

A third option, suitable for issues happening in a production environment, is the diagnostic tracking.
Errors happening in the tracker can be reported to the collector as `diagnostic_error` events.
If you enable the diagnostic feature the log level will be automatically set to error level.

To activate this feature you only need to enable `trackerDiagnostic`:

```
TrackerBuilder trackerBuilder =
    new TrackerBuilder(emitter, namespace, appId, appContext)
        .trackerDiagnostic(true)
        ...
        .build();
Tracker.init(trackerBuilder);
```

