### PR TITLE
Issue/443 set lifecycle off

### DIFF
--- a/snowplow-demo-app/build.gradle
+++ b/snowplow-demo-app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 project.ext {
-    archLifecycleVersion = "1.1.1"
+    archLifecycleVersion = "2.2.0"
 }
 
 android {
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation "androidx.lifecycle:lifecycle-extensions:$project.archLifecycleVersion"
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':snowplow-android-tracker')
     implementation 'androidx.browser:browser:1.3.0'

--- a/snowplow-tracker/build.gradle
+++ b/snowplow-tracker/build.gradle
@@ -11,7 +11,7 @@ jacoco {
 }
 
 project.ext {
-    archLifecycleVersion = "1.1.1"
+    archLifecycleVersion = "2.2.0"
 }
 
 android {
@@ -76,11 +76,12 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
+    implementation 'androidx.annotation:annotation:1.2.0'
+    compileOnly "androidx.lifecycle:lifecycle-extensions:$project.archLifecycleVersion"
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     // test
+    testImplementation "androidx.lifecycle:lifecycle-extensions:$project.archLifecycleVersion"
     testImplementation 'junit:junit:4.13.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/NotificationCenterTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/NotificationCenterTest.java
@@ -1,7 +1,6 @@
 package com.snowplowanalytics.snowplow.internal.utils;
 
 import androidx.annotation.NonNull;
-import androidx.lifecycle.Observer;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Assert;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.java
@@ -257,7 +257,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
      *         geoLocationContext = false;
      *         screenContext = true;
      *         screenViewAutotracking = true;
-     *         lifecycleAutotracking = true;
+     *         lifecycleAutotracking = false;
      *         installAutotracking = true;
      *         exceptionAutotracking = true;
      *         diagnosticAutotracking = false;
@@ -278,7 +278,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
         geoLocationContext = false;
         screenContext = true;
         screenViewAutotracking = true;
-        lifecycleAutotracking = true;
+        lifecycleAutotracking = false;
         installAutotracking = true;
         exceptionAutotracking = true;
         diagnosticAutotracking = false;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -17,10 +17,9 @@ import android.app.Application;
 import android.content.Context;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import android.os.Handler;
-
-import androidx.annotation.NonNull;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -563,15 +562,17 @@ public class Tracker {
             trackerSession = Session.getInstance(context, foregroundTimeout, backgroundTimeout, timeUnit, namespace, callbacks);
         }
 
-        // If lifecycleEvents is True
-        if (this.lifecycleEvents || this.sessionContext) {
-
+        if (this.lifecycleEvents) {
             // addObserver must execute on the mainThread
             Handler mainHandler = new Handler(context.getMainLooper());
             mainHandler.post(new Runnable() {
                 @Override
                 public void run() {
-                    ProcessLifecycleOwner.get().getLifecycle().addObserver(new ProcessObserver());
+                    try {
+                        ProcessLifecycleOwner.get().getLifecycle().addObserver(new ProcessObserver());
+                    } catch (NoClassDefFoundError e) {
+                        Logger.e(TAG,"Class 'ProcessLifecycleOwner' not found. The tracker can't track lifecycle events.");
+                    }
                 }
             });
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/NotificationCenter.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/NotificationCenter.java
@@ -1,7 +1,6 @@
 package com.snowplowanalytics.snowplow.internal.utils;
 
 import androidx.annotation.NonNull;
-import androidx.lifecycle.Observer;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;


### PR DESCRIPTION
As planned, I set lifecycle optional.
In order to keep the behaviour similar between Android and iOS, I've also disabled the background/foreground index in case the lifecycle tracking is disabled. In that case all the events will be considered in foreground.