### PR TITLE
Fix Gdpr context being tracked without enabling it (close #457)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -376,7 +376,6 @@ public class ServiceProvider implements ServiceProviderInterface {
         Subject subject = getSubject();
         TrackerConfigurationInterface trackerConfig = getTrackerConfigurationUpdate();
         SessionConfigurationInterface sessionConfig = getSessionConfigurationUpdate();
-        GdprConfigurationInterface gdprConfig = getGdprConfigurationUpdate();
         Tracker.TrackerBuilder builder = new Tracker.TrackerBuilder(emitter, namespace, trackerConfig.getAppId(), context)
                 .subject(subject)
                 .base64(trackerConfig.isBase64encoding())
@@ -394,7 +393,8 @@ public class ServiceProvider implements ServiceProviderInterface {
                 .trackerDiagnostic(trackerConfig.isDiagnosticAutotracking())
                 .backgroundTimeout(sessionConfig.getBackgroundTimeout().convert(TimeUnit.SECONDS))
                 .foregroundTimeout(sessionConfig.getForegroundTimeout().convert(TimeUnit.SECONDS));
-        if (gdprConfig != null) {
+        GdprConfigurationUpdate gdprConfig = getGdprConfigurationUpdate();
+        if (gdprConfig.sourceConfig != null) {
             builder.gdprContext(
                     gdprConfig.getBasisForProcessing(),
                     gdprConfig.getDocumentId(),


### PR DESCRIPTION
I think this might be a small oversight due to the remote configuration additions in v2.1.0 with the GDPR Context not being part of the remote configuration but adopting a similar pattern when being initialised at tracker creation. The "Update" object is never `null`, it keeps track of only whether it has been updated or has already been configured.

I think this change is pretty safe, looking at the flow current it seems that the only way we need to configure a gdpr context in the builder is if the sourceConfig has been populated yet. I might have missed something though 👀 