### PR TITLE
Add tracker state management (close #468)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContextTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContextTest.java
@@ -145,7 +145,7 @@ public class GlobalContextTest {
         GlobalContext staticGC = new GlobalContext(Collections.singletonList(sdj));
 
         AbstractPrimitive event = new Structured("Category", "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
+        TrackerEvent trackerEvent = new TrackerEvent(event);
 
         List<SelfDescribingJson> contexts = staticGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());
@@ -164,7 +164,7 @@ public class GlobalContextTest {
         });
 
         AbstractPrimitive event = new Structured(stringToMatch, "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
+        TrackerEvent trackerEvent = new TrackerEvent(event);
 
         List<SelfDescribingJson> contexts = filterMatchingGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());
@@ -193,21 +193,21 @@ public class GlobalContextTest {
 
         // Not matching primitive event
         AbstractPrimitive event = new Structured("Category", "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
+        TrackerEvent trackerEvent = new TrackerEvent(event);
         List<SelfDescribingJson> contexts = rulesetGC.generateContexts(trackerEvent);
         assertEquals(0, contexts.size());
 
         // Not matching self-describing event with mobile schema
         AbstractSelfDescribing selfDescribingEvent = new ScreenView("Name", null)
                 .type("Type");
-        trackerEvent = new TrackerEvent(selfDescribingEvent, new HashMap<>());
+        trackerEvent = new TrackerEvent(selfDescribingEvent);
         contexts = rulesetGC.generateContexts(trackerEvent);
         assertEquals(0, contexts.size());
 
         // Matching self-describing event with general schema
         selfDescribingEvent = new Timing("Category", "Variable", 123)
                 .label("Label");
-        trackerEvent = new TrackerEvent(selfDescribingEvent, new HashMap<>());
+        trackerEvent = new TrackerEvent(selfDescribingEvent);
         contexts = rulesetGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());
         assertEquals("schema", contexts.get(0).getMap().get("schema"));
@@ -226,7 +226,7 @@ public class GlobalContextTest {
         });
 
         AbstractPrimitive event = new Structured("Category", "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
+        TrackerEvent trackerEvent = new TrackerEvent(event);
 
         List<SelfDescribingJson> contexts = blockGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());
@@ -237,7 +237,7 @@ public class GlobalContextTest {
     public void testContextGenerator() {
         GlobalContext contextGeneratorGC = new GlobalContext(new GlobalContextGenerator());
         AbstractPrimitive event = new Structured("StringToMatch", "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
+        TrackerEvent trackerEvent = new TrackerEvent(event);
 
         List<SelfDescribingJson> contexts = contextGeneratorGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContextTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContextTest.java
@@ -145,7 +145,7 @@ public class GlobalContextTest {
         GlobalContext staticGC = new GlobalContext(Collections.singletonList(sdj));
 
         AbstractPrimitive event = new Structured("Category", "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event);
+        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
 
         List<SelfDescribingJson> contexts = staticGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());
@@ -164,7 +164,7 @@ public class GlobalContextTest {
         });
 
         AbstractPrimitive event = new Structured(stringToMatch, "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event);
+        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
 
         List<SelfDescribingJson> contexts = filterMatchingGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());
@@ -193,21 +193,21 @@ public class GlobalContextTest {
 
         // Not matching primitive event
         AbstractPrimitive event = new Structured("Category", "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event);
+        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
         List<SelfDescribingJson> contexts = rulesetGC.generateContexts(trackerEvent);
         assertEquals(0, contexts.size());
 
         // Not matching self-describing event with mobile schema
         AbstractSelfDescribing selfDescribingEvent = new ScreenView("Name", null)
                 .type("Type");
-        trackerEvent = new TrackerEvent(selfDescribingEvent);
+        trackerEvent = new TrackerEvent(selfDescribingEvent, new HashMap<>());
         contexts = rulesetGC.generateContexts(trackerEvent);
         assertEquals(0, contexts.size());
 
         // Matching self-describing event with general schema
         selfDescribingEvent = new Timing("Category", "Variable", 123)
                 .label("Label");
-        trackerEvent = new TrackerEvent(selfDescribingEvent);
+        trackerEvent = new TrackerEvent(selfDescribingEvent, new HashMap<>());
         contexts = rulesetGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());
         assertEquals("schema", contexts.get(0).getMap().get("schema"));
@@ -226,7 +226,7 @@ public class GlobalContextTest {
         });
 
         AbstractPrimitive event = new Structured("Category", "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event);
+        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
 
         List<SelfDescribingJson> contexts = blockGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());
@@ -237,7 +237,7 @@ public class GlobalContextTest {
     public void testContextGenerator() {
         GlobalContext contextGeneratorGC = new GlobalContext(new GlobalContextGenerator());
         AbstractPrimitive event = new Structured("StringToMatch", "Action");
-        TrackerEvent trackerEvent = new TrackerEvent(event);
+        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
 
         List<SelfDescribingJson> contexts = contextGeneratorGC.generateContexts(trackerEvent);
         assertEquals(1, contexts.size());

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -1,0 +1,136 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.snowplowanalytics.snowplow.event.Event;
+import com.snowplowanalytics.snowplow.event.SelfDescribing;
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class StateManagerTest {
+
+    @Test
+    public void testStateManager() {
+        StateManager stateManager = new StateManager();
+        stateManager.addStateMachine(new MockStateMachine(), "identifier");
+
+        SelfDescribing eventInc = new SelfDescribing("inc", new HashMap() {{ put("value", 1); }});
+        SelfDescribing eventDec = new SelfDescribing("dec", new HashMap() {{ put("value", 2); }});
+        SelfDescribing event = new SelfDescribing("nothing", new HashMap() {{ put("value", 3); }});
+
+        Map<String, StateFuture> state = stateManager.trackerStateByProcessedEvent(eventInc);
+        MockState mockState = (MockState)(state.get("identifier").getState());
+        assertEquals(1, mockState.value);
+        InspectableEvent e = new TrackerEvent(eventInc, state);
+        List<SelfDescribingJson> entities = stateManager.entitiesByProcessedEvent(e);
+        Map<String,Integer> data = (Map<String, Integer>) entities.get(0).getMap().get("data");
+        assertEquals(1, data.get("value").intValue());
+
+        state = stateManager.trackerStateByProcessedEvent(eventInc);
+        mockState = (MockState)(state.get("identifier").getState());
+        assertEquals(2, mockState.value);
+        e = new TrackerEvent(eventInc, state);
+        entities = stateManager.entitiesByProcessedEvent(e);
+        data = (Map<String, Integer>) entities.get(0).getMap().get("data");
+        assertEquals(2, data.get("value").intValue());
+
+        state = stateManager.trackerStateByProcessedEvent(eventDec);
+        mockState = (MockState)(state.get("identifier").getState());
+        assertEquals(1, mockState.value);
+        e = new TrackerEvent(eventDec, state);
+        entities = stateManager.entitiesByProcessedEvent(e);
+        data = (Map<String, Integer>) entities.get(0).getMap().get("data");
+        assertEquals(1, data.get("value").intValue());
+
+        state = stateManager.trackerStateByProcessedEvent(event);
+        mockState = (MockState)(state.get("identifier").getState());
+        assertEquals(1, mockState.value);
+        e = new TrackerEvent(event, state);
+        entities = stateManager.entitiesByProcessedEvent(e);
+        data = (Map<String, Integer>) entities.get(0).getMap().get("data");
+        assertEquals(1, data.get("value").intValue());
+    }
+
+    @Test
+    public void testAddRemoveStateMachine() {
+        StateManager stateManager = new StateManager();
+        stateManager.addStateMachine(new MockStateMachine(), "identifier");
+        stateManager.removeStateMachine("identifier");
+
+        SelfDescribing eventInc = new SelfDescribing("inc", new HashMap() {{ put("value", 1); }});
+
+        Map<String, StateFuture> state = stateManager.trackerStateByProcessedEvent(eventInc);
+        StateFuture stateFuture = state.get("identifier");
+        assertNull(stateFuture);
+        InspectableEvent e = new TrackerEvent(eventInc, state);
+        List<SelfDescribingJson> entities = stateManager.entitiesByProcessedEvent(e);
+        assertEquals(0, entities.size());
+    }
+}
+
+// Mock classes
+
+class MockState implements State {
+    int value;
+
+    MockState(int value) {
+        this.value = value;
+    }
+}
+
+class MockStateMachine implements StateMachineInterface {
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForTransitions() {
+        return new LinkedList<>(Arrays.asList("inc", "dec"));
+    }
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForEntitiesGeneration() {
+        return new LinkedList<>(Collections.singletonList("*"));
+    }
+
+    @Nullable
+    @Override
+    public State transition(@NonNull Event event, @Nullable State currentState) {
+        SelfDescribing e = (SelfDescribing)event;
+        MockState state = (MockState)currentState;
+        if (state == null) {
+            state = new MockState(0);
+        }
+        if (e.getSchema().equals("inc")) {
+            return new MockState(state.value+1);
+        } else if (e.getSchema().equals("dec")) {
+            return new MockState(state.value-1);
+        } else {
+            return new MockState(0);
+        }
+    }
+
+    @NonNull
+    @Override
+    public List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @NonNull State state) {
+        MockState mockState = (MockState)state;
+        SelfDescribingJson sdj = new SelfDescribingJson("enitity", new HashMap<String,Integer>() {{
+            put("value", mockState.value);
+        }});
+        return new LinkedList<>(Arrays.asList(sdj));
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -42,44 +42,44 @@ public class StateManagerTest {
         SelfDescribing eventDec = new SelfDescribing("dec", new HashMap() {{ put("value", 2); }});
         SelfDescribing event = new SelfDescribing("event", new HashMap() {{ put("value", 3); }});
 
-        Map<String, StateFuture> state = stateManager.trackerStateByProcessedEvent(eventInc);
-        MockState mockState = (MockState)(state.get("identifier").getState());
+        TrackerStateSnapshot trackerState = stateManager.trackerStateForProcessedEvent(eventInc);
+        MockState mockState = (MockState)(trackerState.getState("identifier"));
         assertEquals(1, mockState.value);
-        InspectableEvent e = new TrackerEvent(eventInc, state);
-        List<SelfDescribingJson> entities = stateManager.entitiesByProcessedEvent(e);
+        InspectableEvent e = new TrackerEvent(eventInc, trackerState);
+        List<SelfDescribingJson> entities = stateManager.entitiesForProcessedEvent(e);
         Map<String,Integer> data = (Map<String, Integer>) entities.get(0).getMap().get("data");
         assertEquals(1, data.get("value").intValue());
-        assertTrue(stateManager.addPayloadValuesForEvent(e));
+        assertTrue(stateManager.addPayloadValuesToEvent(e));
         assertNull(e.getPayload().get("newParam"));
 
-        state = stateManager.trackerStateByProcessedEvent(eventInc);
-        mockState = (MockState)(state.get("identifier").getState());
+        trackerState = stateManager.trackerStateForProcessedEvent(eventInc);
+        mockState = (MockState)(trackerState.getState("identifier"));
         assertEquals(2, mockState.value);
-        e = new TrackerEvent(eventInc, state);
-        entities = stateManager.entitiesByProcessedEvent(e);
+        e = new TrackerEvent(eventInc, trackerState);
+        entities = stateManager.entitiesForProcessedEvent(e);
         data = (Map<String, Integer>) entities.get(0).getMap().get("data");
         assertEquals(2, data.get("value").intValue());
-        assertTrue(stateManager.addPayloadValuesForEvent(e));
+        assertTrue(stateManager.addPayloadValuesToEvent(e));
         assertNull(e.getPayload().get("newParam"));
 
-        state = stateManager.trackerStateByProcessedEvent(eventDec);
-        mockState = (MockState)(state.get("identifier").getState());
+        trackerState = stateManager.trackerStateForProcessedEvent(eventDec);
+        mockState = (MockState)(trackerState.getState("identifier"));
         assertEquals(1, mockState.value);
-        e = new TrackerEvent(eventDec, state);
-        entities = stateManager.entitiesByProcessedEvent(e);
+        e = new TrackerEvent(eventDec, trackerState);
+        entities = stateManager.entitiesForProcessedEvent(e);
         data = (Map<String, Integer>) entities.get(0).getMap().get("data");
         assertEquals(1, data.get("value").intValue());
-        assertTrue(stateManager.addPayloadValuesForEvent(e));
+        assertTrue(stateManager.addPayloadValuesToEvent(e));
         assertNull(e.getPayload().get("newParam"));
 
-        state = stateManager.trackerStateByProcessedEvent(event);
-        mockState = (MockState)(state.get("identifier").getState());
+        trackerState = stateManager.trackerStateForProcessedEvent(event);
+        mockState = (MockState)(trackerState.getState("identifier"));
         assertEquals(1, mockState.value);
-        e = new TrackerEvent(event, state);
-        entities = stateManager.entitiesByProcessedEvent(e);
+        e = new TrackerEvent(event, trackerState);
+        entities = stateManager.entitiesForProcessedEvent(e);
         data = (Map<String, Integer>) entities.get(0).getMap().get("data");
         assertEquals(1, data.get("value").intValue());
-        assertTrue(stateManager.addPayloadValuesForEvent(e));
+        assertTrue(stateManager.addPayloadValuesToEvent(e));
         assertEquals("value", e.getPayload().get("newParam"));
     }
 
@@ -91,11 +91,11 @@ public class StateManagerTest {
 
         SelfDescribing eventInc = new SelfDescribing("inc", new HashMap() {{ put("value", 1); }});
 
-        Map<String, StateFuture> state = stateManager.trackerStateByProcessedEvent(eventInc);
-        StateFuture stateFuture = state.get("identifier");
-        assertNull(stateFuture);
-        InspectableEvent e = new TrackerEvent(eventInc, state);
-        List<SelfDescribingJson> entities = stateManager.entitiesByProcessedEvent(e);
+        TrackerStateSnapshot trackerState = stateManager.trackerStateForProcessedEvent(eventInc);
+        State state = trackerState.getState("identifier");
+        assertNull(state);
+        InspectableEvent e = new TrackerEvent(eventInc, trackerState);
+        List<SelfDescribingJson> entities = stateManager.entitiesForProcessedEvent(e);
         assertEquals(0, entities.size());
     }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -3,11 +3,16 @@ package com.snowplowanalytics.snowplow.internal.tracker;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.snowplowanalytics.snowplow.event.Event;
+import com.snowplowanalytics.snowplow.event.ScreenView;
 import com.snowplowanalytics.snowplow.event.SelfDescribing;
+import com.snowplowanalytics.snowplow.event.Timing;
+import com.snowplowanalytics.snowplow.internal.emitter.Emitter;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
+import com.snowplowanalytics.snowplow.tracker.LogLevel;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
+
+import android.content.Context;
 
 @RunWith(AndroidJUnit4.class)
 public class StateManagerTest {
@@ -80,6 +87,28 @@ public class StateManagerTest {
         InspectableEvent e = new TrackerEvent(eventInc, state);
         List<SelfDescribingJson> entities = stateManager.entitiesByProcessedEvent(e);
         assertEquals(0, entities.size());
+    }
+
+    @Test
+    public void testScreenState() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Emitter emitter = new Emitter.EmitterBuilder("http://snowplow-fake-url.com", context).build();
+        Tracker tracker = new Tracker.TrackerBuilder(emitter, "namespace", "appId", context)
+                .screenContext(true)
+                .base64(false)
+                .level(LogLevel.VERBOSE)
+                .build();
+
+        // Send events
+        tracker.track(new Timing("category", "variable", 123));
+
+        tracker.track(new ScreenView("screen1"));
+
+        tracker.track(new Timing("category", "variable", 123));
+
+        tracker.track(new ScreenView("screen2"));
+
+        tracker.track(new Timing("category", "variable", 123));
     }
 }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -42,6 +42,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 import java.util.UUID;
@@ -179,8 +180,8 @@ public class TrackerTest extends AndroidTestCase {
                 .variable("variable")
                 .timing(100)
                 .build();
-        UUID id1 = new TrackerEvent(event).eventId;
-        UUID id2 = new TrackerEvent(event).eventId;
+        UUID id1 = new TrackerEvent(event, new HashMap<>()).eventId;
+        UUID id2 = new TrackerEvent(event, new HashMap<>()).eventId;
         assertNotEquals(id1, id2);
     }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -181,8 +181,8 @@ public class TrackerTest extends AndroidTestCase {
                 .variable("variable")
                 .timing(100)
                 .build();
-        UUID id1 = new TrackerEvent(event, new HashMap<>()).eventId;
-        UUID id2 = new TrackerEvent(event, new HashMap<>()).eventId;
+        UUID id1 = new TrackerEvent(event).eventId;
+        UUID id2 = new TrackerEvent(event).eventId;
         assertNotEquals(id1, id2);
     }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -36,6 +36,7 @@ import com.snowplowanalytics.snowplow.emitter.BufferOption;
 import com.snowplowanalytics.snowplow.event.ScreenView;
 import com.snowplowanalytics.snowplow.event.Timing;
 import com.snowplowanalytics.snowplow.tracker.LogLevel;
+import com.snowplowanalytics.snowplow.tracker.MockEventStore;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -419,7 +419,7 @@ public class TrackerTest extends AndroidTestCase {
         String screenId = (String) screenView.getDataPayload().get("id");
         tracker.track(screenView);
 
-        screenStateMapWrapper = screenState.getCurrentScreen(true).getMap();
+        screenStateMapWrapper = tracker.getScreenState().getCurrentScreen(true).getMap();
         screenStateMap = (Map<String, Object>) screenStateMapWrapper.get(Parameters.DATA);
         assertEquals("screen1", screenStateMap.get(Parameters.SCREEN_NAME));
         assertEquals(screenId, screenStateMap.get(Parameters.SCREEN_ID));
@@ -428,12 +428,6 @@ public class TrackerTest extends AndroidTestCase {
         screenView = ScreenView.builder().name("screen2").build();
         String screenId1 = (String) screenView.getDataPayload().get("id");
         tracker.track(screenView);
-
-        Map<String, Object> payload = (Map<String, Object>) screenView.getDataPayload();
-        assertEquals("screen2", payload.get(Parameters.SCREEN_NAME));
-        assertEquals(screenId1, payload.get(Parameters.SCREEN_ID));
-        assertEquals("screen1", payload.get(Parameters.SV_PREVIOUS_NAME));
-        assertEquals(screenId, payload.get(Parameters.SV_PREVIOUS_ID));
     }
 
     public void testTrackUncaughtException() {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockEventStore.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockEventStore.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Map;
 
 public class MockEventStore implements EventStore {
-    private HashMap<Long, Payload> db = new HashMap<>();
-    private long lastInsertedRow = -1;
+    public HashMap<Long, Payload> db = new HashMap<>();
+    public long lastInsertedRow = -1;
 
     @Override
     public void add(@NonNull Payload payload) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/SelfDescribing.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/SelfDescribing.java
@@ -19,6 +19,7 @@ import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -94,6 +95,12 @@ public class SelfDescribing extends AbstractSelfDescribing {
         Preconditions.checkNotNull(schema);
         this.schema = schema;
         this.eventData = eventData;
+    }
+
+    public SelfDescribing(@NonNull String schema, @NonNull Map<String, Object> payload) {
+        this.schema = schema;
+        this.payload = payload;
+        this.eventData = new SelfDescribingJson(schema, payload);
     }
 
     @Override

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenState.java
@@ -11,7 +11,7 @@ import com.snowplowanalytics.snowplow.payload.TrackerPayload;
 import com.snowplowanalytics.snowplow.internal.utils.Util;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
-public class ScreenState {
+public class ScreenState implements State {
     private String name;
     private String type;
     private String id;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
@@ -6,13 +6,16 @@ import androidx.annotation.Nullable;
 import com.snowplowanalytics.snowplow.event.Event;
 import com.snowplowanalytics.snowplow.event.ScreenView;
 import com.snowplowanalytics.snowplow.event.SelfDescribing;
+import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ScreenStateMachine implements StateMachineInterface {
 
@@ -26,6 +29,12 @@ public class ScreenStateMachine implements StateMachineInterface {
     @Override
     public List<String> subscribedEventSchemasForEntitiesGeneration() {
         return Collections.singletonList("*");
+    }
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForPayloadUpdating() {
+        return Collections.singletonList(TrackerConstants.SCHEMA_SCREEN_VIEW);
     }
 
     @Nullable
@@ -49,5 +58,19 @@ public class ScreenStateMachine implements StateMachineInterface {
         ScreenState screenState = (ScreenState) state;
         SelfDescribingJson entity = screenState.getCurrentScreen(true);
         return Collections.singletonList(entity);
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> payloadValues(@NonNull InspectableEvent event, @Nullable State state) {
+        if (state instanceof ScreenState) {
+            ScreenState screenState = ((ScreenState) state);
+            Map<String, Object> addedValues = new HashMap<>();
+            addedValues.put(Parameters.SV_PREVIOUS_NAME, screenState.getPreviousName());
+            addedValues.put(Parameters.SV_PREVIOUS_TYPE, screenState.getPreviousType());
+            addedValues.put(Parameters.SV_PREVIOUS_ID, screenState.getPreviousId());
+            return addedValues;
+        }
+        return null;
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
@@ -1,0 +1,53 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.event.Event;
+import com.snowplowanalytics.snowplow.event.ScreenView;
+import com.snowplowanalytics.snowplow.event.SelfDescribing;
+import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ScreenStateMachine implements StateMachineInterface {
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForTransitions() {
+        return Collections.singletonList(TrackerConstants.SCHEMA_SCREEN_VIEW);
+    }
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForEntitiesGeneration() {
+        return Collections.singletonList("*");
+    }
+
+    @Nullable
+    @Override
+    public State transition(@NonNull Event event, @Nullable State currentState) {
+        ScreenView screenView = (ScreenView) event;
+        ScreenState screenState;
+        if (currentState != null) {
+            screenState = (ScreenState) currentState;
+        } else {
+            screenState = new ScreenState();
+        }
+        screenView.updateScreenState(screenState);
+        return screenState;
+    }
+
+    @NonNull
+    @Override
+    public List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @Nullable State state) {
+        if (state == null) return new ArrayList<>();
+        ScreenState screenState = (ScreenState) state;
+        SelfDescribingJson entity = screenState.getCurrentScreen(true);
+        return Collections.singletonList(entity);
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
@@ -19,6 +19,16 @@ import java.util.Map;
 
 public class ScreenStateMachine implements StateMachineInterface {
 
+    /*
+     States: Init, Screen
+     Events: SV (ScreenView)
+     Transitions:
+      - Init (SV) Screen
+      - Screen (SV) Screen
+     Entity Generation:
+      - Screen
+     */
+
     @NonNull
     @Override
     public List<String> subscribedEventSchemasForTransitions() {
@@ -43,8 +53,10 @@ public class ScreenStateMachine implements StateMachineInterface {
         ScreenView screenView = (ScreenView) event;
         ScreenState screenState;
         if (currentState != null) {
+            // - Screen (SV) Screen
             screenState = (ScreenState) currentState;
         } else {
+            // - Init (SV) Screen
             screenState = new ScreenState();
         }
         screenView.updateScreenState(screenState);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
@@ -49,12 +49,12 @@ public class ScreenStateMachine implements StateMachineInterface {
 
     @Nullable
     @Override
-    public State transition(@NonNull Event event, @Nullable State currentState) {
+    public State transition(@NonNull Event event, @Nullable State state) {
         ScreenView screenView = (ScreenView) event;
         ScreenState screenState;
-        if (currentState != null) {
+        if (state != null) {
             // - Screen (SV) Screen
-            screenState = (ScreenState) currentState;
+            screenState = (ScreenState) state;
         } else {
             // - Init (SV) Screen
             screenState = new ScreenState();

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/State.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/State.java
@@ -1,0 +1,3 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+public interface State { }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateFuture.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateFuture.java
@@ -13,7 +13,7 @@ public class StateFuture {
 
     private State computedState;
 
-    public StateFuture(@NonNull Event event, @Nullable StateFuture previousState, StateMachineInterface stateMachine) {
+    public StateFuture(@NonNull Event event, @Nullable StateFuture previousState, @NonNull StateMachineInterface stateMachine) {
         this.event = event;
         this.previousState = previousState;
         this.stateMachine = stateMachine;
@@ -21,7 +21,7 @@ public class StateFuture {
 
     @Nullable
     public synchronized State getState() {
-        if (computedState == null) {
+        if (computedState == null && stateMachine != null) {
             State prevState = null;
             if (previousState != null) {
                 prevState = previousState.getState();

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateFuture.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateFuture.java
@@ -5,6 +5,13 @@ import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.event.Event;
 
+/**
+ StateFuture represents the placeholder of a future computation.
+ The proper state value is computed when it's observed. Until that moment the StateFuture keeps the elements
+ (event, previous StateFuture, StateMachine) needed to calculate the real state value.
+ For this reason, the StateFuture can be the head of StateFuture chain which will collapse once the StateFuture
+ head is asked to get the real state value.
+ */
 public class StateFuture {
 
     private Event event;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateFuture.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateFuture.java
@@ -1,0 +1,37 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.event.Event;
+
+public class StateFuture {
+
+    private Event event;
+    private StateFuture previousState;
+    private StateMachineInterface stateMachine;
+
+    private State computedState;
+
+    public StateFuture(@NonNull Event event, @Nullable StateFuture previousState, StateMachineInterface stateMachine) {
+        this.event = event;
+        this.previousState = previousState;
+        this.stateMachine = stateMachine;
+    }
+
+    @Nullable
+    public synchronized State getState() {
+        if (computedState == null) {
+            State prevState = null;
+            if (previousState != null) {
+                prevState = previousState.getState();
+            }
+            computedState = stateMachine.transition(event, prevState);
+            event = null;
+            previousState = null;
+            stateMachine = null;
+        }
+        return computedState;
+    }
+
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateMachineInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateMachineInterface.java
@@ -1,0 +1,25 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.event.Event;
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
+
+import java.util.List;
+
+public interface StateMachineInterface {
+
+    @NonNull
+    List<String> subscribedEventSchemasForTransitions();
+
+    @NonNull
+    List<String> subscribedEventSchemasForEntitiesGeneration();
+
+    @Nullable
+    State transition(@NonNull Event event, @Nullable State currentState);
+
+    @NonNull
+    List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @NonNull State state);
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateMachineInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateMachineInterface.java
@@ -21,5 +21,5 @@ public interface StateMachineInterface {
     State transition(@NonNull Event event, @Nullable State currentState);
 
     @NonNull
-    List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @NonNull State state);
+    List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @Nullable State state);
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateMachineInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateMachineInterface.java
@@ -22,7 +22,7 @@ public interface StateMachineInterface {
     List<String> subscribedEventSchemasForPayloadUpdating();
 
     @Nullable
-    State transition(@NonNull Event event, @Nullable State currentState);
+    State transition(@NonNull Event event, @Nullable State state);
 
     @Nullable
     List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @Nullable State state);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateMachineInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateMachineInterface.java
@@ -8,6 +8,7 @@ import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
 
 import java.util.List;
+import java.util.Map;
 
 public interface StateMachineInterface {
 
@@ -17,9 +18,15 @@ public interface StateMachineInterface {
     @NonNull
     List<String> subscribedEventSchemasForEntitiesGeneration();
 
+    @NonNull
+    List<String> subscribedEventSchemasForPayloadUpdating();
+
     @Nullable
     State transition(@NonNull Event event, @Nullable State currentState);
 
-    @NonNull
+    @Nullable
     List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @Nullable State state);
+
+    @Nullable
+    Map<String, Object> payloadValues(@NonNull InspectableEvent event, @Nullable State state);
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
@@ -1,0 +1,105 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+
+import com.snowplowanalytics.snowplow.event.Event;
+import com.snowplowanalytics.snowplow.event.SelfDescribing;
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class StateManager {
+
+    private HashMap<String, StateMachineInterface> identifierToStateMachine = new HashMap<>();
+    private HashMap<StateMachineInterface, String> stateMachineToIdentifier = new HashMap<>();
+    private HashMap<String, List<StateMachineInterface>> eventSchemaToStateMachine = new HashMap<>();
+    private HashMap<String, List<StateMachineInterface>> eventSchemaToEntitiesGenerator = new HashMap<>();
+    private HashMap<String, StateFuture> stateIdentifierToCurrentState = new HashMap<>();
+
+
+    public synchronized void addStateMachine(@NonNull StateMachineInterface stateMachine, @NonNull String identifier) {
+        identifierToStateMachine.put(identifier, stateMachine);
+        stateMachineToIdentifier.put(stateMachine, identifier);
+        for (String eventSchema : stateMachine.subscribedEventSchemasForTransitions()) {
+            List<StateMachineInterface> list = eventSchemaToStateMachine.get(eventSchema);
+            if (list == null) {
+                list = new LinkedList<>();
+                eventSchemaToStateMachine.put(eventSchema, list);
+            }
+            list.add(stateMachine);
+        }
+        for (String eventSchema : stateMachine.subscribedEventSchemasForEntitiesGeneration()) {
+            List<StateMachineInterface> list = eventSchemaToEntitiesGenerator.get(eventSchema);
+            if (list == null) {
+                list = new LinkedList<>();
+                eventSchemaToEntitiesGenerator.put(eventSchema, list);
+            }
+            list.add(stateMachine);
+        }
+    }
+
+    public synchronized boolean removeStateMachine(@NonNull String identifier) {
+        StateMachineInterface stateMachine = identifierToStateMachine.remove(identifier);
+        if (stateMachine == null) {
+            return false;
+        }
+        stateMachineToIdentifier.remove(stateMachine);
+        stateIdentifierToCurrentState.remove(identifier);
+        for (String eventSchema : stateMachine.subscribedEventSchemasForTransitions()) {
+            List<StateMachineInterface> list = eventSchemaToStateMachine.get(eventSchema);
+            list.remove(stateMachine);
+        }
+        for (String eventSchema : stateMachine.subscribedEventSchemasForEntitiesGeneration()) {
+            List<StateMachineInterface> list = eventSchemaToEntitiesGenerator.get(eventSchema);
+            list.remove(stateMachine);
+        }
+        return true;
+    }
+
+    @NonNull
+    synchronized Map<String, StateFuture> trackerStateByProcessedEvent(@NonNull Event event) {
+        if (event instanceof SelfDescribing) {
+            SelfDescribing sdEvent = (SelfDescribing)event;
+            List<StateMachineInterface> stateMachines = eventSchemaToStateMachine.get(sdEvent.getSchema());
+            if (stateMachines == null) {
+                stateMachines = new LinkedList<>();
+            }
+            List<StateMachineInterface> stateMachinesGeneral = eventSchemaToStateMachine.get("*");
+            if (stateMachinesGeneral != null) {
+                stateMachines.addAll(stateMachinesGeneral);
+            }
+            for (StateMachineInterface stateMachine : stateMachines) {
+                String stateIdentifier = stateMachineToIdentifier.get(stateMachine);
+                StateFuture previousState = stateIdentifierToCurrentState.get(stateIdentifier);
+                StateFuture newState = new StateFuture(sdEvent, previousState, stateMachine);
+                stateIdentifierToCurrentState.put(stateIdentifier, newState);
+            }
+        }
+        return new HashMap<>(stateIdentifierToCurrentState);
+    }
+
+    @NonNull
+    synchronized List<SelfDescribingJson> entitiesByProcessedEvent(@NonNull InspectableEvent event) {
+        List<SelfDescribingJson> result = new LinkedList<>();
+        List<StateMachineInterface> stateMachines = eventSchemaToEntitiesGenerator.get(event.getSchema());
+        if (stateMachines == null) {
+            stateMachines = new LinkedList<>();
+        }
+        List<StateMachineInterface> stateMachinesGeneral = eventSchemaToEntitiesGenerator.get("*");
+        if (stateMachinesGeneral != null) {
+            stateMachines.addAll(stateMachinesGeneral);
+        }
+        for (StateMachineInterface stateMachine : stateMachines) {
+            String stateIdentifier = stateMachineToIdentifier.get(stateMachine);
+            StateFuture stateFuture = event.getState().get(stateIdentifier);
+            List<SelfDescribingJson> entities = stateMachine.entities(event, stateFuture.getState());
+            result.addAll(entities);
+        }
+        return result;
+    }
+
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
@@ -61,6 +61,18 @@ public class StateManager {
                 StateFuture previousState = stateIdentifierToCurrentState.get(stateIdentifier);
                 StateFuture newState = new StateFuture(sdEvent, previousState, stateMachine);
                 stateIdentifierToCurrentState.put(stateIdentifier, newState);
+                // TODO: Remove early state computation.
+                /*
+                The early state-computation causes low performance as it's executed synchronously on
+                the track method thread. Ideally, the state computation should be executed only on
+                entities generation or payload updating (outputs). In that case there are two problems
+                to address:
+                 - long chains of StateFuture filling the memory (in case the outputs are not generated)
+                 - event object reuse by the user (the event object in the StateFuture could be modified
+                   externally)
+                 Remove the early state-computation only when these two problems are fixed.
+                 */
+                newState.getState(); // Early state-computation
             }
         }
         return new HashMap<>(stateIdentifierToCurrentState);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -654,7 +654,7 @@ public class Tracker {
     }
 
     private void processEvent(@NonNull Event event) {
-        TrackerEvent trackerEvent = new TrackerEvent(event);
+        TrackerEvent trackerEvent = new TrackerEvent(event, new HashMap<>());
         transformEvent(trackerEvent);
         Payload payload = payloadWithEvent(trackerEvent);
         Logger.v(TAG, "Adding new payload to event storage: %s", payload);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -670,6 +670,8 @@ public class Tracker {
             event.timestamp = event.trueTimestamp;
             event.trueTimestamp = null;
         }
+        // Payload can be optionally updated with values based on internal state
+        stateManager.addPayloadValuesForEvent(event);
     }
 
     private @NonNull Payload payloadWithEvent(@NonNull TrackerEvent event) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -1099,7 +1099,10 @@ public class Tracker {
     @Deprecated
     public ScreenState getScreenState() {
         StateFuture stateFuture = stateManager.stateIdentifierToCurrentState.get("ScreenContext");
-        if (stateFuture == null) return null;
+        if (stateFuture == null) {
+            // Legacy initialization
+            return new ScreenState();
+        };
         State state = stateFuture.getState();
         if (state instanceof ScreenState) {
             return (ScreenState) state;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerEvent.java
@@ -86,4 +86,19 @@ public class TrackerEvent implements InspectableEvent {
     public Map<String, StateFuture> getState() {
         return state;
     }
+
+    @Override
+    public boolean addPayloadValues(@NonNull Map<String, Object> payloadAdding) {
+        boolean result = true;
+        for (Map.Entry<String, Object> entry : payloadAdding.entrySet()) {
+            String key = entry.getKey();
+            if (payload.get(key) == null) {
+                payload.put(key, entry.getValue());
+            } else {
+                result = false;
+            }
+        }
+        return result;
+    }
+
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerEvent.java
@@ -37,19 +37,27 @@ public class TrackerEvent implements InspectableEvent {
     long timestamp;
     Long trueTimestamp;
     List<SelfDescribingJson> contexts;
-    Map<String, StateFuture> state;
+    TrackerStateSnapshot state;
 
     boolean isPrimitive;
     boolean isService;
 
-    public TrackerEvent(@NonNull Event event, @NonNull Map<String, StateFuture> stateCopy) {
+    public TrackerEvent(@NonNull Event event) {
+        this(event, null);
+    }
+
+    public TrackerEvent(@NonNull Event event, @Nullable TrackerStateSnapshot state) {
         eventId = UUID.randomUUID();
         timestamp = System.currentTimeMillis();
 
         contexts = new ArrayList<>(event.getContexts());
         trueTimestamp = event.getTrueTimestamp();
         payload = new HashMap<>(event.getDataPayload());
-        state = stateCopy;
+        if (state != null) {
+            this.state = state;
+        } else {
+            this.state = new TrackerState();
+        }
 
         isService = event instanceof TrackerError;
         if (event instanceof AbstractPrimitive) {
@@ -83,7 +91,7 @@ public class TrackerEvent implements InspectableEvent {
 
     @NonNull
     @Override
-    public Map<String, StateFuture> getState() {
+    public TrackerStateSnapshot getState() {
         return state;
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerEvent.java
@@ -37,17 +37,19 @@ public class TrackerEvent implements InspectableEvent {
     long timestamp;
     Long trueTimestamp;
     List<SelfDescribingJson> contexts;
+    Map<String, StateFuture> state;
 
     boolean isPrimitive;
     boolean isService;
 
-    public TrackerEvent(@NonNull Event event) {
+    public TrackerEvent(@NonNull Event event, @NonNull Map<String, StateFuture> stateCopy) {
         eventId = UUID.randomUUID();
         timestamp = System.currentTimeMillis();
 
         contexts = new ArrayList<>(event.getContexts());
         trueTimestamp = event.getTrueTimestamp();
         payload = new HashMap<>(event.getDataPayload());
+        state = stateCopy;
 
         isService = event instanceof TrackerError;
         if (event instanceof AbstractPrimitive) {
@@ -77,5 +79,11 @@ public class TrackerEvent implements InspectableEvent {
     @Override
     public Map<String, Object> getPayload() {
         return payload;
+    }
+
+    @NonNull
+    @Override
+    public Map<String, StateFuture> getState() {
+        return state;
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerState.java
@@ -1,0 +1,43 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+
+public class TrackerState implements TrackerStateSnapshot {
+
+    private HashMap<String, StateFuture> trackerState = new HashMap<>();
+
+    public synchronized void put(@NonNull String stateIdentifier, @NonNull StateFuture state) {
+        trackerState.put(stateIdentifier, state);
+    }
+
+    @Nullable
+    public synchronized StateFuture getStateFuture(@NonNull String stateIdentifier) {
+        return trackerState.get(stateIdentifier);
+    }
+
+    public void removeState(@NonNull String stateIdentifier) {
+        trackerState.remove(stateIdentifier);
+    }
+
+    @NonNull
+    public synchronized TrackerStateSnapshot getSnapshot() {
+        TrackerState newTrackerState = new TrackerState();
+        newTrackerState.trackerState = new HashMap<>(trackerState);
+        return newTrackerState;
+    }
+
+    // Implements TrackerStateSnapshot
+
+    @Nullable
+    @Override
+    public State getState(@NonNull String stateIdentifier) {
+        StateFuture stateFuture = getStateFuture(stateIdentifier);
+        if (stateFuture == null) {
+            return null;
+        }
+        return stateFuture.getState();
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerStateSnapshot.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerStateSnapshot.java
@@ -1,0 +1,11 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public interface TrackerStateSnapshot {
+
+    @Nullable
+    State getState(@NonNull String stateIdentifier);
+
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/InspectableEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/InspectableEvent.java
@@ -21,4 +21,6 @@ public interface InspectableEvent {
 
     @NonNull
     Map<String, StateFuture> getState();
+
+    boolean addPayloadValues(@NonNull Map<String, Object> payload);
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/InspectableEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/InspectableEvent.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.internal.tracker.StateFuture;
+import com.snowplowanalytics.snowplow.internal.tracker.TrackerStateSnapshot;
 
 import java.util.Map;
 
@@ -20,7 +21,7 @@ public interface InspectableEvent {
     Map<String, Object> getPayload();
 
     @NonNull
-    Map<String, StateFuture> getState();
+    TrackerStateSnapshot getState();
 
     boolean addPayloadValues(@NonNull Map<String, Object> payload);
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/InspectableEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/InspectableEvent.java
@@ -4,6 +4,8 @@ package com.snowplowanalytics.snowplow.tracker;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.snowplowanalytics.snowplow.internal.tracker.StateFuture;
+
 import java.util.Map;
 
 public interface InspectableEvent {
@@ -16,4 +18,7 @@ public interface InspectableEvent {
 
     @NonNull
     Map<String, Object> getPayload();
+
+    @NonNull
+    Map<String, StateFuture> getState();
 }


### PR DESCRIPTION
As explained in the issue ticket, this PR wants to introduce a common framework for state management in the tracker.
Along with the new feature, I also migrated the old Screen state management to the new one.
As usual, few changes have been limited by the requirement to do not remove public API in minor versions.

The basic logic of the new state management is basically built around the concept of FSM (Finite State Machine).
The state is managed by the state manager and when an event is processed a snapshot of the tracker state is associated to that event.

The FSM is used to calculate the next state based on the event received. The same class is also used to generate outputs: entities (contexts) or new payload values to add to the event.

The system is built in order to avoid decrease of performance on event tracking, executing the computation of the new state only when strictly needed. Unfortunately, there are a couple of issues to address first. For this reason I opted for an early state-computation that solve the problem at the root, with just a minor inefficiency. Something to fix when more internal tracker states are added, as explained in the commented code.

For the review I suggest to follow the changes commit by commit.