### PR TITLE
Add lifecycle context to indicate app state when the event is tracked (close #471)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/entity/LifecycleEntity.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/entity/LifecycleEntity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.entity;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import java.util.HashMap;
+
+public class LifecycleEntity extends SelfDescribingJson {
+
+    public final static String SCHEMA_LIFECYCLEENTITY = "iglu:com.snowplowanalytics.mobile/application_lifecycle/jsonschema/1-0-0";
+
+    public final static String PARAM_LIFECYCLEENTITY_INDEX = "index";
+    public final static String PARAM_LIFECYCLEENTITY_ISVISIBLE = "isVisible";
+
+    private final HashMap<String, Object> parameters = new HashMap<>();
+
+    public LifecycleEntity(boolean isVisible) {
+        super(SCHEMA_LIFECYCLEENTITY);
+        parameters.put(PARAM_LIFECYCLEENTITY_ISVISIBLE, isVisible);
+        setData(parameters);
+        // Set here further checks about the arguments.
+    }
+
+    // Builder methods
+    @NonNull
+    public LifecycleEntity index(@Nullable Integer index) {
+        if (index != null) {
+            parameters.put(PARAM_LIFECYCLEENTITY_INDEX, index);
+        }
+        setData(parameters);
+        return this;
+    }
+}
+

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Background.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Background.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.event;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Background extends AbstractSelfDescribing {
+
+
+    public final static String SCHEMA_BACKGROUND = "iglu:com.snowplowanalytics.snowplow/application_background/jsonschema/1-0-0";
+
+    public final static String PARAM_BACKGROUNDINDEX = "backgroundIndex";
+
+    /// It's the property for `backgroundIndex` JSON key
+    @Nullable
+    public Integer backgroundIndex;
+
+    // Builder methods
+
+    @NonNull
+    public Background backgroundIndex(@Nullable Integer backgroundIndex) {
+        this.backgroundIndex = backgroundIndex;
+        return this;
+    }
+
+    // Tracker methods
+
+    @NonNull
+    @Override
+    public String getSchema() {
+        return SCHEMA_BACKGROUND;
+    }
+
+    @NonNull
+    @Override
+    public Map<String, Object> getDataPayload() {
+        HashMap<String,Object> payload = new HashMap<>();
+        if (backgroundIndex != null) {
+            payload.put(PARAM_BACKGROUNDINDEX, backgroundIndex);
+        }
+        return payload;
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Foreground.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Foreground.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.event;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Foreground extends AbstractSelfDescribing {
+
+
+    public final static String SCHEMA_FOREGROUND = "iglu:com.snowplowanalytics.snowplow/application_foreground/jsonschema/1-0-0";
+
+    public final static String PARAM_FOREGROUNDINDEX = "foregroundIndex";
+
+    /// It's the property for `backgroundIndex` JSON key
+    @Nullable
+    public Integer foregroundIndex;
+
+    // Builder methods
+
+    @NonNull
+    public Foreground foregroundIndex(@Nullable Integer foregroundIndex) {
+        this.foregroundIndex = foregroundIndex;
+        return this;
+    }
+
+    // Tracker methods
+
+    @NonNull
+    @Override
+    public String getSchema() {
+        return SCHEMA_FOREGROUND;
+    }
+
+    @NonNull
+    @Override
+    public Map<String, Object> getDataPayload() {
+        HashMap<String,Object> payload = new HashMap<>();
+        if (foregroundIndex != null) {
+            payload.put(PARAM_FOREGROUNDINDEX, foregroundIndex);
+        }
+        return payload;
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/TrackerConstants.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/TrackerConstants.java
@@ -33,8 +33,6 @@ public class TrackerConstants {
     public static final String MOBILE_SCHEMA = "iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-1";
     public static final String SESSION_SCHEMA = "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1";
     public static final String APPLICATION_ERROR_SCHEMA = "iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-0";
-    public static final String APPLICATION_FOREGOUND_SCHEMA = "iglu:com.snowplowanalytics.snowplow/application_foreground/jsonschema/1-0-0";
-    public static final String APPLICATION_BACKGROUND_SCHEMA = "iglu:com.snowplowanalytics.snowplow/application_background/jsonschema/1-0-0";
     public static final String SCHEMA_SCREEN = "iglu:com.snowplowanalytics.mobile/screen/jsonschema/1-0-0";
     public static final String SCHEMA_APPLICATION_INSTALL = "iglu:com.snowplowanalytics.mobile/application_install/jsonschema/1-0-0";
     public static final String SCHEMA_APPLICATION = "iglu:com.snowplowanalytics.mobile/application/jsonschema/1-0-0";

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/ProcessObserver.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/ProcessObserver.java
@@ -23,6 +23,8 @@ import androidx.lifecycle.Lifecycle;
 import android.os.Build;
 
 
+import com.snowplowanalytics.snowplow.event.Background;
+import com.snowplowanalytics.snowplow.event.Foreground;
 import com.snowplowanalytics.snowplow.event.SelfDescribing;
 import com.snowplowanalytics.snowplow.internal.tracker.Tracker;
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
@@ -88,10 +90,9 @@ public class ProcessObserver implements LifecycleObserver {
 
                 // Send Foreground Event
                 if (tracker.getLifecycleEvents()) {
-                    Map<String, Object> data = new HashMap<>();
-                    Util.addToMap(Parameters.APP_FOREGROUND_INDEX, index, data);
-                    tracker.track(new SelfDescribing(new SelfDescribingJson(TrackerConstants.APPLICATION_FOREGOUND_SCHEMA, data))
-                            .contexts(lifecycleContexts)
+                    tracker.track(
+                            new Foreground().foregroundIndex(index)
+                                    .contexts(lifecycleContexts)
                     );
                 }
             } catch (Exception e) {
@@ -119,10 +120,9 @@ public class ProcessObserver implements LifecycleObserver {
 
                 // Send Background Event
                 if (tracker.getLifecycleEvents()) {
-                    Map<String, Object> data = new HashMap<>();
-                    Util.addToMap(Parameters.APP_BACKGROUND_INDEX, index, data);
-                    tracker.track(new SelfDescribing(new SelfDescribingJson(TrackerConstants.APPLICATION_BACKGROUND_SCHEMA, data))
-                            .contexts(lifecycleContexts)
+                    tracker.track(
+                            new Background().backgroundIndex(index)
+                                    .contexts(lifecycleContexts)
                     );
                 }
             } catch (Exception e) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/LifecycleState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/LifecycleState.java
@@ -1,0 +1,16 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.Nullable;
+
+public class LifecycleState implements State {
+
+    public final boolean isForeground;
+
+    @Nullable
+    public final Integer index;
+
+    public LifecycleState(boolean isForeground, @Nullable Integer index) {
+        this.isForeground = isForeground;
+        this.index = index;
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/LifecycleStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/LifecycleStateMachine.java
@@ -1,0 +1,65 @@
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.entity.LifecycleEntity;
+import com.snowplowanalytics.snowplow.event.Background;
+import com.snowplowanalytics.snowplow.event.Event;
+import com.snowplowanalytics.snowplow.event.Foreground;
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class LifecycleStateMachine implements StateMachineInterface {
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForTransitions() {
+        return Arrays.asList(Background.SCHEMA_BACKGROUND, Foreground.SCHEMA_FOREGROUND);
+    }
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForEntitiesGeneration() {
+        return Collections.singletonList("*");
+    }
+
+    @NonNull
+    @Override
+    public List<String> subscribedEventSchemasForPayloadUpdating() {
+        return Collections.emptyList();
+    }
+
+    @Nullable
+    @Override
+    public State transition(@NonNull Event event, @Nullable State currentState) {
+        if (event instanceof Foreground) {
+            Foreground e = (Foreground) event;
+            return new LifecycleState(true, e.foregroundIndex);
+        }
+        if (event instanceof Background) {
+            Background e = (Background) event;
+            return new LifecycleState(false, e.backgroundIndex);
+        }
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public List<SelfDescribingJson> entities(@NonNull InspectableEvent event, @Nullable State state) {
+        if (state == null) return null;
+        LifecycleState s = (LifecycleState) state;
+        return Collections.singletonList(new LifecycleEntity(s.isForeground).index(s.index));
+    }
+
+    @Nullable
+    @Override
+    public Map<String, Object> payloadValues(@NonNull InspectableEvent event, @Nullable State state) {
+        return null;
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -605,6 +605,8 @@ public class Tracker {
                     }
                 }
             });
+            // Initialize LifecycleStateMachine for lifecycle entities
+            stateManager.addStateMachine(new LifecycleStateMachine(), "Lifecycle");
         }
 
         Logger.v(TAG, "Tracker created successfully.");


### PR DESCRIPTION
As explained in the issue, we want to track the app state as a context in all the events.
This should help the data modelling phase.
It's enabled by default and it doesn't require any particular configuration.

**Update the documentation: TrackerConfiguration new settings**