### PR TITLE
Capture campaign attribution data from deep links (close #470)

### DIFF
--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
@@ -51,6 +51,7 @@ import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.controller.EmitterController;
 import com.snowplowanalytics.snowplow.controller.SessionController;
 import com.snowplowanalytics.snowplow.controller.TrackerController;
+import com.snowplowanalytics.snowplow.event.ScreenView;
 import com.snowplowanalytics.snowplow.globalcontexts.GlobalContext;
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
 import com.snowplowanalytics.snowplow.tracker.LoggerDelegate;
@@ -298,7 +299,7 @@ public class Demo extends Activity implements LoggerDelegate {
             return;
         }
         TrackerEvents.trackAll(tracker);
-        eventsCreated += 9;
+        eventsCreated += 10;
         final String made = "Made: " + eventsCreated;
         runOnUiThread(() -> _eventsCreated.setText(made));
     }

--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 
 import com.snowplowanalytics.snowplow.controller.TrackerController;
 import com.snowplowanalytics.snowplow.event.AbstractPrimitive;
+import com.snowplowanalytics.snowplow.event.DeepLinkReceived;
 import com.snowplowanalytics.snowplow.event.SelfDescribing;
 import com.snowplowanalytics.snowplow.event.ConsentDocument;
 import com.snowplowanalytics.snowplow.event.ConsentGranted;
@@ -42,6 +43,7 @@ import java.util.UUID;
 public class TrackerEvents {
 
     public static void trackAll(@NonNull TrackerController tracker) {
+        trackDeepLink(tracker);
         trackPageView(tracker);
         trackStructuredEvent(tracker);
         trackScreenView(tracker);
@@ -50,6 +52,11 @@ public class TrackerEvents {
         trackEcommerceEvent(tracker);
         trackConsentGranted(tracker);
         trackConsentWithdrawn(tracker);
+    }
+    
+    private static void trackDeepLink(TrackerController tracker) {
+        DeepLinkReceived event = new DeepLinkReceived("url link").referrer("referrer url");
+        tracker.track(event);
     }
 
     private static void trackPageView(TrackerController tracker) {
@@ -133,5 +140,4 @@ public class TrackerEvents {
                 .build();
         tracker.track(event);
     }
-
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.java
@@ -65,6 +65,10 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
      */
     public boolean sessionContext;
     /**
+     * @see #deepLinkContext(boolean)
+     */
+    public boolean deepLinkContext;
+    /**
      * @see #screenContext(boolean) 
      */
     public boolean screenContext;
@@ -191,6 +195,16 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
     }
 
     @Override
+    public boolean isDeepLinkContext() {
+        return deepLinkContext;
+    }
+
+    @Override
+    public void setDeepLinkContext(boolean deepLinkContext) {
+        this.deepLinkContext = deepLinkContext;
+    }
+
+    @Override
     public boolean isScreenContext() {
         return screenContext;
     }
@@ -275,6 +289,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
      *         platformContext = true;
      *         geoLocationContext = false;
      *         screenContext = true;
+     *         deepLinkContext = true;
      *         screenViewAutotracking = true;
      *         lifecycleAutotracking = false;
      *         installAutotracking = true;
@@ -295,6 +310,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
         applicationContext = true;
         platformContext = true;
         geoLocationContext = false;
+        deepLinkContext = true;
         screenContext = true;
         screenViewAutotracking = true;
         lifecycleAutotracking = false;
@@ -390,6 +406,15 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
     }
 
     /**
+     * Whether deepLink context is sent with all the ScreenView events.
+     */
+    @NonNull
+    public TrackerConfiguration deepLinkContext(boolean deepLinkContext) {
+        this.deepLinkContext = deepLinkContext;
+        return this;
+    }
+
+    /**
      * Whether screen context is sent with all the tracked events.
      */
     @NonNull
@@ -471,6 +496,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
         copy.platformContext = platformContext;
         copy.geoLocationContext = geoLocationContext;
         copy.screenContext = screenContext;
+        copy.deepLinkContext = deepLinkContext;
         copy.screenViewAutotracking = screenViewAutotracking;
         copy.lifecycleAutotracking = lifecycleAutotracking;
         copy.installAutotracking = installAutotracking;
@@ -498,6 +524,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
         platformContext = jsonObject.optBoolean("platformContext", platformContext);
         geoLocationContext = jsonObject.optBoolean("geoLocationContext", geoLocationContext);
         screenContext = jsonObject.optBoolean("screenContext", screenContext);
+        deepLinkContext = jsonObject.optBoolean("deepLinkContext", deepLinkContext);
         screenViewAutotracking = jsonObject.optBoolean("screenViewAutotracking", screenViewAutotracking);
         lifecycleAutotracking = jsonObject.optBoolean("lifecycleAutotracking", lifecycleAutotracking);
         installAutotracking = jsonObject.optBoolean("installAutotracking", installAutotracking);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/entity/DeepLink.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/entity/DeepLink.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.entity;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import java.util.HashMap;
+
+public class DeepLink extends SelfDescribingJson {
+
+    public final static String SCHEMA_DEEPLINK = "iglu:com.snowplowanalytics.mobile/deep_link/jsonschema/1-0-0";
+
+    public final static String PARAM_DEEPLINK_REFERRER = "referrer";
+    public final static String PARAM_DEEPLINK_URL = "url";
+
+    private final HashMap<String, Object> parameters = new HashMap<>();
+
+    public DeepLink(@NonNull String url) {
+        super(SCHEMA_DEEPLINK);
+        parameters.put(PARAM_DEEPLINK_URL, url);
+        setData(parameters);
+        // Set here further checks about the arguments.
+    }
+
+    // Builder methods
+    @NonNull
+    public DeepLink referrer(@Nullable String referrer) {
+        if (referrer != null) {
+            parameters.put(PARAM_DEEPLINK_REFERRER, referrer);
+        }
+        setData(parameters);
+        return this;
+    }
+}
+

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/DeepLinkReceived.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/DeepLinkReceived.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.event;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DeepLinkReceived extends AbstractSelfDescribing {
+
+    public final static String SCHEMA_DEEPLINKRECEIVED = "iglu:com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0";
+
+    public final static String PARAM_DEEPLINKRECEIVED_REFERRER = "referrer";
+    public final static String PARAM_DEEPLINKRECEIVED_URL = "url";
+
+    /// It's the property for `referrer` JSON key
+    @Nullable
+    public String referrer;
+    /// It's the property for `url` JSON key
+    @NonNull
+    public final String url;
+
+    public DeepLinkReceived(@NonNull String url) {
+        this.url = url;
+        // Set here further checks about the arguments.
+    }
+
+    // Builder methods
+    @NonNull
+    public DeepLinkReceived referrer(@Nullable String referrer) {
+        this.referrer = referrer;
+        return this;
+    }
+
+    // Tracker methods
+
+    @Override
+    public @NonNull Map<String, Object> getDataPayload() {
+        HashMap<String,Object> payload = new HashMap<>();
+        payload.put(PARAM_DEEPLINKRECEIVED_URL, url);
+        if (referrer != null) {
+            payload.put(PARAM_DEEPLINKRECEIVED_REFERRER, referrer);
+        }
+        return payload;
+    }
+
+    @Override
+    public @NonNull String getSchema() {
+        return SCHEMA_DEEPLINKRECEIVED;
+    }
+}
+

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/DeepLinkState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/DeepLinkState.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class DeepLinkState implements State {
+
+    @NonNull
+    public final String url;
+    @Nullable
+    public final String referrer;
+
+    public boolean readyForOutput = false;
+
+    public DeepLinkState(@NonNull String url, @Nullable String referrer) {
+        this.url = url;
+        this.referrer = referrer;
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/DeepLinkStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/DeepLinkStateMachine.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.entity.DeepLink;
+import com.snowplowanalytics.snowplow.event.DeepLinkReceived;
+import com.snowplowanalytics.snowplow.event.Event;
+import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DeepLinkStateMachine implements StateMachineInterface {
+
+    /*
+     States: Init, DeepLinkReceived, ReadyForOutput
+     Events: DL (DeepLinkReceived), SV (ScreenView)
+     Transitions:
+      - Init (DL) DeepLinkReceived
+      - DeepLinkReceived (SV) ReadyForOutput
+      - ReadyForOutput (DL) DeepLinkReceived
+      - ReadyForOutput (SV) Init
+     Entity Generation:
+      - ReadyForOutput
+      */
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForTransitions() {
+        return Arrays.asList(DeepLinkReceived.SCHEMA_DEEPLINKRECEIVED, TrackerConstants.SCHEMA_SCREEN_VIEW);
+    }
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForEntitiesGeneration() {
+        return Arrays.asList(TrackerConstants.SCHEMA_SCREEN_VIEW);
+    }
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForPayloadUpdating() {
+        return new ArrayList<>();
+    }
+
+    @Nullable
+    @Override
+    public State transition(@NonNull Event event, @Nullable State state) {
+        // - Init (DL) DeepLinkReceived
+        // - ReadyForOutput (DL) DeepLinkReceived
+        if (event instanceof DeepLinkReceived) {
+            DeepLinkReceived dlEvent = (DeepLinkReceived) event;
+            return new DeepLinkState(dlEvent.url, dlEvent.referrer);
+        } else {
+            // - Init (SV) Init
+            if (state == null) {
+                return null;
+            }
+            // - ReadyForOutput (SV) Init
+            DeepLinkState dlState = (DeepLinkState) state;
+            if (dlState.readyForOutput) {
+                return null;
+            }
+            // - DeepLinkReceived (SV) ReadyForOutput
+            DeepLinkState currentState = new DeepLinkState(dlState.url, dlState.referrer);
+            currentState.readyForOutput = true;
+            return currentState;
+        }
+    }
+
+    @Nullable
+    @Override
+    public List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @Nullable State state) {
+        if (state == null) {
+            return null;
+        }
+        DeepLinkState deepLinkState = (DeepLinkState) state;
+        if (!deepLinkState.readyForOutput) {
+            return null;
+        }
+        DeepLink entity = new DeepLink(deepLinkState.url)
+                .referrer(deepLinkState.referrer);
+        return Collections.singletonList(entity);
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> payloadValues(@NonNull InspectableEvent event, @Nullable State state) {
+        return null;
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
@@ -78,9 +78,18 @@ public class ScreenStateMachine implements StateMachineInterface {
         if (state instanceof ScreenState) {
             ScreenState screenState = ((ScreenState) state);
             Map<String, Object> addedValues = new HashMap<>();
-            addedValues.put(Parameters.SV_PREVIOUS_NAME, screenState.getPreviousName());
-            addedValues.put(Parameters.SV_PREVIOUS_TYPE, screenState.getPreviousType());
-            addedValues.put(Parameters.SV_PREVIOUS_ID, screenState.getPreviousId());
+            String value = screenState.getPreviousName();
+            if (value != null && !value.isEmpty()) {
+                addedValues.put(Parameters.SV_PREVIOUS_NAME, value);
+            }
+            value = screenState.getPreviousId();
+            if (value != null && !value.isEmpty()) {
+                addedValues.put(Parameters.SV_PREVIOUS_ID, value);
+            }
+            value = screenState.getPreviousType();
+            if (value != null && !value.isEmpty()) {
+                addedValues.put(Parameters.SV_PREVIOUS_TYPE, value);
+            }
             return addedValues;
         }
         return null;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -386,6 +386,7 @@ public class ServiceProvider implements ServiceProviderInterface {
                 .sessionContext(trackerConfig.isSessionContext())
                 .applicationContext(trackerConfig.isApplicationContext())
                 .mobileContext(trackerConfig.isPlatformContext())
+                .deepLinkContext(trackerConfig.isDeepLinkContext())
                 .screenContext(trackerConfig.isScreenContext())
                 .screenviewEvents(trackerConfig.isScreenViewAutotracking())
                 .lifecycleEvents(trackerConfig.isLifecycleAutotracking())

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -135,11 +135,13 @@ public class Tracker {
     boolean applicationCrash;
     boolean trackerDiagnostic;
     boolean lifecycleEvents;
-    boolean screenContext;
     boolean installTracking;
     boolean activityTracking;
     boolean applicationContext;
     String trackerVersionSuffix;
+
+    private boolean deepLinkcontext;
+    private boolean screenContext;
 
     private Gdpr gdpr;
     private InstallTracker installTracker;
@@ -224,6 +226,7 @@ public class Tracker {
         boolean applicationCrash = true; // Optional
         boolean trackerDiagnostic = false; // Optional
         boolean lifecycleEvents = false; // Optional
+        boolean deepLinkContext = true; // Optional
         boolean screenContext = false; // Optional
         boolean activityTracking = false; // Optional
         boolean installTracking = false; // Optional
@@ -462,6 +465,15 @@ public class Tracker {
         }
 
         /**
+         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.TrackerConfiguration#deepLinkContext(boolean)}
+         */
+        @NonNull
+        public TrackerBuilder deepLinkContext(@NonNull Boolean deepLinkContext) {
+            this.deepLinkContext = deepLinkContext;
+            return this;
+        }
+
+        /**
          * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.TrackerConfiguration#screenContext(boolean)}
          * @param screenContext whether to send a screen context (info pertaining
          *                      to current screen) with every event
@@ -552,12 +564,8 @@ public class Tracker {
         this.backgroundTimeout = builder.backgroundTimeout;
         this.trackerVersionSuffix = builder.trackerVersionSuffix;
 
-        this.screenContext = builder.screenContext;
-        if (screenContext) {
-            stateManager.addStateMachine(new ScreenStateMachine(), "ScreenContext");
-        } else {
-            stateManager.removeStateMachine("ScreenContext");
-        }
+        setScreenContext(builder.screenContext);
+        setDeepLinkContext(builder.deepLinkContext);
 
         if (trackerVersionSuffix != null) {
             String suffix = trackerVersionSuffix.replaceAll("[^A-Za-z0-9.-]", "");
@@ -962,10 +970,6 @@ public class Tracker {
         }
     }
 
-    public boolean getSessionContext() {
-        return sessionContext;
-    }
-
     /**
      * @param platform a valid DevicePlatform object
      */
@@ -973,7 +977,49 @@ public class Tracker {
         this.devicePlatform = platform;
     }
 
+    /**
+     * @deprecated Internal use only
+     */
+    public void setScreenContext(boolean screenContext) {
+        this.screenContext = screenContext;
+        if (screenContext) {
+            stateManager.addStateMachine(new ScreenStateMachine(), "ScreenContext");
+        } else {
+            stateManager.removeStateMachine("ScreenContext");
+        }
+    }
+
+    /**
+     * @deprecated Internal use only
+     */
+    public void setDeepLinkContext(boolean deepLinkContext) {
+        this.deepLinkcontext = deepLinkContext;
+        if (deepLinkcontext) {
+            stateManager.addStateMachine(new DeepLinkStateMachine(), "DeepLinkContext");
+        } else {
+            stateManager.removeStateMachine("DeepLinkContext");
+        }
+    }
+
     // --- Getters
+
+    /**
+     * @deprecated Internal use only
+     */
+    public boolean getScreenContext() {
+        return screenContext;
+    }
+
+    /**
+     * @deprecated Internal use only
+     */
+    public boolean getDeepLinkContext() {
+        return deepLinkcontext;
+    }
+
+    public boolean getSessionContext() {
+        return sessionContext;
+    }
 
     /**
      * @return the tracker version that was set

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationInterface.java
@@ -110,6 +110,16 @@ public interface TrackerConfigurationInterface {
     void setSessionContext(boolean sessionContext);
 
     /**
+     * Whether deepLink context is sent with all the ScreenView events.
+     */
+    boolean isDeepLinkContext();
+
+    /**
+     * Whether deepLink context is sent with all the ScreenView events.
+     */
+    void setDeepLinkContext(boolean deepLinkContext);
+
+    /**
      * Whether screen context is sent with all the tracked events.
      */
     boolean isScreenContext();

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationUpdate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationUpdate.java
@@ -101,6 +101,14 @@ public class TrackerConfigurationUpdate extends TrackerConfiguration {
         return (sourceConfig == null || sessionContextUpdated) ? super.sessionContext : sourceConfig.sessionContext;
     }
 
+    // deepLinkContext flag
+
+    public boolean deepLinkContextUpdated;
+
+    public boolean isDeepLinkContext() {
+        return (sourceConfig == null || deepLinkContextUpdated) ? super.deepLinkContext : sourceConfig.deepLinkContext;
+    }
+
     // screenContext flag
 
     public boolean screenContextUpdated;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
@@ -223,15 +223,27 @@ public class TrackerControllerImpl extends Controller implements TrackerControll
     }
 
     @Override
+    public boolean isDeepLinkContext() {
+        return getTracker().getDeepLinkContext();
+    }
+
+    @Override
+    public void setDeepLinkContext(boolean deepLinkContext) {
+        getDirtyConfig().deepLinkContext = deepLinkContext;
+        getDirtyConfig().deepLinkContextUpdated = true;
+        getTracker().setDeepLinkContext(deepLinkContext);
+    }
+
+    @Override
     public boolean isScreenContext() {
-        return getTracker().screenContext;
+        return getTracker().getScreenContext();
     }
 
     @Override
     public void setScreenContext(boolean screenContext) {
         getDirtyConfig().screenContext = screenContext;
         getDirtyConfig().screenContextUpdated = true;
-        getTracker().screenContext = screenContext;
+        getTracker().setScreenContext(screenContext);
     }
 
     @Override


### PR DESCRIPTION
This PR introduces the deep-linking in the Android tracker.
The process is partially manual.
1. The user tracks a deep-link event passing url and eventually referrer
2. The tracker keeps those info in the internal state
3. At the first ScreenView tracked, the tracker adds a DeepLink entity to the event
(The latter can be disabled from TrackerConfiguration)

**Below the proposed documentation update:**

--
## Deep Linking

In the mobile world the Deep Links are url that links to a specific content directly in a mobile app. Usually they are used to redirect the user from a website or a banner-ad to the installed app instead of another web page. The Deep Links help the user to go straight to the content they are interested of inside the app, similarly to the navigation in the web. 

Usually the Deep Link is received by the mobile operating system and passed to the related app. It's the responsability of the developer to parse the received deep-link's url and show the right content to the user. The way the Deep Link is used is strongly dependant by the way the app routing is implemented. For this reason, our mobile tracker can't automatically track the Deep Link, but we provide an out-of-the-box event that can be used by the developer to manually track it as soon as the Deep Link is received in the app. It will be duty of the tracker to automatically attach the informations of the Deep Link to the first ScreenView tracked.

The [Android platform documentation](https://developer.android.com/training/app-links/deep-linking) provides clear instructions about how to declare the Deep Links that the app is able to handle. Following those instructions, to enable Deep Link support in your app you should declare an *intent filter* in your `AndroidManifest.xml` that sends the Deep Link to the selected Activity as an intent.

In practice, when the activity receives the intent, the developer can track it through the DeepLinkReceived event.
For example (in your Activity):
```
@Override
public void onCreate(Bundle savedInstanceState) {
    ...

    // Extract info from Intent
    Intent intent = getIntent();
    String deepLinkUrl = intent.getData().toString();
    String referrer = null;
    Bundle extras = intent.getExtras();
    if (extras != null) {
        Uri referrerUri = extras.get(Intent.EXTRA_REFERRER);
        if (referrerUri != null) {
            referrer = referrerUri.toString();
        }
    }
    // Create and track the event
    DeepLinkReceived event = new DeepLinkReceived(deepLinkUrl).referrer(referrer);
    tracker.track(event);

    ...
}
```

The tracker keeps memory of the tracked Deep Link event and will attach a Deep Link entity to the first ScreenView tracked in the tracker.
This is helpful during the analysis of the data because it will be clear the relation between the content visualized by the user (ScreenView event) and source (DeepLink entity) that originated that visualization.

This behaviour is enabled by default but it can be disabled from the TrackerConfiguration.

For example:
```
TrackerConfiguration config = new TrackerConfiguration()
    ...
    .deepLinkContext(false)
    ...
```
