### PR TITLE
Remove v1 API (close #484)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.10.1"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.vanniktech:gradle-maven-publish-plugin:0.13.0'

--- a/snowplow-demo-app/build.gradle
+++ b/snowplow-demo-app/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':snowplow-android-tracker')
     implementation 'androidx.browser:browser:1.3.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.9'
 }

--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
@@ -14,7 +14,6 @@
 package com.snowplowanalytics.snowplowtrackerdemo;
 
 import android.Manifest;
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -22,11 +21,7 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import androidx.annotation.NonNull;
 
-import androidx.annotation.Nullable;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.widget.EditText;
 import android.widget.Button;
@@ -35,10 +30,15 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.text.method.ScrollingMovementMethod;
-import androidx.browser.customtabs.CustomTabsIntent;
-import androidx.core.util.Consumer;
 
 import android.net.Uri;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import androidx.browser.customtabs.CustomTabsIntent;
+import androidx.core.util.Consumer;
 
 import com.snowplowanalytics.snowplow.Snowplow;
 import com.snowplowanalytics.snowplow.configuration.EmitterConfiguration;
@@ -51,7 +51,6 @@ import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.controller.EmitterController;
 import com.snowplowanalytics.snowplow.controller.SessionController;
 import com.snowplowanalytics.snowplow.controller.TrackerController;
-import com.snowplowanalytics.snowplow.event.ScreenView;
 import com.snowplowanalytics.snowplow.globalcontexts.GlobalContext;
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
 import com.snowplowanalytics.snowplow.tracker.LoggerDelegate;
@@ -214,6 +213,7 @@ public class Demo extends Activity implements LoggerDelegate {
         String uri = _uriField.getText().toString();
         if (uri.isEmpty()) {
             updateLogger("URI field empty!");
+            return false;
         }
         SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit();
         editor.putString("uri", uri).apply();
@@ -451,17 +451,17 @@ public class Demo extends Activity implements LoggerDelegate {
     /// - Implements LoggerDelegate
 
     @Override
-    public void error(@NonNull String tag, @Nullable String msg) {
+    public void error(@NonNull String tag, @NonNull String msg) {
         Log.e("[" + tag + "]", msg);
     }
 
     @Override
-    public void debug(@Nullable String tag, @Nullable String msg) {
+    public void debug(@NonNull String tag, @NonNull String msg) {
         Log.d("[" + tag + "]", msg);
     }
 
     @Override
-    public void verbose(@Nullable String tag, @Nullable String msg) {
+    public void verbose(@NonNull String tag, @NonNull String msg) {
         Log.v("[" + tag + "]", msg);
     }
 }

--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/MainActivity.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/MainActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/DemoUtils.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/DemoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
@@ -59,95 +59,74 @@ public class TrackerEvents {
     }
     
     private static void trackDeepLink(TrackerController tracker) {
-        DeepLinkReceived event = new DeepLinkReceived("url link").referrer("referrer url");
+        DeepLinkReceived event = new DeepLinkReceived("http://snowplowanalytics.com/path?param=value&param2=value2")
+                .referrer("http://snowplowanalytics.com/path?param=value&param2=value2");
         tracker.track(event);
     }
 
     private static void trackPageView(TrackerController tracker) {
-        tracker.track(PageView.builder().pageUrl("pageUrl").pageTitle("pageTitle").referrer("pageReferrer").build());
+        tracker.track(new PageView("pageUrl").pageTitle("pageTitle").referrer("pageReferrer"));
     }
 
     private static void trackStructuredEvent(TrackerController tracker) {
-        tracker.track(Structured.builder().category("category").action("action").label("label").property("property").value(0.00).build());
+        tracker.track(new Structured("category", "action").label("label").property("property").value(0.00));
     }
 
     private static void trackScreenView(TrackerController tracker) {
-        tracker.track(ScreenView.builder().name("screenName1").id(UUID.randomUUID().toString()).build());
+        tracker.track(new ScreenView("screenName1", UUID.randomUUID()));
     }
 
     private static void trackTimings(TrackerController tracker) {
-        tracker.track(Timing.builder().category("category").variable("variable").timing(1).label("label").build());
+        tracker.track(new Timing("category","variable", 1).label("label"));
     }
 
     private static void trackUnstructuredEvent(TrackerController tracker) {
         Map<String, String> attributes = new HashMap<>();
         attributes.put("targetUrl", "http://a-target-url.com");
         SelfDescribingJson test = new SelfDescribingJson("iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1", attributes);
-        tracker.track(SelfDescribing.builder().eventData(test).build());
+        tracker.track(new SelfDescribing(test));
     }
 
     private static void trackEcommerceEvent(TrackerController tracker) {
-        EcommerceTransactionItem item = EcommerceTransactionItem.builder().itemId("item-1").sku("sku-1").price(35.00).quantity(1).name("Acme 1").category("Stuff").currency("AUD").build();
+        EcommerceTransactionItem item = new EcommerceTransactionItem("sku-1", 35.00, 1).name("Acme 1").category("Stuff").currency("AUD").orderId("item-1");
         List<EcommerceTransactionItem> items = new LinkedList<>();
         items.add(item);
-
-        tracker.track(EcommerceTransaction.builder().orderId("order-1").totalValue(42.50).affiliation("affiliation").taxValue(2.50).shipping(5.00).city("Sydney").state("NSW").country("Australia").currency("AUD").items(items).build());
+        tracker.track(new EcommerceTransaction("order-1", 42.50, items).affiliation("affiliation").taxValue(2.50).shipping(5.00).city("Sydney").state("NSW").country("Australia").currency("AUD"));
     }
 
     private static void trackConsentGranted(TrackerController tracker) {
         List<ConsentDocument> documents = new LinkedList<>();
-        documents.add(ConsentDocument.builder()
+        documents.add(new ConsentDocument("granted context id 1", "granted context version 1")
                 .documentDescription("granted context desc 1")
-                .documentId("granted context id 1")
-                .documentName("granted context name 1")
-                .documentVersion("granted context version 1")
-                .build());
-        documents.add(ConsentDocument.builder()
+                .documentName("granted context name 1"));
+        documents.add(new ConsentDocument("granted context id 2", "granted context version 2")
                 .documentDescription("granted context desc 2")
-                .documentId("granted context id 2")
-                .documentName("granted context name 2")
-                .documentVersion("granted context version 2")
-                .build());
-
-        ConsentGranted event = ConsentGranted.builder()
-                .expiry("2018-05-08T18:12:02+00:00")
+                .documentName("granted context name 2"));
+        ConsentGranted event = new ConsentGranted("2018-05-08T18:12:02+00:00", "granted event doc id", "granted event doc version")
                 .documentDescription("granted event doc description")
-                .documentId("granted event doc id")
                 .documentName("granted event doc name")
-                .documentVersion("granted event doc version")
-                .consentDocuments(documents)
-                .build();
+                .documents(documents);
         tracker.track(event);
     }
 
     private static void trackConsentWithdrawn(TrackerController tracker) {
         List<ConsentDocument> documents = new LinkedList<>();
-        documents.add(ConsentDocument.builder()
+        documents.add(new ConsentDocument("withdrawn context id 1", "withdrawn context version 1")
                 .documentDescription("withdrawn context desc 1")
-                .documentId("withdrawn context id 1")
-                .documentName("withdrawn context name 1")
-                .documentVersion("withdrawn context version 1")
-                .build());
-        documents.add(ConsentDocument.builder()
+                .documentName("withdrawn context name 1"));
+        documents.add(new ConsentDocument("withdrawn context id 2", "withdrawn context version 2")
                 .documentDescription("withdrawn context desc 2")
-                .documentId("withdrawn context id 2")
-                .documentName("withdrawn context name 2")
-                .documentVersion("withdrawn context version 2")
-                .build());
-        ConsentWithdrawn event = ConsentWithdrawn.builder()
-                .all(false)
+                .documentName("withdrawn context name 2"));
+        ConsentWithdrawn event = new ConsentWithdrawn(false, "withdrawn event doc  id", "withdrawn event doc version")
                 .documentDescription("withdrawn event doc description")
-                .documentId("withdrawn event doc  id")
                 .documentName("withdrawn event doc name")
-                .documentVersion("withdrawn event doc version")
-                .consentDocuments(documents)
-                .build();
+                .documents(documents);
         tracker.track(event);
     }
 
     private static void trackMessageNotification(TrackerController tracker) {
         MessageNotification event = new MessageNotification("title", "body", MessageNotificationTrigger.push)
-                .notificationTimestamp("2020-12-31T15:59:60-08:00")
+                .notificationTimestamp("2021-10-18T10:16:08.008Z")
                 .category("category")
                 .action("action")
                 .bodyLocKey("loc key")
@@ -155,7 +134,6 @@ public class TrackerEvents {
                 .sound("chime.mp3")
                 .notificationCount(9)
                 .category("category1");
-
         tracker.track(event);
     }
 }

--- a/snowplow-tracker/build.gradle
+++ b/snowplow-tracker/build.gradle
@@ -77,8 +77,8 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.2.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     compileOnly "androidx.lifecycle:lifecycle-extensions:$project.archLifecycleVersion"
     compileOnly "com.android.installreferrer:installreferrer:2.2"
     implementation fileTree(dir: 'libs', include: ['*.jar'])
@@ -87,10 +87,10 @@ dependencies {
     testImplementation "androidx.lifecycle:lifecycle-extensions:$project.archLifecycleVersion"
     testImplementation "com.android.installreferrer:installreferrer:2.2"
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-    androidTestImplementation 'com.google.android.gms:play-services-analytics:17.0.0'
-    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.0.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'com.google.android.gms:play-services-analytics:17.0.1'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.7.2'
 }
 
 android.libraryVariants.all { variant ->

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ConsentGrantedTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ConsentGrantedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -24,13 +24,9 @@ import java.util.Map;
 public class ConsentGrantedTest extends AndroidTestCase {
 
     public void testExpectedForm() {
-        ConsentGranted event = ConsentGranted.builder()
+        ConsentGranted event = new ConsentGranted("expiration", "id", "v1.0")
                 .documentName("name")
-                .documentDescription("description")
-                .documentId("id")
-                .documentVersion("v1.0")
-                .expiry("expiration")
-                .build();
+                .documentDescription("description");
 
         Map<String, Object> data = event.getDataPayload();
 
@@ -38,27 +34,17 @@ public class ConsentGrantedTest extends AndroidTestCase {
         assertEquals("expiration", data.get(Parameters.CG_EXPIRY));
 
         List<ConsentDocument> documents = new LinkedList<>();
-        documents.add(ConsentDocument.builder()
+        documents.add(new ConsentDocument("granted context id 1", "granted context version 1")
                 .documentDescription("granted context desc 1")
-                .documentId("granted context id 1")
-                .documentName("granted context name 1")
-                .documentVersion("granted context version 1")
-                .build());
-        documents.add(ConsentDocument.builder()
+                .documentName("granted context name 1"));
+        documents.add(new ConsentDocument("granted context id 2", "granted context version 2")
                 .documentDescription("granted context desc 2")
-                .documentId("granted context id 2")
-                .documentName("granted context name 2")
-                .documentVersion("granted context version 2")
-                .build());
+                .documentName("granted context name 2"));
 
-        event = ConsentGranted.builder()
+        event = new ConsentGranted("expiration", "id", "v1.0")
                 .documentName("name")
                 .documentDescription("description")
-                .documentId("id")
-                .documentVersion("v1.0")
-                .expiry("expiration")
-                .consentDocuments(documents)
-                .build();
+                .documents(documents);
 
         data = event.getDataPayload();
 
@@ -69,7 +55,7 @@ public class ConsentGrantedTest extends AndroidTestCase {
     public void testBuilderFailures() {
         boolean exception = false;
         try {
-            ConsentGranted.builder().build();
+            new ConsentGranted(null, null, null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -78,7 +64,7 @@ public class ConsentGrantedTest extends AndroidTestCase {
 
         exception = false;
         try {
-            ConsentGranted.builder().documentId("").documentVersion("test").expiry("").build();
+            new ConsentGranted("", "", "test");
         } catch (Exception e) {
             assertEquals("Expiry cannot be empty", e.getMessage());
             exception = true;
@@ -87,7 +73,7 @@ public class ConsentGrantedTest extends AndroidTestCase {
 
         exception = false;
         try {
-            ConsentGranted.builder().documentId("").documentVersion("test").expiry("test").build();
+            new ConsentGranted("test", "", "test");
         } catch (Exception e) {
             assertEquals("Document ID cannot be empty", e.getMessage());
             exception = true;
@@ -96,7 +82,7 @@ public class ConsentGrantedTest extends AndroidTestCase {
 
         exception = false;
         try {
-            ConsentGranted.builder().documentId("test").documentVersion("").expiry("test").build();
+            new ConsentGranted("test", "test", "");
         } catch (Exception e) {
             assertEquals("Document version cannot be empty", e.getMessage());
             exception = true;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ConsentWithdrawnTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ConsentWithdrawnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -24,13 +24,9 @@ import java.util.Map;
 public class ConsentWithdrawnTest extends AndroidTestCase {
 
     public void testExpectedForm() {
-        ConsentWithdrawn event = ConsentWithdrawn.builder()
+        ConsentWithdrawn event = new ConsentWithdrawn(false, "id", "v1.0")
                 .documentName("name")
-                .documentDescription("description")
-                .documentId("id")
-                .documentVersion("v1.0")
-                .all(false)
-                .build();
+                .documentDescription("description");
 
         Map data = event.getDataPayload();
 
@@ -38,27 +34,17 @@ public class ConsentWithdrawnTest extends AndroidTestCase {
         assertEquals(false, data.get(Parameters.CW_ALL));
 
         List<ConsentDocument> documents = new LinkedList<>();
-        documents.add(ConsentDocument.builder()
+        documents.add(new ConsentDocument("withdrawn context id 1", "withdrawn context version 1")
                 .documentDescription("withdrawn context desc 1")
-                .documentId("withdrawn context id 1")
-                .documentName("withdrawn context name 1")
-                .documentVersion("withdrawn context version 1")
-                .build());
-        documents.add(ConsentDocument.builder()
+                .documentName("withdrawn context name 1"));
+        documents.add(new ConsentDocument("withdrawn context id 2", "withdrawn context version 2")
                 .documentDescription("withdrawn context desc 2")
-                .documentId("withdrawn context id 2")
-                .documentName("withdrawn context name 2")
-                .documentVersion("withdrawn context version 2")
-                .build());
+                .documentName("withdrawn context name 2"));
 
-        event = ConsentWithdrawn.builder()
+        event = new ConsentWithdrawn(false, "id", "v1.0")
                 .documentName("name")
                 .documentDescription("description")
-                .documentId("id")
-                .documentVersion("v1.0")
-                .all(false)
-                .consentDocuments(documents)
-                .build();
+                .documents(documents);
 
         data = event.getDataPayload();
 
@@ -69,7 +55,7 @@ public class ConsentWithdrawnTest extends AndroidTestCase {
     public void testBuilderFailures() {
         boolean exception = false;
         try {
-            ConsentWithdrawn.builder().build();
+            new ConsentWithdrawn(false, null, null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -78,7 +64,7 @@ public class ConsentWithdrawnTest extends AndroidTestCase {
 
         exception = false;
         try {
-            ConsentWithdrawn.builder().documentId("").documentVersion("test").build();
+            new ConsentWithdrawn(false, "", "test");
         } catch (Exception e) {
             assertEquals("Document ID cannot be empty", e.getMessage());
             exception = true;
@@ -87,7 +73,7 @@ public class ConsentWithdrawnTest extends AndroidTestCase {
 
         exception = false;
         try {
-            ConsentWithdrawn.builder().documentVersion("").documentId("test").build();
+            new ConsentWithdrawn(false, "test", "");
         } catch (Exception e) {
             assertEquals("Document version cannot be empty", e.getMessage());
             exception = true;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/DeepLinkReceivedTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/DeepLinkReceivedTest.java
@@ -16,11 +16,9 @@ import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.controller.TrackerController;
 import com.snowplowanalytics.snowplow.emitter.EmitterEvent;
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
-import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.internal.emitter.Executor;
 import com.snowplowanalytics.snowplow.network.HttpMethod;
 import com.snowplowanalytics.snowplow.payload.Payload;
-import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.MockEventStore;
 
 import org.junit.Before;
@@ -50,8 +48,8 @@ public class DeepLinkReceivedTest {
 
         Map<String, Object> payload = event.getDataPayload();
         assertNotNull(payload);
-        assertEquals("url", payload.get(DeepLinkReceived.PARAM_DEEPLINKRECEIVED_URL));
-        assertEquals("referrer", payload.get(DeepLinkReceived.PARAM_DEEPLINKRECEIVED_REFERRER));
+        assertEquals("url", payload.get(DeepLinkReceived.PARAM_URL));
+        assertEquals("referrer", payload.get(DeepLinkReceived.PARAM_REFERRER));
     }
 
     @Test

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/EcommerceItemTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/EcommerceItemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -22,18 +22,14 @@ import java.util.Map;
 public class EcommerceItemTest extends AndroidTestCase {
 
     public void testExpectedForm() {
-        EcommerceTransactionItem ecommerceTransactionItem = EcommerceTransactionItem.builder()
-                .itemId("some item id")
-                .sku("some sku")
-                .price(123.456)
-                .quantity(1)
-                .build();
+        EcommerceTransactionItem ecommerceTransactionItem = new EcommerceTransactionItem("some sku", 123.456, 1)
+                .orderId("orderId");
 
         assertEquals("ti", ecommerceTransactionItem.getName());
         Map data = ecommerceTransactionItem.getDataPayload();
 
         assertNotNull(data);
-        assertEquals("some item id", data.get(Parameters.TI_ITEM_ID));
+        assertEquals("orderId", data.get(Parameters.TI_ITEM_ID));
         assertEquals("some sku", data.get(Parameters.TI_ITEM_SKU));
         assertEquals("123.456", data.get(Parameters.TI_ITEM_PRICE));
         assertEquals("1", data.get(Parameters.TI_ITEM_QUANTITY));
@@ -41,20 +37,16 @@ public class EcommerceItemTest extends AndroidTestCase {
         assertFalse(data.containsKey(Parameters.TI_ITEM_CATEGORY));
         assertFalse(data.containsKey(Parameters.TI_ITEM_CURRENCY));
 
-        ecommerceTransactionItem = EcommerceTransactionItem.builder()
-                .itemId("some item id")
-                .sku("some sku")
-                .price(123.456)
-                .quantity(1)
+        ecommerceTransactionItem = new EcommerceTransactionItem("some sku", 123.456, 1)
                 .name("some name")
                 .category("some category")
                 .currency("EUR")
-                .build();
+                .orderId("orderId");
 
         data = ecommerceTransactionItem.getDataPayload();
 
         assertNotNull(data);
-        assertEquals("some item id", data.get(Parameters.TI_ITEM_ID));
+        assertEquals("orderId", data.get(Parameters.TI_ITEM_ID));
         assertEquals("some sku", data.get(Parameters.TI_ITEM_SKU));
         assertEquals("123.456", data.get(Parameters.TI_ITEM_PRICE));
         assertEquals("1", data.get(Parameters.TI_ITEM_QUANTITY));
@@ -66,45 +58,7 @@ public class EcommerceItemTest extends AndroidTestCase {
     public void testBuilderFailures() {
         boolean exception = false;
         try {
-            EcommerceTransactionItem.builder().build();
-        } catch (Exception e) {
-            assertEquals(null, e.getMessage());
-            exception = true;
-        }
-        assertTrue(exception);
-
-        exception = false;
-        try {
-            EcommerceTransactionItem.builder().itemId("some item id").build();
-        } catch (Exception e) {
-            assertEquals(null, e.getMessage());
-            exception = true;
-        }
-        assertTrue(exception);
-
-        exception = false;
-        try {
-            EcommerceTransactionItem.builder().itemId("some item id").sku("some sku").build();
-        } catch (Exception e) {
-            assertEquals(null, e.getMessage());
-            exception = true;
-        }
-        assertTrue(exception);
-
-        exception = false;
-        try {
-            EcommerceTransactionItem.builder().itemId("some item id").sku("some sku").price(123.456)
-                    .build();
-        } catch (Exception e) {
-            assertEquals(null, e.getMessage());
-            exception = true;
-        }
-        assertTrue(exception);
-
-        exception = false;
-        try {
-            EcommerceTransactionItem.builder().itemId("item id").sku("").price(123.456)
-                    .quantity(1).build();
+            new EcommerceTransactionItem("", 123.456, 1);
         } catch (Exception e) {
             assertEquals("sku cannot be empty", e.getMessage());
             exception = true;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/EcommerceTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/EcommerceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -15,19 +15,18 @@ package com.snowplowanalytics.snowplow.event;
 
 import android.test.AndroidTestCase;
 
+import androidx.test.espresso.core.internal.deps.guava.collect.Lists;
+
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class EcommerceTest extends AndroidTestCase {
 
     public void testExpectedForm() {
-        EcommerceTransaction ecommerceTransaction = EcommerceTransaction.builder()
-                .orderId("some order id")
-                .totalValue(123.456)
-                .items(new ArrayList<EcommerceTransactionItem>())
-                .build();
+        EcommerceTransaction ecommerceTransaction = new EcommerceTransaction("some order id", 123.456, new ArrayList<EcommerceTransactionItem>());
 
         assertEquals("tr", ecommerceTransaction.getName());
         Map data = ecommerceTransaction.getDataPayload();
@@ -43,25 +42,17 @@ public class EcommerceTest extends AndroidTestCase {
         assertFalse(data.containsKey(Parameters.TR_COUNTRY));
         assertFalse(data.containsKey(Parameters.TR_CURRENCY));
 
-        EcommerceTransactionItem ecommerceTransactionItem = EcommerceTransactionItem.builder()
-                .itemId("some item id")
-                .sku("some sku")
-                .price(123.456)
-                .quantity(1)
-                .build();
+        EcommerceTransactionItem ecommerceTransactionItem = new EcommerceTransactionItem("some sku", 123.456, 1);
+        List<EcommerceTransactionItem> items = Lists.newArrayList(ecommerceTransactionItem);
 
-        ecommerceTransaction = EcommerceTransaction.builder()
-                .orderId("some order id")
-                .totalValue(123.456)
+        ecommerceTransaction = new EcommerceTransaction("some order id", 123.456, items)
                 .affiliation("some affiliate")
                 .taxValue(50.6)
                 .shipping(10.0)
                 .city("Dijon")
                 .state("Bourgogne")
                 .country("France")
-                .currency("EUR")
-                .items(ecommerceTransactionItem)
-                .build();
+                .currency("EUR");
 
         data = ecommerceTransaction.getDataPayload();
 
@@ -80,7 +71,7 @@ public class EcommerceTest extends AndroidTestCase {
     public void testBuilderFailures() {
         boolean exception = false;
         try {
-            EcommerceTransaction.builder().build();
+            new EcommerceTransaction(null, null, null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -89,7 +80,7 @@ public class EcommerceTest extends AndroidTestCase {
 
         exception = false;
         try {
-            EcommerceTransaction.builder().orderId("some order id").build();
+            new EcommerceTransaction("some order id", null, new ArrayList<EcommerceTransactionItem>());
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -98,7 +89,7 @@ public class EcommerceTest extends AndroidTestCase {
 
         exception = false;
         try {
-            EcommerceTransaction.builder().orderId("some order id").totalValue(123.456).build();
+            new EcommerceTransaction("some order id", 123.456, null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -107,8 +98,7 @@ public class EcommerceTest extends AndroidTestCase {
 
         exception = false;
         try {
-            EcommerceTransaction.builder().orderId("").totalValue(123.456)
-                    .items(new ArrayList<EcommerceTransactionItem>()).build();
+            new EcommerceTransaction("", 123.456, new ArrayList<EcommerceTransactionItem>());
         } catch (Exception e) {
             assertEquals("orderId cannot be empty", e.getMessage());
             exception = true;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/MessageNotificationTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/MessageNotificationTest.java
@@ -30,26 +30,26 @@ public class MessageNotificationTest {
 
         Map<String, Object> payload = event.getDataPayload();
         assertNotNull(payload);
-        assertEquals("title", payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_TITLE));
-        assertEquals("body", payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_BODY));
-        assertEquals("push", payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_TRIGGER));
-        assertEquals("2020-12-31T15:59:60-08:00", payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_NOTIFICATIONTIMESTAMP));
-        assertEquals("action", payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_ACTION));
-        assertEquals("loc key", payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_BODYLOCKEY));
-        List<String> locArgs = (List<String>)payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_BODYLOCARGS);
+        assertEquals("title", payload.get(MessageNotification.PARAM_TITLE));
+        assertEquals("body", payload.get(MessageNotification.PARAM_BODY));
+        assertEquals("push", payload.get(MessageNotification.PARAM_TRIGGER));
+        assertEquals("2020-12-31T15:59:60-08:00", payload.get(MessageNotification.PARAM_NOTIFICATIONTIMESTAMP));
+        assertEquals("action", payload.get(MessageNotification.PARAM_ACTION));
+        assertEquals("loc key", payload.get(MessageNotification.PARAM_BODYLOCKEY));
+        List<String> locArgs = (List<String>)payload.get(MessageNotification.PARAM_BODYLOCARGS);
         assertNotNull(locArgs);
         assertEquals(2, locArgs.size());
         assertEquals("loc arg1", locArgs.get(0));
         assertEquals("loc arg2", locArgs.get(1));
-        assertEquals("chime.mp3", payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_SOUND));
-        assertEquals(9, payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_NOTIFICATIONCOUNT));
-        assertEquals("category1", payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_CATEGORY));
-        List<MessageNotificationAttachment> attachments = (List<MessageNotificationAttachment>)payload.get(MessageNotification.PARAM_MESSAGENOTIFICATION_MESSAGENOTIFICATIONATTACHMENTS);
+        assertEquals("chime.mp3", payload.get(MessageNotification.PARAM_SOUND));
+        assertEquals(9, payload.get(MessageNotification.PARAM_NOTIFICATIONCOUNT));
+        assertEquals("category1", payload.get(MessageNotification.PARAM_CATEGORY));
+        List<MessageNotificationAttachment> attachments = (List<MessageNotificationAttachment>)payload.get(MessageNotification.PARAM_MESSAGENOTIFICATIONATTACHMENTS);
         assertNotNull(attachments);
         assertEquals(1, attachments.size());
         MessageNotificationAttachment attachment = attachments.get(0);
-        assertEquals("id", attachment.get(MessageNotificationAttachment.PARAM_MESSAGENOTIFICATIONATTACHMENT_IDENTIFIER));
-        assertEquals("type", attachment.get(MessageNotificationAttachment.PARAM_MESSAGENOTIFICATIONATTACHMENT_TYPE));
-        assertEquals("url", attachment.get(MessageNotificationAttachment.PARAM_MESSAGENOTIFICATIONATTACHMENT_URL));
+        assertEquals("id", attachment.get(MessageNotificationAttachment.PARAM_IDENTIFIER));
+        assertEquals("type", attachment.get(MessageNotificationAttachment.PARAM_TYPE));
+        assertEquals("url", attachment.get(MessageNotificationAttachment.PARAM_URL));
     }
 }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/PageViewTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/PageViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -22,9 +22,7 @@ import java.util.Map;
 public class PageViewTest extends AndroidTestCase {
 
     public void testExpectedForm() {
-        PageView pageView = PageView.builder()
-                .pageUrl("http://com.acme/foo/bar")
-                .build();
+        PageView pageView = new PageView("http://com.acme/foo/bar");
 
         assertEquals("pv", pageView.getName());
 
@@ -34,11 +32,9 @@ public class PageViewTest extends AndroidTestCase {
         assertFalse(data.containsKey(Parameters.PAGE_TITLE));
         assertFalse(data.containsKey(Parameters.PAGE_REFR));
 
-        pageView = PageView.builder()
-                .pageUrl("http://com.acme/foo/bar")
+        pageView = new PageView("http://com.acme/foo/bar")
                 .pageTitle("Page Title")
-                .referrer("http://refr.com")
-                .build();
+                .referrer("http://refr.com");
 
         data = pageView.getDataPayload();
 
@@ -51,7 +47,7 @@ public class PageViewTest extends AndroidTestCase {
     public void testBuilderFailures() {
         boolean exception = false;
         try {
-            PageView.builder().build();
+            new PageView(null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -60,7 +56,7 @@ public class PageViewTest extends AndroidTestCase {
 
         exception = false;
         try {
-            PageView.builder().pageUrl("").build();
+            new PageView("");
         } catch (Exception e) {
             assertEquals("pageUrl cannot be empty", e.getMessage());
             exception = true;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ScreenViewTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ScreenViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -23,9 +23,7 @@ import java.util.UUID;
 public class ScreenViewTest extends AndroidTestCase {
 
     public void testExpectedForm() {
-        ScreenView screenView = ScreenView.builder()
-                .name("name")
-                .build();
+        ScreenView screenView = new ScreenView("name");
 
         Map<String, Object> data = screenView.getDataPayload();
 
@@ -33,22 +31,19 @@ public class ScreenViewTest extends AndroidTestCase {
         assertEquals("name", data.get(Parameters.SV_NAME));
         assertTrue(data.containsKey(Parameters.SV_ID));
 
-        String id = UUID.randomUUID().toString();
-        screenView = ScreenView.builder()
-                .id(id)
-                .name("name")
-                .build();
+        UUID id = UUID.randomUUID();
+        screenView = new ScreenView("name", id);
 
         data = screenView.getDataPayload();
 
         assertNotNull(data);
-        assertEquals(id, data.get(Parameters.SV_ID));
+        assertEquals(id.toString(), data.get(Parameters.SV_ID));
         assertEquals("name", data.get(Parameters.SV_NAME));
     }
 
     public void testBuilderFailures() {
         try {
-            ScreenView.builder().id("id").build();
+            new ScreenView(null, UUID.randomUUID());
             fail();
         } catch (Exception e) {
             assertNull(e.getMessage());

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/SelfDescribingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/SelfDescribingTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
 package com.snowplowanalytics.snowplow.event;
 
 import android.test.AndroidTestCase;
@@ -7,10 +20,8 @@ import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 public class SelfDescribingTest extends AndroidTestCase {
 
     public void testSetSessionTrueTimestamp() {
-        Event e = SelfDescribing.builder()
-                .eventData(new SelfDescribingJson("schema"))
-                .trueTimestamp(123456789)
-                .build();
+        SelfDescribing e = new SelfDescribing(new SelfDescribingJson("schema"));
+        e.trueTimestamp(123456789L);
         assertEquals(new Long(123456789), e.getTrueTimestamp());
     }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/StructuredTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/StructuredTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -22,10 +22,7 @@ import java.util.Map;
 public class StructuredTest extends AndroidTestCase {
 
     public void testExpectedForm() {
-        Structured structured = Structured.builder()
-                .category("some category")
-                .action("some action")
-                .build();
+        Structured structured = new Structured("some category", "some action");
 
         assertEquals("se", structured.getName());
         Map data = structured.getDataPayload();
@@ -36,14 +33,11 @@ public class StructuredTest extends AndroidTestCase {
         assertFalse(data.containsKey(Parameters.SE_PROPERTY));
         assertFalse(data.containsKey(Parameters.SE_VALUE));
 
-        structured = Structured.builder()
-                .category("some category")
-                .action("some action")
+        structured = new Structured("some category", "some action")
                 .label("some label")
                 .property("some property")
-                .value(123.56700)
-                .trueTimestamp(123456789)
-                .build();
+                .value(123.56700);
+        structured.trueTimestamp(123456789L);
 
         data = structured.getDataPayload();
 
@@ -58,7 +52,7 @@ public class StructuredTest extends AndroidTestCase {
     public void testBuilderFailures() {
         boolean exception = false;
         try {
-            Structured.builder().build();
+            new Structured(null, null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -67,7 +61,7 @@ public class StructuredTest extends AndroidTestCase {
 
         exception = false;
         try {
-            Structured.builder().category("category").build();
+            new Structured("category", null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -76,7 +70,7 @@ public class StructuredTest extends AndroidTestCase {
 
         exception = false;
         try {
-            Structured.builder().category("").action("hello").build();
+            new Structured("", "hello");
         } catch (Exception e) {
             assertEquals("category cannot be empty", e.getMessage());
             exception = true;
@@ -85,7 +79,7 @@ public class StructuredTest extends AndroidTestCase {
 
         exception = false;
         try {
-            Structured.builder().category("category").action("").build();
+            new Structured("category", "");
         } catch (Exception e) {
             assertEquals("action cannot be empty", e.getMessage());
             exception = true;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/TimingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/TimingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -22,12 +22,8 @@ import java.util.Map;
 public class TimingTest extends AndroidTestCase {
 
     public void testExpectedForm() {
-        Timing timing = Timing.builder()
-                .category("some category")
-                .timing(123456789)
-                .variable("some var")
-                .label("some label")
-                .build();
+        Timing timing = new Timing("some category", "some var", 123456789)
+                .label("some label");
 
         Map<String, Object> data = timing.getDataPayload();
 
@@ -37,11 +33,7 @@ public class TimingTest extends AndroidTestCase {
         assertEquals("some var", data.get(Parameters.UT_VARIABLE));
         assertEquals("some label", data.get(Parameters.UT_LABEL));
 
-        timing = Timing.builder()
-                .category("some category")
-                .timing(123456789)
-                .variable("some var")
-                .build();
+        timing = new Timing("some category", "some var", 123456789);
 
         data = timing.getDataPayload();
 
@@ -51,12 +43,8 @@ public class TimingTest extends AndroidTestCase {
         assertEquals("some var", data.get(Parameters.UT_VARIABLE));
         assertFalse(data.containsKey(Parameters.UT_LABEL));
 
-        timing = Timing.builder()
-                .category("some category")
-                .timing(123456789)
-                .variable("some var")
-                .label("")
-                .build();
+        timing = new Timing("some category", "some var", 123456789)
+                .label("");
 
         data = timing.getDataPayload();
 
@@ -66,12 +54,8 @@ public class TimingTest extends AndroidTestCase {
         assertEquals("some var", data.get(Parameters.UT_VARIABLE));
         assertFalse(data.containsKey(Parameters.UT_LABEL));
 
-        timing = Timing.builder()
-                .category("some category")
-                .timing(123456789)
-                .variable("some var")
-                .label(null)
-                .build();
+        timing = new Timing("some category", "some var", 123456789)
+                .label(null);
 
         data = timing.getDataPayload();
 
@@ -85,7 +69,7 @@ public class TimingTest extends AndroidTestCase {
     public void testBuilderFailures() {
         boolean exception = false;
         try {
-            Timing.builder().build();
+            new Timing(null, null, null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -94,7 +78,7 @@ public class TimingTest extends AndroidTestCase {
 
         exception = false;
         try {
-            Timing.builder().category("category").build();
+            new Timing("category", null, null);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -103,7 +87,7 @@ public class TimingTest extends AndroidTestCase {
 
         exception = false;
         try {
-            Timing.builder().category("category").timing(123).build();
+            new Timing("category", null, 123);
         } catch (Exception e) {
             assertEquals(null, e.getMessage());
             exception = true;
@@ -112,7 +96,7 @@ public class TimingTest extends AndroidTestCase {
 
         exception = false;
         try {
-            Timing.builder().category("").timing(123).variable("variable").build();
+            new Timing("", "variable", 123);
         } catch (Exception e) {
             assertEquals("category cannot be empty", e.getMessage());
             exception = true;
@@ -121,7 +105,7 @@ public class TimingTest extends AndroidTestCase {
 
         exception = false;
         try {
-            Timing.builder().category("category").timing(123).variable("").build();
+            new Timing("category", "", 123);
         } catch (Exception e) {
             assertEquals("variable cannot be empty", e.getMessage());
             exception = true;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -106,11 +106,11 @@ public class StateManagerTest {
         Emitter emitter = new Emitter.EmitterBuilder("http://snowplow-fake-url.com", context)
                 .eventStore(eventStore)
                 .build();
-        Tracker tracker = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "namespace", "appId", context)
+        Tracker tracker = new Tracker(new Tracker.TrackerBuilder(emitter, "namespace", "appId", context)
                 .screenContext(true)
                 .base64(false)
                 .level(LogLevel.VERBOSE)
-        ));
+        );
 
         // Send events
         tracker.track(new Timing("category", "variable", 123));

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -106,11 +106,11 @@ public class StateManagerTest {
         Emitter emitter = new Emitter.EmitterBuilder("http://snowplow-fake-url.com", context)
                 .eventStore(eventStore)
                 .build();
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, "namespace", "appId", context)
+        Tracker tracker = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "namespace", "appId", context)
                 .screenContext(true)
                 .base64(false)
                 .level(LogLevel.VERBOSE)
-                .build();
+        ));
 
         // Send events
         tracker.track(new Timing("category", "variable", 123));

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -103,9 +103,9 @@ public class StateManagerTest {
     public void testScreenStateMachine() throws InterruptedException {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         MockEventStore eventStore = new MockEventStore();
-        Emitter emitter = new Emitter.EmitterBuilder("http://snowplow-fake-url.com", context)
+        Emitter emitter = new Emitter(context, "http://snowplow-fake-url.com", new Emitter.EmitterBuilder()
                 .eventStore(eventStore)
-                .build();
+        );
         Tracker tracker = new Tracker(new Tracker.TrackerBuilder(emitter, "namespace", "appId", context)
                 .screenContext(true)
                 .base64(false)

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -176,11 +176,7 @@ public class TrackerTest extends AndroidTestCase {
     }
 
     public void testTrackEventMultipleTimes() {
-        Timing event = Timing.builder()
-                .category("category")
-                .variable("variable")
-                .timing(100)
-                .build();
+        Timing event = new Timing("category", "variable", 100);
         UUID id1 = new TrackerEvent(event).eventId;
         UUID id2 = new TrackerEvent(event).eventId;
         assertNotEquals(id1, id2);
@@ -227,9 +223,7 @@ public class TrackerTest extends AndroidTestCase {
 
         SelfDescribingJson sdj = new SelfDescribingJson("iglu:foo/bar/jsonschema/1-0-0");
 
-        SelfDescribing sdEvent = SelfDescribing.builder()
-                .eventData(sdj)
-                .build();
+        SelfDescribing sdEvent = new SelfDescribing(sdj);
 
         tracker.track(sdEvent);
         RecordedRequest req = mockWebServer.takeRequest(60, TimeUnit.SECONDS);
@@ -415,7 +409,7 @@ public class TrackerTest extends AndroidTestCase {
         assertEquals("Unknown", screenStateMap.get(Parameters.SCREEN_NAME));
 
         // Send screenView
-        ScreenView screenView = ScreenView.builder().name("screen1").build();
+        ScreenView screenView = new ScreenView("screen1");
         String screenId = (String) screenView.getDataPayload().get("id");
         tracker.track(screenView);
 
@@ -425,7 +419,7 @@ public class TrackerTest extends AndroidTestCase {
         assertEquals(screenId, screenStateMap.get(Parameters.SCREEN_ID));
 
         // Send another screenView
-        screenView = ScreenView.builder().name("screen2").build();
+        screenView = new ScreenView("screen2");
         String screenId1 = (String) screenView.getDataPayload().get("id");
         tracker.track(screenView);
     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -99,7 +99,7 @@ public class TrackerTest extends AndroidTestCase {
                 .context(getContext())
                 .build();
 
-        return new Tracker.TrackerBuilder(emitter, "myNamespace", "myAppId", getContext())
+        return Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "myNamespace", "myAppId", getContext())
             .subject(subject)
             .platform(DevicePlatform.InternetOfThings)
             .base64(false)
@@ -115,7 +115,7 @@ public class TrackerTest extends AndroidTestCase {
             .lifecycleEvents(true)
             .installTracking(installTracking)
             .applicationContext(true)
-            .build();
+        ));
     }
 
     // Tests
@@ -201,7 +201,7 @@ public class TrackerTest extends AndroidTestCase {
             fail("Exception on Emitter creation");
         }
 
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, "testTrackWithNoContext", getContext())
+        Tracker tracker = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "testTrackWithNoContext", getContext())
                 .base64(false)
                 .level(LogLevel.VERBOSE)
                 .sessionContext(false)
@@ -211,7 +211,7 @@ public class TrackerTest extends AndroidTestCase {
                 .installTracking(false)
                 .applicationCrash(false)
                 .screenviewEvents(false)
-                .build();
+        ));
 
         EventStore eventStore = emitter.getEventStore();
         if (eventStore != null) {
@@ -266,7 +266,7 @@ public class TrackerTest extends AndroidTestCase {
             fail("Exception on Emitter creation");
         }
 
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, "testTrackWithNoContext", getContext())
+        Tracker tracker = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "testTrackWithNoContext", getContext())
                 .base64(false)
                 .level(LogLevel.VERBOSE)
                 .sessionContext(false)
@@ -276,7 +276,7 @@ public class TrackerTest extends AndroidTestCase {
                 .installTracking(false)
                 .applicationCrash(false)
                 .screenviewEvents(false)
-                .build();
+        ));
 
         Log.i("testTrackWithNoContext", "Send ScreenView event");
         tracker.track(new ScreenView("name"));
@@ -322,7 +322,7 @@ public class TrackerTest extends AndroidTestCase {
                 .option(BufferOption.Single)
                 .build();
 
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
+        Tracker tracker = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
                 .level(LogLevel.VERBOSE)
                 .sessionContext(false)
@@ -331,7 +331,7 @@ public class TrackerTest extends AndroidTestCase {
                 .installTracking(false)
                 .applicationCrash(false)
                 .screenviewEvents(false)
-                .build();
+        ));
 
         tracker.pauseEventTracking();
         tracker.track(new ScreenView("name"));
@@ -356,7 +356,7 @@ public class TrackerTest extends AndroidTestCase {
                 .option(BufferOption.Single)
                 .build();
 
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
+        Tracker tracker = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
                 .level(LogLevel.VERBOSE)
                 .sessionContext(true)
@@ -368,7 +368,7 @@ public class TrackerTest extends AndroidTestCase {
                 .foregroundTimeout(5)
                 .backgroundTimeout(5)
                 .timeUnit(TimeUnit.SECONDS)
-                .build();
+        ));
 
         assertNotNull(tracker.getSession());
         tracker.resumeSessionChecking();
@@ -386,7 +386,7 @@ public class TrackerTest extends AndroidTestCase {
                 .option(BufferOption.Single)
                 .build();
 
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
+        Tracker tracker = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
                 .level(LogLevel.VERBOSE)
                 .sessionContext(false)
@@ -399,7 +399,7 @@ public class TrackerTest extends AndroidTestCase {
                 .foregroundTimeout(5)
                 .backgroundTimeout(5)
                 .timeUnit(TimeUnit.SECONDS)
-                .build();
+        ));
 
         ScreenState screenState = tracker.getScreenState();
         assertNotNull(screenState);
@@ -439,13 +439,13 @@ public class TrackerTest extends AndroidTestCase {
 
         Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext()).build();
 
-        Tracker tracker = new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
+        Tracker tracker = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
                 .level(LogLevel.VERBOSE)
                 .installTracking(false)
                 .screenviewEvents(false)
                 .applicationCrash(true)
-                .build();
+        ));
 
         assertTrue(tracker.getApplicationCrash());
         assertEquals(
@@ -467,13 +467,13 @@ public class TrackerTest extends AndroidTestCase {
         );
 
         Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext()).build();
-        new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
+        Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
                 .level(LogLevel.VERBOSE)
                 .installTracking(false)
                 .screenviewEvents(false)
                 .applicationCrash(false)
-                .build();
+        ));
 
         ExceptionHandler handler1 = new ExceptionHandler();
         Thread.setDefaultUncaughtExceptionHandler(handler1);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -96,10 +96,7 @@ public class TrackerTest extends AndroidTestCase {
                 .emptyLimit(0)
                 .build();
 
-        Subject subject = new Subject
-                .SubjectBuilder()
-                .context(getContext())
-                .build();
+        Subject subject = new Subject(getContext(), null);
 
         tracker = new Tracker(new Tracker.TrackerBuilder(emitter, "myNamespace", "myAppId", getContext())
             .subject(subject)

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -90,11 +90,10 @@ public class TrackerTest extends AndroidTestCase {
         String namespace = "myNamespace";
         TestUtils.createSessionSharedPreferences(getContext(), namespace);
 
-        Emitter emitter = new Emitter
-                .EmitterBuilder("testUrl", getContext())
+        Emitter emitter = new Emitter(getContext(), "testUrl", new Emitter.EmitterBuilder()
                 .tick(0)
                 .emptyLimit(0)
-                .build();
+        );
 
         Subject subject = new Subject(getContext(), null);
 
@@ -140,7 +139,7 @@ public class TrackerTest extends AndroidTestCase {
         Tracker tracker = getTracker();
         assertNotNull(tracker.getEmitter());
 
-        tracker.setEmitter(new Emitter.EmitterBuilder("test", getContext()).build());
+        tracker.setEmitter(new Emitter(getContext(), "test", null));
         assertNotNull(tracker.getEmitter());
     }
 
@@ -193,9 +192,9 @@ public class TrackerTest extends AndroidTestCase {
 
         Emitter emitter = null;
         try {
-            emitter = new Emitter.EmitterBuilder(getMockServerURI(mockWebServer), getContext())
+            emitter = new Emitter(getContext(), getMockServerURI(mockWebServer), new Emitter.EmitterBuilder()
                     .option(BufferOption.Single)
-                    .build();
+            );
         } catch (Exception e) {
             e.printStackTrace();
             fail("Exception on Emitter creation");
@@ -258,9 +257,9 @@ public class TrackerTest extends AndroidTestCase {
 
         Emitter emitter = null;
         try {
-            emitter = new Emitter.EmitterBuilder(getMockServerURI(mockWebServer), getContext())
+            emitter = new Emitter(getContext(), getMockServerURI(mockWebServer), new Emitter.EmitterBuilder()
                     .option(BufferOption.Single)
-                    .build();
+            );
         } catch (Exception e) {
             e.printStackTrace();
             fail("Exception on Emitter creation");
@@ -318,9 +317,9 @@ public class TrackerTest extends AndroidTestCase {
 
         MockWebServer mockWebServer = getMockServer(1);
 
-        Emitter emitter = new Emitter.EmitterBuilder(getMockServerURI(mockWebServer), getContext())
+        Emitter emitter = new Emitter(getContext(), getMockServerURI(mockWebServer), new Emitter.EmitterBuilder()
                 .option(BufferOption.Single)
-                .build();
+        );
 
         tracker = new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
@@ -352,9 +351,9 @@ public class TrackerTest extends AndroidTestCase {
 
         MockWebServer mockWebServer = getMockServer(1);
 
-        Emitter emitter = new Emitter.EmitterBuilder(getMockServerURI(mockWebServer), getContext())
+        Emitter emitter = new Emitter(getContext(), getMockServerURI(mockWebServer), new Emitter.EmitterBuilder()
                 .option(BufferOption.Single)
-                .build();
+        );
 
         tracker = new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
@@ -382,9 +381,9 @@ public class TrackerTest extends AndroidTestCase {
         String namespace = "myNamespace";
         TestUtils.createSessionSharedPreferences(getContext(), namespace);
 
-        Emitter emitter = new Emitter.EmitterBuilder("fake-uri", getContext())
+        Emitter emitter = new Emitter(getContext(), "fake-uri", new Emitter.EmitterBuilder()
                 .option(BufferOption.Single)
-                .build();
+        );
 
         tracker = new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
@@ -437,7 +436,7 @@ public class TrackerTest extends AndroidTestCase {
                 Thread.getDefaultUncaughtExceptionHandler().getClass()
         );
 
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext()).build();
+        Emitter emitter = new Emitter(getContext(), "com.acme", null);
 
         tracker = new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
@@ -466,7 +465,7 @@ public class TrackerTest extends AndroidTestCase {
                 Thread.getDefaultUncaughtExceptionHandler().getClass()
         );
 
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext()).build();
+        Emitter emitter = new Emitter(getContext(), "com.acme", null);
         tracker = new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .base64(false)
                 .level(LogLevel.VERBOSE)

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/FileStoreTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/FileStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/payload/SelfDescribingJsonTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/payload/SelfDescribingJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/payload/TrackerPayloadTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/payload/TrackerPayloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/DevicePlatformTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/DevicePlatformTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.java
@@ -48,36 +48,37 @@ public class EmitterTest extends AndroidTestCase {
     // Builder Tests
 
     public void testHttpMethodSet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .method(GET)
-                .build();
+        );
         assertEquals(GET, emitter.getHttpMethod());
 
-        emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .method(POST)
-                .build();
+        );
         assertEquals(POST, emitter.getHttpMethod());
     }
 
     public void testBufferOptionSet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .option(Single)
-                .build();
+        );
         assertEquals(Single, emitter.getBufferOption());
 
-        emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .option(DefaultGroup)
-                .build();
+        );
         assertEquals(DefaultGroup, emitter.getBufferOption());
 
-        emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .option(HeavyGroup)
-                .build();
+        );
         assertEquals(HeavyGroup, emitter.getBufferOption());
     }
 
     public void testCallbackSet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext()).callback(new RequestCallback() {
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
+                .callback(new RequestCallback() {
             @Override
             public void onSuccess(int successCount) {
             }
@@ -85,7 +86,8 @@ public class EmitterTest extends AndroidTestCase {
             @Override
             public void onFailure(int successCount, int failureCount) {
             }
-        }).build();
+        })
+        );
 
         assertNotNull(emitter.getRequestCallback());
     }
@@ -93,86 +95,86 @@ public class EmitterTest extends AndroidTestCase {
     public void testUriSet() {
         String uri = "com.acme";
 
-        Emitter emitter = new Emitter.EmitterBuilder(uri, getContext())
+        Emitter emitter = new Emitter(getContext(), uri, new Emitter.EmitterBuilder()
                 .method(GET)
                 .security(HTTP)
                 .option(Single)
-                .build();
+        );
         assertEquals("http://" + uri + "/i", emitter.getEmitterUri());
 
-        emitter = new Emitter.EmitterBuilder(uri, getContext())
+        emitter = new Emitter(getContext(), uri, new Emitter.EmitterBuilder()
                 .method(POST)
                 .security(HTTP)
                 .option(DefaultGroup)
-                .build();
+        );
         assertEquals("http://" + uri + "/com.snowplowanalytics.snowplow/tp2",
                 emitter.getEmitterUri());
 
-        emitter = new Emitter.EmitterBuilder(uri, getContext())
+        emitter = new Emitter(getContext(), uri, new Emitter.EmitterBuilder()
                 .method(GET)
                 .security(HTTPS)
                 .option(DefaultGroup)
-                .build();
+        );
         assertEquals("https://" + uri + "/i", emitter.getEmitterUri());
 
-        emitter = new Emitter.EmitterBuilder(uri, getContext())
+        emitter = new Emitter(getContext(), uri, new Emitter.EmitterBuilder()
                 .method(POST)
                 .security(HTTPS)
                 .option(DefaultGroup)
-                .build();
+        );
         assertEquals("https://" + uri + "/com.snowplowanalytics.snowplow/tp2", emitter.getEmitterUri());
     }
 
     public void testSecuritySet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .security(HTTP)
-                .build();
+        );
         assertEquals(HTTP, emitter.getRequestSecurity());
 
-        emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .security(HTTPS)
-                .build();
+        );
         assertEquals(Protocol.HTTPS, emitter.getRequestSecurity());
     }
 
     public void testTickSet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .tick(0)
-                .build();
+        );
         assertEquals(0, emitter.getEmitterTick());
     }
 
     public void testEmptyLimitSet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .emptyLimit(0)
-                .build();
+        );
         assertEquals(0, emitter.getEmptyLimit());
     }
 
     public void testSendLimitSet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .sendLimit(200)
-                .build();
+        );
         assertEquals(200, emitter.getSendLimit());
     }
 
     public void testByteLimitGetSet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .byteLimitGet(20000)
-                .build();
+        );
         assertEquals(20000, emitter.getByteLimitGet());
     }
 
     public void testByteLimitPostSet() {
-        Emitter emitter = new Emitter.EmitterBuilder("com.acme", getContext())
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .byteLimitPost(25000)
-                .build();
+        );
         assertEquals(25000, emitter.getByteLimitPost());
     }
 
     public void testUpdatingEmitterSettings() throws InterruptedException {
         String uri = "snowplowanalytics.com";
-        Emitter emitter = new Emitter.EmitterBuilder(uri, getContext())
+        Emitter emitter = new Emitter(getContext(), uri, new Emitter.EmitterBuilder()
                 .option(Single)
                 .method(POST)
                 .security(HTTP)
@@ -183,7 +185,7 @@ public class EmitterTest extends AndroidTestCase {
                 .byteLimitPost(25000)
                 .timeUnit(TimeUnit.MILLISECONDS)
                 .eventStore(new MockEventStore())
-                .build();
+        );
 
         assertFalse(emitter.getEmitterStatus());
         assertEquals(Single, emitter.getBufferOption());
@@ -212,7 +214,7 @@ public class EmitterTest extends AndroidTestCase {
 
         emitter.shutdown();
 
-        Emitter customPathEmitter = new Emitter.EmitterBuilder(uri, getContext())
+        Emitter customPathEmitter = new Emitter(getContext(), uri, new Emitter.EmitterBuilder()
                 .option(Single)
                 .method(POST)
                 .security(HTTP)
@@ -224,7 +226,7 @@ public class EmitterTest extends AndroidTestCase {
                 .timeUnit(TimeUnit.MILLISECONDS)
                 .customPostPath("com.acme.company/tpx")
                 .eventStore(new MockEventStore())
-                .build();
+        );
         assertEquals("com.acme.company/tpx", customPathEmitter.getCustomPostPath());
         assertEquals("http://" + uri + "/com.acme.company/tpx", customPathEmitter.getEmitterUri());
 
@@ -350,11 +352,7 @@ public class EmitterTest extends AndroidTestCase {
     // Emitter Builder
 
     public Emitter getEmitter(NetworkConnection networkConnection, BufferOption option) {
-        return getEmitterBuilder(networkConnection, option).build();
-    }
-
-    public Emitter.EmitterBuilder getEmitterBuilder(NetworkConnection networkConnection, BufferOption option) {
-        return new Emitter.EmitterBuilder("com.acme", getContext())
+        return new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
                 .networkConnection(networkConnection)
                 .option(option)
                 .tick(0)
@@ -364,7 +362,8 @@ public class EmitterTest extends AndroidTestCase {
                 .byteLimitPost(25000)
                 .timeUnit(TimeUnit.SECONDS)
                 .tls(EnumSet.of(TLSVersion.TLSv1_2))
-                .eventStore(new MockEventStore());
+                .eventStore(new MockEventStore())
+        );
     }
 
     // Service methods

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/NetworkConnectionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/NetworkConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -239,7 +239,7 @@ public class SessionTest extends AndroidTestCase {
         cleanSharedPreferences(getContext(), "tracker1");
         cleanSharedPreferences(getContext(), "tracker2");
 
-        Emitter emitter = new Emitter.EmitterBuilder("", getContext()).build();
+        Emitter emitter = new Emitter(getContext(), "", null);
         Tracker tracker1 = new Tracker(new Tracker.TrackerBuilder(emitter, "tracker1", "app", getContext())
                 .sessionContext(true)
                 .foregroundTimeout(20)

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -242,16 +242,16 @@ public class SessionTest extends AndroidTestCase {
         cleanSharedPreferences(getContext(), "tracker2");
 
         Emitter emitter = new Emitter.EmitterBuilder("", getContext()).build();
-        Tracker tracker1 = new Tracker.TrackerBuilder(emitter, "tracker1", "app", getContext())
+        Tracker tracker1 = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "tracker1", "app", getContext())
                 .sessionContext(true)
                 .foregroundTimeout(20)
                 .backgroundTimeout(20)
-                .build();
-        Tracker tracker2 = new Tracker.TrackerBuilder(emitter, "tracker2", "app", getContext())
+        ));
+        Tracker tracker2 = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "tracker2", "app", getContext())
                 .sessionContext(true)
                 .foregroundTimeout(20)
                 .backgroundTimeout(20)
-                .build();
+        ));
         Session session1 = tracker1.getSession();
         Session session2 = tracker2.getSession();
 
@@ -276,11 +276,11 @@ public class SessionTest extends AndroidTestCase {
         String id2 = session2.getCurrentSessionId();
 
         // Recreate tracker2
-        Tracker tracker2b = new Tracker.TrackerBuilder(emitter, "tracker2", "app", getContext())
+        Tracker tracker2b = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "tracker2", "app", getContext())
                 .sessionContext(true)
                 .foregroundTimeout(20)
                 .backgroundTimeout(20)
-                .build();
+        ));
         tracker2b.getSession().getSessionContext("fake-id3");
         long initialValue2b = tracker2b.getSession().getSessionIndex();
         String previousId2b = tracker2b.getSession().getPreviousSessionId();

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -66,7 +66,6 @@ public class SessionTest extends AndroidTestCase {
 
         Map<String, Object> sessionContext = getSessionContext(session,"event_1");
         assertNotNull(sessionContext.get(Parameters.SESSION_USER_ID));
-        String sessionId = (String)sessionContext.get(Parameters.SESSION_ID);
         assertEquals(1, session.getSessionIndex());
         assertNotNull(sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
@@ -206,7 +205,7 @@ public class SessionTest extends AndroidTestCase {
         prefs.edit().clear().commit();
         prefs.edit().putString(Parameters.SESSION_USER_ID, UUID.randomUUID().toString()).commit();
 
-        Session session = new Session(600, 300, TimeUnit.SECONDS, getContext());
+        Session session = new Session(600, 300, TimeUnit.SECONDS, null, getContext());
 
         assertNotNull(session);
         assertEquals(600000, session.getForegroundTimeout());
@@ -296,8 +295,7 @@ public class SessionTest extends AndroidTestCase {
                 .edit()
                 .clear()
                 .commit();
-        Session session = new Session(foregroundTimeout, backgroundTimeout, TimeUnit.SECONDS, getContext());
-        return session;
+        return new Session(foregroundTimeout, backgroundTimeout, TimeUnit.SECONDS, null, getContext());
     }
 
     private Map<String, Object> getSessionContext(Session session, String eventId) {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -18,8 +18,6 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.test.AndroidTestCase;
 
-import com.snowplowanalytics.snowplow.event.Event;
-import com.snowplowanalytics.snowplow.event.Structured;
 import com.snowplowanalytics.snowplow.internal.emitter.Emitter;
 import com.snowplowanalytics.snowplow.internal.session.Session;
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
@@ -102,7 +100,7 @@ public class SessionTest extends AndroidTestCase {
     public void testBackgroundEventsOnSameSession() throws InterruptedException {
         Session session = getSession(0, 15);
 
-        session.setIsBackground(true);
+        session.updateLifecycleNotification(false);
 
         Map<String, Object> sessionContext = getSessionContext(session, "event_1");
         String sessionId = (String)sessionContext.get(Parameters.SESSION_ID);
@@ -135,7 +133,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         String oldSessionId = sessionId;
 
-        session.setIsBackground(true);
+        session.updateLifecycleNotification(false);
         Thread.sleep(1100);
 
         sessionContext = getSessionContext(session, "event_2");
@@ -145,7 +143,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals("event_2", sessionContext.get(Parameters.SESSION_FIRST_ID));
         oldSessionId = sessionId;
 
-        session.setIsBackground(false);
+        session.updateLifecycleNotification(true);
         Thread.sleep(1100);
 
         sessionContext = getSessionContext(session, "event_3");
@@ -155,7 +153,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
         oldSessionId = sessionId;
 
-        session.setIsBackground(true);
+        session.updateLifecycleNotification(false);
         Thread.sleep(1100);
 
         sessionContext = getSessionContext(session, "event_4");
@@ -242,16 +240,16 @@ public class SessionTest extends AndroidTestCase {
         cleanSharedPreferences(getContext(), "tracker2");
 
         Emitter emitter = new Emitter.EmitterBuilder("", getContext()).build();
-        Tracker tracker1 = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "tracker1", "app", getContext())
+        Tracker tracker1 = new Tracker(new Tracker.TrackerBuilder(emitter, "tracker1", "app", getContext())
                 .sessionContext(true)
                 .foregroundTimeout(20)
                 .backgroundTimeout(20)
-        ));
-        Tracker tracker2 = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "tracker2", "app", getContext())
+        );
+        Tracker tracker2 = new Tracker(new Tracker.TrackerBuilder(emitter, "tracker2", "app", getContext())
                 .sessionContext(true)
                 .foregroundTimeout(20)
                 .backgroundTimeout(20)
-        ));
+        );
         Session session1 = tracker1.getSession();
         Session session2 = tracker2.getSession();
 
@@ -276,11 +274,11 @@ public class SessionTest extends AndroidTestCase {
         String id2 = session2.getCurrentSessionId();
 
         // Recreate tracker2
-        Tracker tracker2b = Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, "tracker2", "app", getContext())
+        Tracker tracker2b = new Tracker(new Tracker.TrackerBuilder(emitter, "tracker2", "app", getContext())
                 .sessionContext(true)
                 .foregroundTimeout(20)
                 .backgroundTimeout(20)
-        ));
+        );
         tracker2b.getSession().getSessionContext("fake-id3");
         long initialValue2b = tracker2b.getSession().getSessionIndex();
         String previousId2b = tracker2b.getSession().getPreviousSessionId();

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -30,19 +30,10 @@ public class SubjectTest extends AndroidTestCase {
 
     private Subject getSubject() {
         Logger.updateLogLevel(LogLevel.DEBUG);
-        return new Subject
-                .SubjectBuilder()
-                .context(getContext())
-                .build();
+        return new Subject(getContext(), null);
     }
 
     // Tests
-
-    public void testSubjectWithNullContext() {
-        Subject subject = new Subject.SubjectBuilder().build();
-        Map<String, String> map = subject.getSubject();
-        assertFalse(map.containsKey(Parameters.RESOLUTION));
-    }
 
     public void testGetSubjectStandardPairs() throws Exception {
         Subject subject = getSubject();
@@ -56,12 +47,6 @@ public class SubjectTest extends AndroidTestCase {
     public void testSetUserId() {
         Subject subject = getSubject();
         subject.setUserId("newUserId");
-        assertEquals("newUserId", subject.getSubject().get("uid"));
-    }
-
-    public void testIdentifyUser() {
-        Subject subject = getSubject();
-        subject.identifyUser("newUserId");
         assertEquals("newUserId", subject.getSubject().get("uid"));
     }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/emitter/TLSArgumentsTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/emitter/TLSArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -59,11 +59,13 @@ import java.util.concurrent.TimeUnit;
 
 public class EventSendingTest extends AndroidTestCase {
 
+    private static Tracker tracker;
+
     @Override
     protected void setUp() throws Exception {
         super.setUp();
         try {
-            Tracker tracker = Tracker.instance();
+            if (tracker == null) return;
             Emitter emitter = tracker.getEmitter();
             tracker.close();
             boolean isClean = emitter.getEventStore().removeAllEvents();
@@ -155,16 +157,15 @@ public class EventSendingTest extends AndroidTestCase {
                 .context(getContext())
                 .build();
 
-        Tracker.close();
-        Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
+        if (tracker != null) tracker.close();
+        tracker = new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
                 .subject(subject)
                 .base64(false)
                 .level(LogLevel.DEBUG)
                 .sessionContext(true)
                 .mobileContext(true)
                 .geoLocationContext(false)
-        ));
-        Tracker tracker = Tracker.instance();
+        );
         emitter.getEventStore().removeAllEvents();
         return tracker;
     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -17,6 +17,9 @@ import android.annotation.SuppressLint;
 import android.test.AndroidTestCase;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.snowplowanalytics.snowplow.TestUtils;
 import com.snowplowanalytics.snowplow.tracker.BuildConfig;
 import com.snowplowanalytics.snowplow.internal.emitter.Emitter;
@@ -54,7 +57,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class EventSendingTest extends AndroidTestCase {
@@ -139,6 +141,7 @@ public class EventSendingTest extends AndroidTestCase {
 
     // Helpers
 
+    @NonNull
     public Tracker getTracker(String uri, HttpMethod method) {
         String namespace = "myNamespace";
         TestUtils.createSessionSharedPreferences(getContext(), namespace);
@@ -167,6 +170,7 @@ public class EventSendingTest extends AndroidTestCase {
     }
 
     @SuppressLint("DefaultLocale")
+    @Nullable
     public String getMockServerURI(MockWebServer mockServer) {
         if (mockServer != null) {
             return String.format("%s:%d", mockServer.getHostName(), mockServer.getPort());
@@ -174,6 +178,7 @@ public class EventSendingTest extends AndroidTestCase {
         return null;
     }
 
+    @NonNull
     public LinkedList<RecordedRequest> getRequests(MockWebServer mockServer, int count) throws Exception {
         LinkedList<RecordedRequest> requests = new LinkedList<>();
         for (int i = 0; i < count; i++) {
@@ -186,6 +191,7 @@ public class EventSendingTest extends AndroidTestCase {
         return requests;
     }
 
+    @NonNull
     public Map<String, String> getQueryMap(String query) throws Exception {
         String[] params = query.split("&");
         Map<String, String> map = new HashMap<>();
@@ -356,7 +362,7 @@ public class EventSendingTest extends AndroidTestCase {
     }
 
     public void checkConsentWithdrawnEvent(JSONObject json) throws Exception {
-        assertEquals(false, json.getBoolean("all"));
+        assertFalse(json.getBoolean("all"));
     }
 
     public void checkUnstructuredEvent(JSONObject json) throws Exception {
@@ -391,23 +397,22 @@ public class EventSendingTest extends AndroidTestCase {
         tracker.track(new PageView("pageUrl").pageTitle("pageTitle").referrer("pageReferrer").contexts(getCustomContext()));
     }
 
-    public void trackStructuredEvent(Tracker tracker) throws Exception {
+    public void trackStructuredEvent(Tracker tracker) {
         tracker.track(new Structured("category", "action").label("label").property("property").value(0.00));
         tracker.track(new Structured("category", "action").label("label").property("property").value(0.00).contexts(getCustomContext()));
     }
 
-    public void trackScreenView(Tracker tracker) throws Exception {
-        String id = UUID.randomUUID().toString();
+    public void trackScreenView(Tracker tracker) {
         tracker.track(new ScreenView("screenName"));
         tracker.track(new ScreenView("screenName").contexts(getCustomContext()));
     }
 
-    public void trackTimings(Tracker tracker) throws Exception {
+    public void trackTimings(Tracker tracker) {
         tracker.track(new Timing("category", "variable", 1).label("label"));
         tracker.track(new Timing("category", "variable", 1).label("label").contexts(getCustomContext()));
     }
 
-    public void trackUnstructuredEvent(Tracker tracker) throws Exception {
+    public void trackUnstructuredEvent(Tracker tracker) {
         Map<String, String> attributes = new HashMap<>();
         attributes.put("test-key-1", "test-value-1");
         SelfDescribingJson test = new SelfDescribingJson("iglu:com.snowplowanalytics.snowplow/test_sdj/jsonschema/1-0-1", attributes);
@@ -415,7 +420,7 @@ public class EventSendingTest extends AndroidTestCase {
         tracker.track(new SelfDescribing(test).contexts(getCustomContext()));
     }
 
-    public void trackEcommerceEvent(Tracker tracker) throws Exception {
+    public void trackEcommerceEvent(Tracker tracker) {
         EcommerceTransactionItem item = new EcommerceTransactionItem("sku-1", 35.00, 1).name("Acme 1").category("Stuff").currency("AUD");
         List<EcommerceTransactionItem> items = new LinkedList<>();
         items.add(item);
@@ -423,7 +428,7 @@ public class EventSendingTest extends AndroidTestCase {
         tracker.track(new EcommerceTransaction("order-1", 42.50, items).affiliation("affiliation").taxValue(2.50).shipping(5.00).city("Sydney").state("NSW").country("Australia").currency("AUD").contexts(getCustomContext()));
     }
 
-    public void trackConsentGranted(Tracker tracker) throws Exception {
+    public void trackConsentGranted(Tracker tracker) {
         List<ConsentDocument> documents = new LinkedList<>();
         documents.add(new ConsentDocument("granted context id 1", "granted context version 1")
                 .documentDescription("granted context desc 1")
@@ -436,7 +441,7 @@ public class EventSendingTest extends AndroidTestCase {
         tracker.track(new ConsentGranted("gexpiry", "gid", "dversion").documentDescription("gdesc").documentName("dname").documents(documents).contexts(getCustomContext()));
     }
 
-    public void trackConsentWithdrawn(Tracker tracker) throws Exception {
+    public void trackConsentWithdrawn(Tracker tracker) {
         List<ConsentDocument> documents = new LinkedList<>();
         documents.add(new ConsentDocument("withdrawn context id 1", "withdrawn context version 1")
                 .documentDescription("withdrawn context desc 1")

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -392,78 +392,66 @@ public class EventSendingTest extends AndroidTestCase {
     // Event Tracker Functions
 
     public void trackPageView(Tracker tracker) throws Exception {
-        tracker.track(PageView.builder().pageUrl("pageUrl").pageTitle("pageTitle").referrer("pageReferrer").build());
-        tracker.track(PageView.builder().pageUrl("pageUrl").pageTitle("pageTitle").referrer("pageReferrer").contexts(getCustomContext()).build());
+        tracker.track(new PageView("pageUrl").pageTitle("pageTitle").referrer("pageReferrer"));
+        tracker.track(new PageView("pageUrl").pageTitle("pageTitle").referrer("pageReferrer").contexts(getCustomContext()));
     }
 
     public void trackStructuredEvent(Tracker tracker) throws Exception {
-        tracker.track(Structured.builder().category("category").action("action").label("label").property("property").value(0.00).build());
-        tracker.track(Structured.builder().category("category").action("action").label("label").property("property").value(0.00).contexts(getCustomContext()).build());
+        tracker.track(new Structured("category", "action").label("label").property("property").value(0.00));
+        tracker.track(new Structured("category", "action").label("label").property("property").value(0.00).contexts(getCustomContext()));
     }
 
     public void trackScreenView(Tracker tracker) throws Exception {
         String id = UUID.randomUUID().toString();
-        tracker.track(ScreenView.builder().name("screenName").build());
-        tracker.track(ScreenView.builder().name("screenName").contexts(getCustomContext()).build());
+        tracker.track(new ScreenView("screenName"));
+        tracker.track(new ScreenView("screenName").contexts(getCustomContext()));
     }
 
     public void trackTimings(Tracker tracker) throws Exception {
-        tracker.track(Timing.builder().category("category").variable("variable").timing(1).label("label").build());
-        tracker.track(Timing.builder().category("category").variable("variable").timing(1).label("label").contexts(getCustomContext()).build());
+        tracker.track(new Timing("category", "variable", 1).label("label"));
+        tracker.track(new Timing("category", "variable", 1).label("label").contexts(getCustomContext()));
     }
 
     public void trackUnstructuredEvent(Tracker tracker) throws Exception {
         Map<String, String> attributes = new HashMap<>();
         attributes.put("test-key-1", "test-value-1");
         SelfDescribingJson test = new SelfDescribingJson("iglu:com.snowplowanalytics.snowplow/test_sdj/jsonschema/1-0-1", attributes);
-        tracker.track(SelfDescribing.builder().eventData(test).build());
-        tracker.track(SelfDescribing.builder().eventData(test).contexts(getCustomContext()).build());
+        tracker.track(new SelfDescribing(test));
+        tracker.track(new SelfDescribing(test).contexts(getCustomContext()));
     }
 
     public void trackEcommerceEvent(Tracker tracker) throws Exception {
-        EcommerceTransactionItem item = EcommerceTransactionItem.builder().itemId("item-1").sku("sku-1").price(35.00).quantity(1).name("Acme 1").category("Stuff").currency("AUD").build();
+        EcommerceTransactionItem item = new EcommerceTransactionItem("sku-1", 35.00, 1).name("Acme 1").category("Stuff").currency("AUD");
         List<EcommerceTransactionItem> items = new LinkedList<>();
         items.add(item);
-        tracker.track(EcommerceTransaction.builder().orderId("order-1").totalValue(42.50).affiliation("affiliation").taxValue(2.50).shipping(5.00).city("Sydney").state("NSW").country("Australia").currency("AUD").items(items).build());
-        tracker.track(EcommerceTransaction.builder().orderId("order-1").totalValue(42.50).affiliation("affiliation").taxValue(2.50).shipping(5.00).city("Sydney").state("NSW").country("Australia").currency("AUD").items(items).contexts(getCustomContext()).build());
+        tracker.track(new EcommerceTransaction("order-1", 42.50, items).affiliation("affiliation").taxValue(2.50).shipping(5.00).city("Sydney").state("NSW").country("Australia").currency("AUD"));
+        tracker.track(new EcommerceTransaction("order-1", 42.50, items).affiliation("affiliation").taxValue(2.50).shipping(5.00).city("Sydney").state("NSW").country("Australia").currency("AUD").contexts(getCustomContext()));
     }
 
     public void trackConsentGranted(Tracker tracker) throws Exception {
         List<ConsentDocument> documents = new LinkedList<>();
-        documents.add(ConsentDocument.builder()
+        documents.add(new ConsentDocument("granted context id 1", "granted context version 1")
                 .documentDescription("granted context desc 1")
-                .documentId("granted context id 1")
-                .documentName("granted context name 1")
-                .documentVersion("granted context version 1")
-                .build());
-        documents.add(ConsentDocument.builder()
+                .documentName("granted context name 1"));
+        documents.add(new ConsentDocument("granted context id 2", "granted context version 2")
                 .documentDescription("granted context desc 2")
-                .documentId("granted context id 2")
-                .documentName("granted context name 2")
-                .documentVersion("granted context version 2")
-                .build());
+                .documentName("granted context name 2"));
 
-        tracker.track(ConsentGranted.builder().expiry("gexpiry").documentDescription("gdesc").documentId("gid").documentName("dname").documentVersion("dversion").consentDocuments(documents).build());
-        tracker.track(ConsentGranted.builder().expiry("gexpiry").documentDescription("gdesc").documentId("gid").documentName("dname").documentVersion("dversion").consentDocuments(documents).contexts(getCustomContext()).build());
+        tracker.track(new ConsentGranted("gexpiry", "gid", "dversion").documentDescription("gdesc").documentName("dname").documents(documents));
+        tracker.track(new ConsentGranted("gexpiry", "gid", "dversion").documentDescription("gdesc").documentName("dname").documents(documents).contexts(getCustomContext()));
     }
 
     public void trackConsentWithdrawn(Tracker tracker) throws Exception {
         List<ConsentDocument> documents = new LinkedList<>();
-        documents.add(ConsentDocument.builder()
+        documents.add(new ConsentDocument("withdrawn context id 1", "withdrawn context version 1")
                 .documentDescription("withdrawn context desc 1")
-                .documentId("withdrawn context id 1")
-                .documentName("withdrawn context name 1")
-                .documentVersion("withdrawn context version 1")
-                .build());
-        documents.add(ConsentDocument.builder()
+                .documentName("withdrawn context name 1"));
+        documents.add(new ConsentDocument("withdrawn context id 2", "withdrawn context version 2")
                 .documentDescription("withdrawn context desc 2")
-                .documentId("withdrawn context id 2")
-                .documentName("withdrawn context name 2")
-                .documentVersion("withdrawn context version 2")
-                .build());
+                .documentName("withdrawn context name 2"));
 
-        tracker.track(ConsentWithdrawn.builder().all(false).documentDescription("gdesc").documentId("gid").documentName("dname").documentVersion("dversion").consentDocuments(documents).build());
-        tracker.track(ConsentWithdrawn.builder().all(false).documentDescription("gdesc").documentId("gid").documentName("dname").documentVersion("dversion").consentDocuments(documents).contexts(getCustomContext()).build());
+        tracker.track(new ConsentWithdrawn(false, "gid", "dversion").documentDescription("gdesc").documentName("dname").documents(documents));
+        tracker.track(new ConsentWithdrawn(false, "gid", "dversion").documentDescription("gdesc").documentName("dname").documents(documents).contexts(getCustomContext()));
     }
 
     public List<SelfDescribingJson> getCustomContext() {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -156,16 +156,14 @@ public class EventSendingTest extends AndroidTestCase {
                 .build();
 
         Tracker.close();
-        Tracker.init(
-                new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
-                    .subject(subject)
-                    .base64(false)
-                    .level(LogLevel.DEBUG)
-                    .sessionContext(true)
-                    .mobileContext(true)
-                    .geoLocationContext(false)
-                    .build()
-        );
+        Tracker.init(new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())
+                .subject(subject)
+                .base64(false)
+                .level(LogLevel.DEBUG)
+                .sessionContext(true)
+                .mobileContext(true)
+                .geoLocationContext(false)
+        ));
         Tracker tracker = Tracker.instance();
         emitter.getEventStore().removeAllEvents();
         return tracker;

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -152,10 +152,7 @@ public class EventSendingTest extends AndroidTestCase {
                 .emptyLimit(0)
                 .build();
 
-        Subject subject = new Subject
-                .SubjectBuilder()
-                .context(getContext())
-                .build();
+        Subject subject = new Subject(getContext(), null);
 
         if (tracker != null) tracker.close();
         tracker = new Tracker(new Tracker.TrackerBuilder(emitter, namespace, "myAppId", getContext())

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -143,14 +143,13 @@ public class EventSendingTest extends AndroidTestCase {
         String namespace = "myNamespace";
         TestUtils.createSessionSharedPreferences(getContext(), namespace);
 
-        Emitter emitter = new Emitter
-                .EmitterBuilder(uri, getContext())
+        Emitter emitter = new Emitter(getContext(), uri, new Emitter.EmitterBuilder()
                 .option(BufferOption.Single)
                 .method(method)
                 .security(Protocol.HTTP)
                 .tick(0)
                 .emptyLimit(0)
-                .build();
+        );
 
         Subject subject = new Subject(getContext(), null);
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/noise/NoiseTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/noise/NoiseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/BufferOption.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/BufferOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/EmitterEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/EmitterEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/EventStore.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/EventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -17,16 +17,11 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.internal.tracker.Tracker;
-import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
-import com.snowplowanalytics.snowplow.payload.TrackerPayload;
-import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
-import com.snowplowanalytics.snowplow.internal.utils.Util;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Base AbstractEvent class which contains common
@@ -37,73 +32,22 @@ import java.util.UUID;
  */
 public abstract class AbstractEvent implements Event {
 
-    public final List<SelfDescribingJson> customContexts;
+    /** List of custom contexts associated to the event. */
+    public final List<SelfDescribingJson> customContexts = new LinkedList<>();
+    /** Custom timestamp of the event. */
     @Nullable
     public Long trueTimestamp;
 
-    public static abstract class Builder<T extends Builder<T>> {
-
-        private final List<SelfDescribingJson> customContexts = new LinkedList<>();
-        private Long trueTimestamp;
-
-        @NonNull
-        protected abstract T self();
-
-        /**
-         * Adds a list of custom contexts.
-         *
-         * @param contexts the list of contexts
-         * @return itself
-         */
-        @NonNull
-        public T contexts(@NonNull List<SelfDescribingJson> contexts) {
-            customContexts.addAll(contexts);
-            return self();
-        }
-
-        /**
-         * A custom event timestamp.
-         *
-         * @param trueTimestamp the true event timestamp as
-         *                      unix epoch
-         * @return itself
-         */
-        @NonNull
-        public T trueTimestamp(long trueTimestamp) {
-            this.trueTimestamp = trueTimestamp;
-            return self();
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    protected AbstractEvent() {
-        this(new Builder2());
-    }
-
-    AbstractEvent(Builder<?> builder) {
-
-        // Precondition checks
-        Preconditions.checkNotNull(builder.customContexts);
-
-        this.customContexts = builder.customContexts;
-        this.trueTimestamp = builder.trueTimestamp;
-    }
-
     // Builder methods
 
+    /** Adds a list of contexts. */
     @NonNull
     public AbstractEvent contexts(@Nullable List<SelfDescribingJson> contexts) {
         if (contexts != null) customContexts.addAll(contexts);
         return this;
     }
 
+    /** Set the custom timestamp of the event. */
     @NonNull
     public AbstractEvent trueTimestamp(@Nullable Long trueTimestamp) {
         this.trueTimestamp = trueTimestamp;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractPrimitive.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractPrimitive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -15,14 +15,7 @@ package com.snowplowanalytics.snowplow.event;
 
 import androidx.annotation.NonNull;
 
-import com.snowplowanalytics.snowplow.internal.constants.Parameters;
-import com.snowplowanalytics.snowplow.payload.TrackerPayload;
-
 public abstract class AbstractPrimitive extends AbstractEvent {
-
-    AbstractPrimitive(Builder<?> builder) {
-        super(builder);
-    }
 
     protected AbstractPrimitive() { super(); }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractSelfDescribing.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractSelfDescribing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -15,13 +15,7 @@ package com.snowplowanalytics.snowplow.event;
 
 import androidx.annotation.NonNull;
 
-import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
-
 public abstract class AbstractSelfDescribing extends AbstractEvent {
-
-    AbstractSelfDescribing(Builder<?> builder) {
-        super(builder);
-    }
 
     protected AbstractSelfDescribing() { super(); }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Background.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Background.java
@@ -19,19 +19,20 @@ import androidx.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
+/** A background transition event. */
 public class Background extends AbstractSelfDescribing {
 
+    public final static String SCHEMA = "iglu:com.snowplowanalytics.snowplow/application_background/jsonschema/1-0-0";
 
-    public final static String SCHEMA_BACKGROUND = "iglu:com.snowplowanalytics.snowplow/application_background/jsonschema/1-0-0";
+    public final static String PARAM_INDEX = "backgroundIndex";
 
-    public final static String PARAM_BACKGROUNDINDEX = "backgroundIndex";
-
-    /// It's the property for `backgroundIndex` JSON key
+    /** Index indicating the current transition. */
     @Nullable
     public Integer backgroundIndex;
 
     // Builder methods
 
+    /** Index indicating the current transition. */
     @NonNull
     public Background backgroundIndex(@Nullable Integer backgroundIndex) {
         this.backgroundIndex = backgroundIndex;
@@ -43,7 +44,7 @@ public class Background extends AbstractSelfDescribing {
     @NonNull
     @Override
     public String getSchema() {
-        return SCHEMA_BACKGROUND;
+        return SCHEMA;
     }
 
     @NonNull
@@ -51,7 +52,7 @@ public class Background extends AbstractSelfDescribing {
     public Map<String, Object> getDataPayload() {
         HashMap<String,Object> payload = new HashMap<>();
         if (backgroundIndex != null) {
-            payload.put(PARAM_BACKGROUNDINDEX, backgroundIndex);
+            payload.put(PARAM_INDEX, backgroundIndex);
         }
         return payload;
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ConsentDocument.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ConsentDocument.java
@@ -1,7 +1,5 @@
-package com.snowplowanalytics.snowplow.event;
-
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -13,6 +11,8 @@ package com.snowplowanalytics.snowplow.event;
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
 
+package com.snowplowanalytics.snowplow.event;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -23,99 +23,27 @@ import com.snowplowanalytics.snowplow.payload.TrackerPayload;
 
 import java.util.Map;
 
+/** A consent document event. */
 public class ConsentDocument extends AbstractSelfDescribing {
+
+    /** Identifier of the document. */
     @NonNull
     public final String documentId;
+    /** Version of the document. */
     @NonNull
     public final String documentVersion;
+    /** Name of the document. */
     @Nullable
     public String documentName;
+    /** Description of the document. */
     @Nullable
     public String documentDescription;
 
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private String documentId;
-        private String documentVersion;
-        private String documentName;
-        private String documentDescription;
-
-        /**
-         * @param id ID of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentId(@NonNull String id) {
-            this.documentId = id;
-            return self();
-        }
-
-        /**
-         * @param version Version of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentVersion(@NonNull String version) {
-            this.documentVersion = version;
-            return self();
-        }
-
-        /**
-         * @param name Name of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentName(@NonNull String name) {
-            this.documentName = name;
-            return self();
-        }
-
-        /**
-         * @param description Description of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentDescription(@NonNull String description) {
-            this.documentDescription = description;
-            return self();
-        }
-
-        @NonNull
-        public ConsentDocument build() {
-            return new ConsentDocument(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    protected ConsentDocument(@NonNull Builder<?> builder) {
-        super(builder);
-
-        // Precondition checks
-
-        Preconditions.checkNotNull(builder.documentId);
-        Preconditions.checkArgument(!builder.documentId.isEmpty(), "Document ID cannot be empty");
-
-        Preconditions.checkNotNull(builder.documentVersion);
-        Preconditions.checkArgument(!builder.documentVersion.isEmpty(), "Document version cannot be empty");
-
-        this.documentId = builder.documentId;
-        this.documentName = builder.documentName;
-        this.documentVersion = builder.documentVersion;
-        this.documentDescription = builder.documentDescription;
-    }
-
+    /**
+     Create a consent document event.
+     @param documentId identifier of the document.
+     @param documentVersion version of the document.
+     */
     public ConsentDocument(@NonNull String documentId, @NonNull String documentVersion) {
         Preconditions.checkNotNull(documentId);
         Preconditions.checkArgument(!documentId.isEmpty(), "Document ID cannot be empty");
@@ -129,12 +57,14 @@ public class ConsentDocument extends AbstractSelfDescribing {
 
     // Builder methods
 
+    /** Name of the document. */
     @NonNull
     public ConsentDocument documentName(@Nullable String documentName) {
         this.documentName = documentName;
         return this;
     }
 
+    /** Description of the document. */
     @NonNull
     public ConsentDocument documentDescription(@Nullable String documentDescription) {
         this.documentDescription = documentDescription;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ConsentGranted.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ConsentGranted.java
@@ -110,7 +110,7 @@ public class ConsentGranted extends AbstractSelfDescribing {
     @Override
     public @NonNull Map<String, Object> getDataPayload() {
         HashMap<String,Object> payload = new HashMap<>();
-        if (expiry != null) payload.put(Parameters.CG_EXPIRY, expiry);
+        payload.put(Parameters.CG_EXPIRY, expiry);
         return payload;
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ConsentGranted.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ConsentGranted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -21,7 +21,6 @@ import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
-import com.snowplowanalytics.snowplow.payload.TrackerPayload;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,128 +28,34 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+/** A consent granted event. */
 public class ConsentGranted extends AbstractSelfDescribing {
 
+    /** Expiration of the consent. */
     @NonNull
     public final String expiry;
+    /** Identifier of the first document. */
     @NonNull
     public final String documentId;
+    /** Version of the first document. */
     @NonNull
     public final String documentVersion;
+    /** Name of the first document. */
     @Nullable
     public String documentName;
+    /** Description of the first document. */
     @Nullable
     public String documentDescription;
+    /** Other attached documents. */
     @NonNull
     public final List<ConsentDocument> consentDocuments = new LinkedList<>();
 
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private String expiry;
-        private String documentId;
-        private String documentVersion;
-        private String documentName;
-        private String documentDescription;
-        private List<ConsentDocument> consentDocuments = new LinkedList<>();
-
-        /**
-         * @param expiry Whether to withdraw consent for all consent documents
-         * @return itself
-         */
-        @NonNull
-        public T expiry(@NonNull String expiry) {
-            this.expiry = expiry;
-            return self();
-        }
-
-        /**
-         * @param id ID of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentId(@NonNull String id) {
-            this.documentId = id;
-            return self();
-        }
-
-        /**
-         * @param version Version of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentVersion(@NonNull String version) {
-            this.documentVersion = version;
-            return self();
-        }
-
-        /**
-         * @param name Name of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentName(@NonNull String name) {
-            this.documentName = name;
-            return self();
-        }
-
-        /**
-         * @param description Description of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentDescription(@NonNull String description) {
-            this.documentDescription = description;
-            return self();
-        }
-
-        /**
-         * @param documents Consent documents attached to consent granted event
-         * @return itself
-         */
-        @NonNull
-        public T consentDocuments(@NonNull List<ConsentDocument> documents) {
-            this.consentDocuments.addAll(documents);
-            return self();
-        }
-
-        @NonNull
-        public ConsentGranted build() {
-            return new ConsentGranted(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    protected ConsentGranted(@NonNull Builder<?> builder) {
-        super(builder);
-
-        // Precondition checks
-        Preconditions.checkNotNull(builder.expiry);
-        Preconditions.checkArgument(!builder.expiry.isEmpty(), "Expiry cannot be empty");
-
-        Preconditions.checkNotNull(builder.documentId);
-        Preconditions.checkArgument(!builder.documentId.isEmpty(), "Document ID cannot be empty");
-
-        Preconditions.checkNotNull(builder.documentVersion);
-        Preconditions.checkArgument(!builder.documentVersion.isEmpty(), "Document version cannot be empty");
-
-        this.expiry = builder.expiry;
-        this.documentId = builder.documentId;
-        this.documentVersion = builder.documentVersion;
-        this.consentDocuments.addAll(builder.consentDocuments);
-    }
-
+    /**
+     Creates a consent granted event with a first document.
+     @param expiry Consent expiration.
+     @param documentId Identifier of the first document.
+     @param documentVersion Version of the first document.
+     */
     public ConsentGranted(@NonNull String expiry, @NonNull String documentId, @NonNull String documentVersion) {
         Preconditions.checkNotNull(expiry);
         Preconditions.checkArgument(!expiry.isEmpty(), "Expiry cannot be empty");
@@ -165,18 +70,21 @@ public class ConsentGranted extends AbstractSelfDescribing {
 
     // Builder methods
 
+    /** Name of the first document. */
     @NonNull
     public ConsentGranted documentName(@Nullable String documentName) {
         this.documentName = documentName;
         return this;
     }
 
+    /** Description of the first document. */
     @NonNull
     public ConsentGranted documentDescription(@Nullable String documentDescription) {
         this.documentDescription = documentDescription;
         return this;
     }
 
+    /** Other attached documents. */
     @NonNull
     public ConsentGranted documents(@NonNull List<ConsentDocument> documents) {
         consentDocuments.clear();
@@ -186,11 +94,7 @@ public class ConsentGranted extends AbstractSelfDescribing {
 
     // Public methods
 
-    /**
-     * Returns a list of consent documents associated with the event.
-     *
-     * @return the consent documents
-     */
+    /** Returns a list of consent documents associated with the event. */
     public @NonNull List<ConsentDocument> getDocuments() {
         List<ConsentDocument> docs = new ArrayList<>();
         ConsentDocument doc = new ConsentDocument(documentId, documentVersion)
@@ -200,6 +104,8 @@ public class ConsentGranted extends AbstractSelfDescribing {
         docs.addAll(consentDocuments);
         return docs;
     }
+
+    // Tracker methods
 
     @Override
     public @NonNull Map<String, Object> getDataPayload() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ConsentWithdrawn.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ConsentWithdrawn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -21,7 +21,6 @@ import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
-import com.snowplowanalytics.snowplow.payload.TrackerPayload;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,125 +28,33 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+/** A consent withdrawn event. */
 public class ConsentWithdrawn extends AbstractSelfDescribing {
+
+    /** Whether to withdraw consent for all consent documents. */
     public final boolean all;
+    /** Identifier of the first document. */
     @NonNull
     public final String documentId;
+    /** Version of the first document. */
     @NonNull
     public final String documentVersion;
+    /** Name of the first document. */
     @Nullable
     public String documentName;
+    /** Description of the first document. */
     @Nullable
     public String documentDescription;
+    /** Other attached documents. */
     @NonNull
     public final List<ConsentDocument> consentDocuments = new LinkedList<>();
 
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private boolean all;
-        private String documentId;
-        private String documentVersion;
-        private String documentName;
-        private String documentDescription;
-        private List<ConsentDocument> consentDocuments = new LinkedList<>();
-
-        /**
-         * @param all Whether to withdraw consent for all consent documents
-         * @return itself
-         */
-        @NonNull
-        public T all(boolean all) {
-            this.all = all;
-            return self();
-        }
-
-        /**
-         * @param id ID of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentId(@NonNull String id) {
-            this.documentId = id;
-            return self();
-        }
-
-        /**
-         * @param version Version of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentVersion(@NonNull String version) {
-            this.documentVersion = version;
-            return self();
-        }
-
-        /**
-         * @param name Name of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentName(@NonNull String name) {
-            this.documentName = name;
-            return self();
-        }
-
-        /**
-         * @param description Description of the consent document
-         * @return itself
-         */
-        @NonNull
-        public T documentDescription(@NonNull String description) {
-            this.documentDescription = description;
-            return self();
-        }
-
-        /**
-         * @param documents Consent documents attached to consent withdrawn event
-         * @return itself
-         */
-        @NonNull
-        public T consentDocuments(@NonNull List<ConsentDocument> documents) {
-            this.consentDocuments = documents;
-            return self();
-        }
-
-        @NonNull
-        public ConsentWithdrawn build() {
-            return new ConsentWithdrawn(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    protected ConsentWithdrawn(@NonNull Builder<?> builder) {
-        super(builder);
-
-        // Precondition checks
-        Preconditions.checkNotNull(builder.documentId);
-        Preconditions.checkArgument(!builder.documentId.isEmpty(), "Document ID cannot be empty");
-
-        Preconditions.checkNotNull(builder.documentVersion);
-        Preconditions.checkArgument(!builder.documentVersion.isEmpty(), "Document version cannot be empty");
-
-        this.all = builder.all;
-        this.documentId = builder.documentId;
-        this.documentName = builder.documentName;
-        this.documentVersion = builder.documentVersion;
-        this.documentDescription = builder.documentDescription;
-        this.consentDocuments.addAll(builder.consentDocuments);
-    }
-
+    /**
+     * Creates a consent withdrawn event.
+     * @param all Whether to withdraw consent for all consent documents.
+     * @param documentId Identifier of the first document.
+     * @param documentVersion Version of the first document.
+     */
     public ConsentWithdrawn(boolean all, @NonNull String documentId, @NonNull String documentVersion) {
         Preconditions.checkNotNull(documentId);
         Preconditions.checkArgument(!documentId.isEmpty(), "Document ID cannot be empty");
@@ -160,18 +67,21 @@ public class ConsentWithdrawn extends AbstractSelfDescribing {
 
     // Builder methods
 
+    /** Name of the first document. */
     @NonNull
     public ConsentWithdrawn documentName(@Nullable String documentName) {
         this.documentName = documentName;
         return this;
     }
 
+    /** Description of the first document. */
     @NonNull
     public ConsentWithdrawn documentDescription(@Nullable String documentDescription) {
         this.documentDescription = documentDescription;
         return this;
     }
 
+    /** Other attached documents. */
     @NonNull
     public ConsentWithdrawn documents(@NonNull List<ConsentDocument> documents) {
         consentDocuments.clear();

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/DeepLinkReceived.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/DeepLinkReceived.java
@@ -25,20 +25,25 @@ import com.android.installreferrer.api.ReferrerDetails;
 import java.util.HashMap;
 import java.util.Map;
 
+/** A deep-link received in the app. */
 public class DeepLinkReceived extends AbstractSelfDescribing {
 
-    public final static String SCHEMA_DEEPLINKRECEIVED = "iglu:com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0";
+    public final static String SCHEMA = "iglu:com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0";
 
-    public final static String PARAM_DEEPLINKRECEIVED_REFERRER = "referrer";
-    public final static String PARAM_DEEPLINKRECEIVED_URL = "url";
+    public final static String PARAM_REFERRER = "referrer";
+    public final static String PARAM_URL = "url";
 
-    /// It's the property for `referrer` JSON key
+    /** Referrer URL, source of this deep-link. */
     @Nullable
     public String referrer;
-    /// It's the property for `url` JSON key
+    /** URL in the received deep-link. */
     @NonNull
     public final String url;
 
+    /**
+     * Creates a deep-link received event.
+     * @param url URL in the received deep-link.
+     */
     public DeepLinkReceived(@NonNull String url) {
         this.url = url;
     }
@@ -90,6 +95,8 @@ public class DeepLinkReceived extends AbstractSelfDescribing {
     }
 
     // Builder methods
+
+    /** Referrer URL, source of this deep-link. */
     @NonNull
     public DeepLinkReceived referrer(@Nullable String referrer) {
         this.referrer = referrer;
@@ -101,16 +108,16 @@ public class DeepLinkReceived extends AbstractSelfDescribing {
     @Override
     public @NonNull Map<String, Object> getDataPayload() {
         HashMap<String,Object> payload = new HashMap<>();
-        payload.put(PARAM_DEEPLINKRECEIVED_URL, url);
+        payload.put(PARAM_URL, url);
         if (referrer != null) {
-            payload.put(PARAM_DEEPLINKRECEIVED_REFERRER, referrer);
+            payload.put(PARAM_REFERRER, referrer);
         }
         return payload;
     }
 
     @Override
     public @NonNull String getSchema() {
-        return SCHEMA_DEEPLINKRECEIVED;
+        return SCHEMA;
     }
 }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/EcommerceTransaction.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/EcommerceTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -22,199 +22,50 @@ import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/** An ecommerce event. */
 public class EcommerceTransaction extends AbstractPrimitive {
 
+    /** Identifier of the order. */
     @NonNull
     public final String orderId;
+    /** Total amount of the order. */
     @NonNull
     public final Double totalValue;
+    /** Items purchased. */
     @NonNull
     public final List<EcommerceTransactionItem> items;
+    /** Identifies an affiliation. */
     @Nullable
     public String affiliation;
+    /** Taxes applied to the purchase. */
     @Nullable
     public Double taxValue;
+    /** Total amount for shipping. */
     @Nullable
     public Double shipping;
+    /** City for shipping. */
     @Nullable
     public String city;
+    /** State for shipping. */
     @Nullable
     public String state;
+    /** Country for shipping. */
     @Nullable
     public String country;
+    /** Currency used for totalValue and taxValue. */
     @Nullable
     public String currency;
 
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private String orderId;
-        private Double totalValue;
-        private String affiliation;
-        private Double taxValue;
-        private Double shipping;
-        private String city;
-        private String state;
-        private String country;
-        private String currency;
-        private List<EcommerceTransactionItem> items;
-
-        /**
-         * @param orderId ID of the eCommerce transaction
-         * @return itself
-         */
-        @NonNull
-        public T orderId(@NonNull String orderId) {
-            this.orderId = orderId;
-            return self();
-        }
-
-        /**
-         * @param totalValue Total transaction value
-         * @return itself
-         */
-        @NonNull
-        public T totalValue(@NonNull Double totalValue) {
-            this.totalValue = totalValue;
-            return self();
-        }
-
-        /**
-         * @param affiliation Transaction affiliation
-         * @return itself
-         */
-        @NonNull
-        public T affiliation(@NonNull String affiliation) {
-            this.affiliation = affiliation;
-            return self();
-        }
-
-        /**
-         * @param taxValue Transaction tax value
-         * @return itself
-         */
-        @NonNull
-        public T taxValue(@NonNull Double taxValue) {
-            this.taxValue = taxValue;
-            return self();
-        }
-
-        /**
-         * @param shipping Delivery cost charged
-         * @return itself
-         */
-        @NonNull
-        public T shipping(@NonNull Double shipping) {
-            this.shipping = shipping;
-            return self();
-        }
-
-        /**
-         * @param city Delivery address city
-         * @return itself
-         */
-        @NonNull
-        public T city(@NonNull String city) {
-            this.city = city;
-            return self();
-        }
-
-        /**
-         * @param state Delivery address state
-         * @return itself
-         */
-        @NonNull
-        public T state(@NonNull String state) {
-            this.state = state;
-            return self();
-        }
-
-        /**
-         * @param country Delivery address country
-         * @return itself
-         */
-        @NonNull
-        public T country(@NonNull String country) {
-            this.country = country;
-            return self();
-        }
-
-        /**
-         * @param currency The currency the price is expressed in
-         * @return itself
-         */
-        @NonNull
-        public T currency(@NonNull String currency) {
-            this.currency = currency;
-            return self();
-        }
-
-        /**
-         * @param items The items in the transaction
-         * @return itself
-         */
-        @NonNull
-        public T items(@NonNull List<EcommerceTransactionItem> items) {
-            this.items = items;
-            return self();
-        }
-
-        /**
-         * @param itemArgs The items as a varargs argument
-         * @return itself
-         */
-        @NonNull
-        public T items(@NonNull EcommerceTransactionItem... itemArgs) {
-            List<EcommerceTransactionItem> items = new ArrayList<>();
-            Collections.addAll(items, itemArgs);
-            this.items = items;
-            return self();
-        }
-
-        @NonNull
-        public EcommerceTransaction build() {
-            return new EcommerceTransaction(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    protected EcommerceTransaction(@NonNull Builder<?> builder) {
-        super(builder);
-
-        // Precondition checks
-        Preconditions.checkNotNull(builder.orderId);
-        Preconditions.checkArgument(!builder.orderId.isEmpty(), "orderId cannot be empty");
-        Preconditions.checkNotNull(builder.totalValue);
-        Preconditions.checkNotNull(builder.items);
-
-        this.orderId = builder.orderId;
-        this.totalValue = builder.totalValue;
-        this.affiliation = builder.affiliation;
-        this.taxValue = builder.taxValue;
-        this.shipping = builder.shipping;
-        this.city = builder.city;
-        this.state = builder.state;
-        this.country = builder.country;
-        this.currency = builder.currency;
-        this.items = builder.items;
-    }
-
+    /**
+     * Creates an ecommerce event.
+     * @param orderId Identifier of the order.
+     * @param totalValue Total amount of the order.
+     * @param items Items purchased.
+     */
     public EcommerceTransaction(@NonNull String orderId, @NonNull Double totalValue, @NonNull List<EcommerceTransactionItem> items) {
         Preconditions.checkNotNull(orderId);
         Preconditions.checkArgument(!orderId.isEmpty(), "orderId cannot be empty");
@@ -227,48 +78,54 @@ public class EcommerceTransaction extends AbstractPrimitive {
 
     // Builder methods
 
+    /** Identifies an affiliation. */
     @NonNull
     public EcommerceTransaction affiliation(@Nullable String affiliation) {
         this.affiliation = affiliation;
         return this;
     }
 
+    /** Taxes applied to the purchase. */
     @NonNull
     public EcommerceTransaction taxValue(@Nullable Double taxValue) {
         this.taxValue = taxValue;
         return this;
     }
 
+    /** Total amount for shipping. */
     @NonNull
     public EcommerceTransaction shipping(@Nullable Double shipping) {
         this.shipping = shipping;
         return this;
     }
 
+    /** City for shipping. */
     @NonNull
     public EcommerceTransaction city(@Nullable String city) {
         this.city = city;
         return this;
     }
 
+    /** State for shipping. */
     @NonNull
     public EcommerceTransaction state(@Nullable String state) {
         this.state = state;
         return this;
     }
 
+    /** Country for shipping. */
     @NonNull
     public EcommerceTransaction country(@Nullable String country) {
         this.country = country;
         return this;
     }
 
+    /** Currency used for totalValue and taxValue. */
     @NonNull
     public EcommerceTransaction currency(@Nullable String currency) {
         this.currency = currency;
         return this;
     }
-
 
     // Public methods
 
@@ -292,11 +149,7 @@ public class EcommerceTransaction extends AbstractPrimitive {
         return TrackerConstants.EVENT_ECOMM;
     }
 
-    /**
-     * The list of Transaction Items passed with the event.
-     *
-     * @return the items.
-     */
+    /** The list of Transaction Items passed with the event. */
     @NonNull
     public List<EcommerceTransactionItem> getItems() {
         return this.items;
@@ -304,8 +157,8 @@ public class EcommerceTransaction extends AbstractPrimitive {
 
     @Override
     public void endProcessing(@NonNull Tracker tracker) {
-        for(EcommerceTransactionItem item : items) {
-            item.setOrderId(orderId);
+        for (EcommerceTransactionItem item : items) {
+            item.orderId = orderId;
             tracker.track(item);
         }
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/EcommerceTransactionItem.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/EcommerceTransactionItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -23,140 +23,37 @@ import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 
+/** An ecommerce item event. */
 public class EcommerceTransactionItem extends AbstractPrimitive {
 
-    @Nullable
-    private String orderId;
+    /** Stock Keeping Unit of the item. */
     @NonNull
     public final String sku;
+    /** Price of the item. */
     @NonNull
     public final Double price;
+    /** Quantity of the item. */
     @NonNull
     public final Integer quantity;
+    /** Name of the item. */
     @Nullable
     public String name;
+    /** Category of the item. */
     @Nullable
     public String category;
+    /** Currency used for the price of the item. */
     @Nullable
     public String currency;
+    /** OrderID of the order that contains this item. */
+    @Nullable
+    public String orderId;
 
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private String itemId;
-        private String sku;
-        private Double price;
-        private Integer quantity;
-        private String name;
-        private String category;
-        private String currency;
-
-        /**
-         * @param itemId Item ID
-         * @return itself
-         */
-        @NonNull
-        public T itemId(@NonNull String itemId) {
-            this.itemId = itemId;
-            return self();
-        }
-
-        /**
-         * @param sku Item SKU
-         * @return itself
-         */
-        @NonNull
-        public T sku(@NonNull String sku) {
-            this.sku = sku;
-            return self();
-        }
-
-        /**
-         * @param price Item price
-         * @return itself
-         */
-        @NonNull
-        public T price(@NonNull Double price) {
-            this.price = price;
-            return self();
-        }
-
-        /**
-         * @param quantity Item quantity
-         * @return itself
-         */
-        @NonNull
-        public T quantity(@NonNull Integer quantity) {
-            this.quantity = quantity;
-            return self();
-        }
-
-        /**
-         * @param name Item name
-         * @return itself
-         */
-        @NonNull
-        public T name(@NonNull String name) {
-            this.name = name;
-            return self();
-        }
-
-        /**
-         * @param category Item category
-         * @return itself
-         */
-        @NonNull
-        public T category(@NonNull String category) {
-            this.category = category;
-            return self();
-        }
-
-        /**
-         * @param currency The currency the price is expressed in
-         * @return itself
-         */
-        @NonNull
-        public T currency(@NonNull String currency) {
-            this.currency = currency;
-            return self();
-        }
-
-        @NonNull
-        public EcommerceTransactionItem build() {
-            return new EcommerceTransactionItem(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    private EcommerceTransactionItem(@NonNull Builder<?> builder) {
-        super(builder);
-
-        // Precondition checks
-        Preconditions.checkNotNull(builder.sku);
-        Preconditions.checkNotNull(builder.price);
-        Preconditions.checkNotNull(builder.quantity);
-        Preconditions.checkArgument(!builder.sku.isEmpty(), "sku cannot be empty");
-
-        this.orderId = builder.itemId;
-        this.sku = builder.sku;
-        this.price = builder.price;
-        this.quantity = builder.quantity;
-        this.name = builder.name;
-        this.category = builder.category;
-        this.currency = builder.currency;
-    }
-
+    /**
+     Creates an ecommerce item event.
+     @param sku Stock Keeping Unit of the item.
+     @param price Price of the item.
+     @param quantity Quantity of the item.
+     */
     public EcommerceTransactionItem(@NonNull String sku, double price, int quantity) {
         Preconditions.checkNotNull(sku);
         Preconditions.checkArgument(!sku.isEmpty(), "sku cannot be empty");
@@ -167,31 +64,35 @@ public class EcommerceTransactionItem extends AbstractPrimitive {
 
     // Builder methods
 
+    /** Name of the item. */
     @NonNull
     public EcommerceTransactionItem name(@Nullable String name) {
         this.name = name;
         return this;
     }
 
+    /** Category of the item. */
     @NonNull
     public EcommerceTransactionItem category(@Nullable String category) {
         this.category = category;
         return this;
     }
 
+    /** Currency used for the price of the item. */
     @NonNull
     public EcommerceTransactionItem currency(@Nullable String currency) {
         this.currency = currency;
         return this;
     }
 
-    // Public methods
-
-    public void setOrderId(@NonNull String orderId) {
-        Preconditions.checkNotNull(orderId);
-        Preconditions.checkArgument(!orderId.isEmpty(), "orderId cannot be empty");
+    /** OrderID of the order that contains this item. */
+    @NonNull
+    public EcommerceTransactionItem orderId(@Nullable String orderId) {
         this.orderId = orderId;
+        return this;
     }
+
+    // Public methods
 
     @Override
     public @NonNull Map<String, Object> getDataPayload() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Event.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -10,6 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
+
 package com.snowplowanalytics.snowplow.event;
 
 // Java
@@ -21,7 +22,6 @@ import java.util.Map;
 
 // This library
 import com.snowplowanalytics.snowplow.internal.tracker.Tracker;
-import com.snowplowanalytics.snowplow.payload.Payload;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 
 /**
@@ -47,14 +47,12 @@ public interface Event {
 
     /**
      * Hook method called just before the event processing in order to execute special operations.
-     *
      * @apiNote Internal use only - Don't use in production, it can change without notice.
      */
     void beginProcessing(@NonNull Tracker tracker);
 
     /**
      * Hook method called just after the event processing in order to execute special operations.
-     *
      * @apiNote Internal use only - Don't use in production, it can change without notice.
      */
     void endProcessing(@NonNull Tracker tracker);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Foreground.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Foreground.java
@@ -19,19 +19,20 @@ import androidx.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
+/** A foreground transition event. */
 public class Foreground extends AbstractSelfDescribing {
 
+    public final static String SCHEMA = "iglu:com.snowplowanalytics.snowplow/application_foreground/jsonschema/1-0-0";
 
-    public final static String SCHEMA_FOREGROUND = "iglu:com.snowplowanalytics.snowplow/application_foreground/jsonschema/1-0-0";
+    public final static String PARAM_INDEX = "foregroundIndex";
 
-    public final static String PARAM_FOREGROUNDINDEX = "foregroundIndex";
-
-    /// It's the property for `backgroundIndex` JSON key
+    /** Index indicating the current transition. */
     @Nullable
     public Integer foregroundIndex;
 
     // Builder methods
 
+    /** Index indicating the current transition. */
     @NonNull
     public Foreground foregroundIndex(@Nullable Integer foregroundIndex) {
         this.foregroundIndex = foregroundIndex;
@@ -43,7 +44,7 @@ public class Foreground extends AbstractSelfDescribing {
     @NonNull
     @Override
     public String getSchema() {
-        return SCHEMA_FOREGROUND;
+        return SCHEMA;
     }
 
     @NonNull
@@ -51,7 +52,7 @@ public class Foreground extends AbstractSelfDescribing {
     public Map<String, Object> getDataPayload() {
         HashMap<String,Object> payload = new HashMap<>();
         if (foregroundIndex != null) {
-            payload.put(PARAM_FOREGROUNDINDEX, foregroundIndex);
+            payload.put(PARAM_INDEX, foregroundIndex);
         }
         return payload;
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/MessageNotification.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/MessageNotification.java
@@ -23,27 +23,27 @@ import java.util.Map;
 /** Event that represents the reception of a push notification (or a locally generated one). */
 public class MessageNotification extends AbstractSelfDescribing {
 
-    public final static String SCHEMA_MESSAGENOTIFICATION = "iglu:com.snowplowanalytics.mobile/message_notification/jsonschema/1-0-0";
+    public final static String SCHEMA = "iglu:com.snowplowanalytics.mobile/message_notification/jsonschema/1-0-0";
 
-    public final static String PARAM_MESSAGENOTIFICATION_ACTION = "action";
-    public final static String PARAM_MESSAGENOTIFICATION_MESSAGENOTIFICATIONATTACHMENTS = "attachments";
-    public final static String PARAM_MESSAGENOTIFICATION_BODY = "body";
-    public final static String PARAM_MESSAGENOTIFICATION_BODYLOCARGS = "bodyLocArgs";
-    public final static String PARAM_MESSAGENOTIFICATION_BODYLOCKEY = "bodyLocKey";
-    public final static String PARAM_MESSAGENOTIFICATION_CATEGORY = "category";
-    public final static String PARAM_MESSAGENOTIFICATION_CONTENTAVAILABLE = "contentAvailable";
-    public final static String PARAM_MESSAGENOTIFICATION_GROUP = "group";
-    public final static String PARAM_MESSAGENOTIFICATION_ICON = "icon";
-    public final static String PARAM_MESSAGENOTIFICATION_NOTIFICATIONCOUNT = "notificationCount";
-    public final static String PARAM_MESSAGENOTIFICATION_NOTIFICATIONTIMESTAMP = "notificationTimestamp";
-    public final static String PARAM_MESSAGENOTIFICATION_SOUND = "sound";
-    public final static String PARAM_MESSAGENOTIFICATION_SUBTITLE = "subtitle";
-    public final static String PARAM_MESSAGENOTIFICATION_TAG = "tag";
-    public final static String PARAM_MESSAGENOTIFICATION_THREADIDENTIFIER = "threadIdentifier";
-    public final static String PARAM_MESSAGENOTIFICATION_TITLE = "title";
-    public final static String PARAM_MESSAGENOTIFICATION_TITLELOCARGS = "titleLocArgs";
-    public final static String PARAM_MESSAGENOTIFICATION_TITLELOCKEY = "titleLocKey";
-    public final static String PARAM_MESSAGENOTIFICATION_TRIGGER = "trigger";
+    public final static String PARAM_ACTION = "action";
+    public final static String PARAM_MESSAGENOTIFICATIONATTACHMENTS = "attachments";
+    public final static String PARAM_BODY = "body";
+    public final static String PARAM_BODYLOCARGS = "bodyLocArgs";
+    public final static String PARAM_BODYLOCKEY = "bodyLocKey";
+    public final static String PARAM_CATEGORY = "category";
+    public final static String PARAM_CONTENTAVAILABLE = "contentAvailable";
+    public final static String PARAM_GROUP = "group";
+    public final static String PARAM_ICON = "icon";
+    public final static String PARAM_NOTIFICATIONCOUNT = "notificationCount";
+    public final static String PARAM_NOTIFICATIONTIMESTAMP = "notificationTimestamp";
+    public final static String PARAM_SOUND = "sound";
+    public final static String PARAM_SUBTITLE = "subtitle";
+    public final static String PARAM_TAG = "tag";
+    public final static String PARAM_THREADIDENTIFIER = "threadIdentifier";
+    public final static String PARAM_TITLE = "title";
+    public final static String PARAM_TITLELOCARGS = "titleLocArgs";
+    public final static String PARAM_TITLELOCKEY = "titleLocKey";
+    public final static String PARAM_TRIGGER = "trigger";
 
     /** The action associated with the notification. */
     @Nullable
@@ -235,63 +235,63 @@ public class MessageNotification extends AbstractSelfDescribing {
     @Override
     public @NonNull Map<String, Object> getDataPayload() {
         HashMap<String,Object> payload = new HashMap<>();
-        payload.put(PARAM_MESSAGENOTIFICATION_TITLE, title);
-        payload.put(PARAM_MESSAGENOTIFICATION_BODY, body);
-        payload.put(PARAM_MESSAGENOTIFICATION_TRIGGER, trigger.name());
+        payload.put(PARAM_TITLE, title);
+        payload.put(PARAM_BODY, body);
+        payload.put(PARAM_TRIGGER, trigger.name());
         if (action != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_ACTION, action);
+            payload.put(PARAM_ACTION, action);
         }
         if (attachments != null && attachments.size() > 0) {
-            payload.put(PARAM_MESSAGENOTIFICATION_MESSAGENOTIFICATIONATTACHMENTS, attachments);
+            payload.put(PARAM_MESSAGENOTIFICATIONATTACHMENTS, attachments);
         }
         if (bodyLocArgs != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_BODYLOCARGS, bodyLocArgs);
+            payload.put(PARAM_BODYLOCARGS, bodyLocArgs);
         }
         if (bodyLocKey != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_BODYLOCKEY, bodyLocKey);
+            payload.put(PARAM_BODYLOCKEY, bodyLocKey);
         }
         if (category != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_CATEGORY, category);
+            payload.put(PARAM_CATEGORY, category);
         }
         if (contentAvailable != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_CONTENTAVAILABLE, contentAvailable);
+            payload.put(PARAM_CONTENTAVAILABLE, contentAvailable);
         }
         if (group != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_GROUP, group);
+            payload.put(PARAM_GROUP, group);
         }
         if (icon != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_ICON, icon);
+            payload.put(PARAM_ICON, icon);
         }
         if (notificationCount != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_NOTIFICATIONCOUNT, notificationCount);
+            payload.put(PARAM_NOTIFICATIONCOUNT, notificationCount);
         }
         if (notificationTimestamp != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_NOTIFICATIONTIMESTAMP, notificationTimestamp);
+            payload.put(PARAM_NOTIFICATIONTIMESTAMP, notificationTimestamp);
         }
         if (sound != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_SOUND, sound);
+            payload.put(PARAM_SOUND, sound);
         }
         if (subtitle != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_SUBTITLE, subtitle);
+            payload.put(PARAM_SUBTITLE, subtitle);
         }
         if (tag != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_TAG, tag);
+            payload.put(PARAM_TAG, tag);
         }
         if (threadIdentifier != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_THREADIDENTIFIER, threadIdentifier);
+            payload.put(PARAM_THREADIDENTIFIER, threadIdentifier);
         }
         if (titleLocArgs != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_TITLELOCARGS, titleLocArgs);
+            payload.put(PARAM_TITLELOCARGS, titleLocArgs);
         }
         if (titleLocKey != null) {
-            payload.put(PARAM_MESSAGENOTIFICATION_TITLELOCKEY, titleLocKey);
+            payload.put(PARAM_TITLELOCKEY, titleLocKey);
         }
         return payload;
     }
 
     @Override
     public @NonNull String getSchema() {
-        return SCHEMA_MESSAGENOTIFICATION;
+        return SCHEMA;
     }
 }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/MessageNotificationAttachment.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/MessageNotificationAttachment.java
@@ -17,17 +17,17 @@ import androidx.annotation.NonNull;
 
 import java.util.HashMap;
 
-/// Attachment object that identify an attachment in the MessageNotification
+/** Attachment object that identify an attachment in the MessageNotification. */
 public class MessageNotificationAttachment extends HashMap<String, Object> {
 
-    public final static String PARAM_MESSAGENOTIFICATIONATTACHMENT_IDENTIFIER = "identifier";
-    public final static String PARAM_MESSAGENOTIFICATIONATTACHMENT_TYPE = "type";
-    public final static String PARAM_MESSAGENOTIFICATIONATTACHMENT_URL = "url";
+    public final static String PARAM_IDENTIFIER = "identifier";
+    public final static String PARAM_TYPE = "type";
+    public final static String PARAM_URL = "url";
 
-    /// Attachments added to the notification (they can be part of the data object).
+    /** Attachments added to the notification (they can be part of the data object). */
     public MessageNotificationAttachment(@NonNull String identifier, @NonNull String type, @NonNull String url) {
-        put(PARAM_MESSAGENOTIFICATIONATTACHMENT_IDENTIFIER, identifier);
-        put(PARAM_MESSAGENOTIFICATIONATTACHMENT_TYPE, type);
-        put(PARAM_MESSAGENOTIFICATIONATTACHMENT_URL, url);
+        put(PARAM_IDENTIFIER, identifier);
+        put(PARAM_TYPE, type);
+        put(PARAM_URL, url);
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/MessageNotificationTrigger.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/MessageNotificationTrigger.java
@@ -13,6 +13,7 @@
 
 package com.snowplowanalytics.snowplow.event;
 
+/** Trigger that caused the message notification. */
 public enum MessageNotificationTrigger {
     push,
     location,

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/PageView.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/PageView.java
@@ -70,7 +70,7 @@ public class PageView extends AbstractPrimitive {
     @Override
     public @NonNull Map<String, Object> getDataPayload() {
         HashMap<String, Object> payload = new HashMap<>();
-        if (pageUrl != null) payload.put(Parameters.PAGE_URL, pageUrl);
+        payload.put(Parameters.PAGE_URL, pageUrl);
         if (pageTitle != null) payload.put(Parameters.PAGE_TITLE, pageTitle);
         if (referrer != null) payload.put(Parameters.PAGE_REFR, referrer);
         return payload;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/PageView.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/PageView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -24,84 +24,25 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Constructs a PageView event object.
+ * A pageview event.
+ * @deprecated This event has been designed for web trackers, not suitable for mobile apps. Use `DeepLinkReceived` event to track deep-link received in the app.
  */
 public class PageView extends AbstractPrimitive {
 
+    /** Page URL. */
     @NonNull
     private final String pageUrl;
+    /** Page title. */
     @Nullable
     private String pageTitle;
+    /** Page referrer URL. */
     @Nullable
     private String referrer;
 
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private String pageUrl;
-        private String pageTitle;
-        private String referrer;
-
-        /**
-         * @param pageUrl URL of the viewed page
-         * @return itself
-         */
-        @NonNull
-        public T pageUrl(@NonNull String pageUrl) {
-            this.pageUrl = pageUrl;
-            return self();
-        }
-
-        /**
-         * @param pageTitle Title of the viewed page
-         * @return itself
-         */
-        @NonNull
-        public T pageTitle(@NonNull String pageTitle) {
-            this.pageTitle = pageTitle;
-            return self();
-        }
-
-        /**
-         * @param referrer Referrer of the page
-         * @return itself
-         */
-        @NonNull
-        public T referrer(@NonNull String referrer) {
-            this.referrer = referrer;
-            return self();
-        }
-
-        @NonNull
-        public PageView build() {
-            return new PageView(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    protected PageView(@NonNull Builder<?> builder) {
-        super(builder);
-
-        // Precondition checks
-        Preconditions.checkNotNull(builder.pageUrl);
-        Preconditions.checkArgument(!builder.pageUrl.isEmpty(), "pageUrl cannot be empty");
-
-        this.pageUrl = builder.pageUrl;
-        this.pageTitle = builder.pageTitle;
-        this.referrer = builder.referrer;
-    }
-
+    /**
+     * Creates a pageview event.
+     * @param pageUrl The page URL.
+     */
     public PageView(@NonNull String pageUrl) {
         Preconditions.checkNotNull(pageUrl);
         Preconditions.checkArgument(!pageUrl.isEmpty(), "pageUrl cannot be empty");
@@ -110,12 +51,14 @@ public class PageView extends AbstractPrimitive {
 
     // Builder methods
 
+    /** Page title. */
     @NonNull
     public PageView pageTitle(@Nullable String pageTitle) {
         this.pageTitle = pageTitle;
         return this;
     }
 
+    /** Page referrer URL. */
     @NonNull
     public PageView referrer(@Nullable String referrer) {
         this.referrer = referrer;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScreenView.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScreenView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -21,10 +21,8 @@ import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
-import com.snowplowanalytics.snowplow.internal.tracker.ScreenState;
 import com.snowplowanalytics.snowplow.internal.tracker.Logger;
 import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
-import com.snowplowanalytics.snowplow.payload.TrackerPayload;
 import com.snowplowanalytics.snowplow.internal.utils.Util;
 
 import java.lang.reflect.Field;
@@ -32,219 +30,88 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+/** A ScreenView event. */
 public class ScreenView extends AbstractSelfDescribing {
 
     private final static String TAG = ScreenView.class.getSimpleName();
 
+    /** Name of the screen. */
     @NonNull
     public final String name;
+    /** Identifier of the screen. */
     @NonNull
     public final String id;
+    /** Type of screen. */
     @Nullable
     public String type;
-    @Nullable
-    public String transitionType;
+    /** Name of the previous screen. */
     @Nullable
     public String previousName;
+    /** Identifier of the previous screen. */
     @Nullable
     public String previousId;
+    /** Type of the previous screen. */
     @Nullable
     public String previousType;
+    /** Type of transition between previous and current screen. */
+    @Nullable
+    public String transitionType;
+    /** Name of the Fragment subclass. */
     @Nullable
     public String fragmentClassName;
+    /** Tag of the Fragment subclass. */
     @Nullable
     public String fragmentTag;
+    /** Name of the Activity subclass. */
     @Nullable
     public String activityClassName;
+    /** Tag of the Activity subclass. */
     @Nullable
     public String activityTag;
 
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private String name;
-        private String id;
-        private String type;
-        private String transitionType;
-        private String previousName;
-        private String previousId;
-        private String previousType;
-        private String fragmentClassName;
-        private String fragmentTag;
-        private String activityClassName;
-        private String activityTag;
-
-        /**
-         * @param name The name of the screen view event
-         * @return itself
-         */
-        @NonNull
-        public T name(@NonNull String name) {
-            this.name = name;
-            return self();
-        }
-
-        /**
-         * @param id Screen view ID
-         * @return itself
-         */
-        @NonNull
-        public T id(@NonNull String id) {
-            this.id = id;
-            return self();
-        }
-
-        /**
-         * @param type The type of the screen view event
-         * @return itself
-         */
-        @NonNull
-        public T type(@NonNull String type) {
-            this.type = type;
-            return self();
-        }
-
-        /**
-         * @param name The name from the previous screen view event
-         * @return itself
-         */
-        @NonNull
-        public T previousName(@NonNull String name) {
-            this.previousName = name;
-            return self();
-        }
-
-        /**
-         * @param type The type from the previous screen view event
-         * @return itself
-         */
-        @NonNull
-        public T previousType(@NonNull String type) {
-            this.previousType = type;
-            return self();
-        }
-
-        /**
-         * @param id The id from the previous screen view event
-         * @return itself
-         */
-        @NonNull
-        public T previousId(@Nullable String id) {
-            this.previousId = id;
-            return self();
-        }
-
-        /**
-         * @param transitionType The transition type of the screen view event
-         * @return itself
-         */
-        @NonNull
-        public T transitionType(@Nullable String transitionType) {
-            this.transitionType = transitionType;
-            return self();
-        }
-
-        @NonNull
-        public T fragmentClassName(@Nullable String fragmentClassName) {
-            this.fragmentClassName = fragmentClassName;
-            return self();
-        }
-
-        @NonNull
-        public T fragmentTag(@Nullable String fragmentTag) {
-            this.fragmentTag = fragmentTag;
-            return self();
-        }
-
-        @NonNull
-        public T activityClassName(@Nullable String activityClassName) {
-            this.activityClassName = activityClassName;
-            return self();
-        }
-
-        @NonNull
-        public T activityTag(@Nullable String activityTag) {
-            this.activityTag = activityTag;
-            return self();
-        }
-
-        @NonNull
-        public ScreenView build() {
-            return new ScreenView(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
+    /** Creates a ScreenView event using the data of an Activity class. */
     @NonNull
     public static ScreenView buildWithActivity(@NonNull Activity activity) {
         String activityClassName = activity.getLocalClassName();
         String activityTag = getSnowplowScreenId(activity);
         String name = getValidName(activityClassName, activityTag);
-        return ScreenView.builder()
+        return new ScreenView(name)
                 .activityClassName(activityClassName)
                 .activityTag(activityTag)
                 .fragmentClassName(null)
                 .fragmentTag(null)
-                .name(name)
                 .type(activityClassName)
-                .transitionType(null)
-                .build();
+                .transitionType(null);
     }
 
+    /** Creates a ScreenView event using the data of an Fragment class. */
     @NonNull
     public static ScreenView buildWithFragment(@NonNull Fragment fragment) {
         String fragmentClassName = fragment.getClass().getSimpleName();
         String fragmentTag = fragment.getTag();
         String name = getValidName(fragmentClassName, fragmentTag);
-        return ScreenView.builder()
+        return new ScreenView(name)
                 .activityClassName(null)
                 .activityTag(null)
                 .fragmentClassName(fragment.getClass().getSimpleName())
                 .fragmentTag(fragment.getTag())
-                .name(name)
                 .type(fragmentClassName)
-                .transitionType(null)
-                .build();
+                .transitionType(null);
     }
 
-    protected ScreenView(@NonNull Builder<?> builder) {
-        super(builder);
-        Preconditions.checkNotNull(builder.name);
-        Preconditions.checkArgument(!builder.name.isEmpty(), "Name cannot be empty.");
-        if (builder.id != null) {
-            Preconditions.checkArgument(Util.isUUIDString(builder.id));
-            id = builder.id;
-        } else {
-            id = Util.getUUIDString();
-        }
-
-        this.name = builder.name;
-        this.type = builder.type;
-        this.previousId = builder.previousId;
-        this.previousName = builder.previousName;
-        this.previousType = builder.previousType;
-        this.transitionType = builder.transitionType;
-        this.fragmentClassName = builder.fragmentClassName;
-        this.fragmentTag = builder.fragmentTag;
-        this.activityClassName = builder.activityClassName;
-        this.activityTag = builder.activityTag;
-    }
-
+    /**
+     * Creates a ScreenView event.
+     * @param name Name of the screen.
+     */
     public ScreenView(@NonNull String name) {
         this(name, null);
     }
 
+    /**
+     * Creates a ScreenView event.
+     * @param name Name of the screen.
+     * @param screenId Identifier of the screen.
+     */
     public ScreenView(@NonNull String name, @Nullable UUID screenId) {
         Preconditions.checkNotNull(name);
         Preconditions.checkArgument(!name.isEmpty(), "Name cannot be empty.");
@@ -258,77 +125,70 @@ public class ScreenView extends AbstractSelfDescribing {
 
     // Builder methods
 
+    /** Type of screen. */
     @NonNull
     public ScreenView type(@Nullable String type) {
         this.type = type;
         return this;
     }
 
-    @NonNull
-    public ScreenView transitionType(@Nullable String transitionType) {
-        this.transitionType = transitionType;
-        return this;
-    }
-
+    /** Name of the previous screen. */
     @NonNull
     public ScreenView previousName(@Nullable String previousName) {
         this.previousName = previousName;
         return this;
     }
 
+    /** Identifier of the previous screen. */
     @NonNull
     public ScreenView previousId(@Nullable String previousId) {
         this.previousId = previousId;
         return this;
     }
 
+    /** Type of the previous screen. */
     @NonNull
     public ScreenView previousType(@Nullable String previousType) {
         this.previousType = previousType;
         return this;
     }
 
+    /** Type of transition between previous and current screen. */
+    @NonNull
+    public ScreenView transitionType(@Nullable String transitionType) {
+        this.transitionType = transitionType;
+        return this;
+    }
+
+    /** Name of the Fragment subclass. */
     @NonNull
     public ScreenView fragmentClassName(@Nullable String fragmentClassName) {
         this.fragmentClassName = fragmentClassName;
         return this;
     }
 
+    /** Tag of the Fragment subclass. */
     @NonNull
     public ScreenView fragmentTag(@Nullable String fragmentTag) {
         this.fragmentTag = fragmentTag;
         return this;
     }
 
+    /** Name of the Activity subclass. */
     @NonNull
     public ScreenView activityClassName(@Nullable String activityClassName) {
         this.activityClassName = activityClassName;
         return this;
     }
 
+    /** Tag of the Activity subclass. */
     @NonNull
     public ScreenView activityTag(@Nullable String activityTag) {
         this.activityTag = activityTag;
         return this;
     }
 
-    // Public methods
-
-    /**
-     * Update the passed screen state with the data related to
-     * the current ScreenView event.
-     * @apiNote ScreenState updates back the previous screen fields
-     * in the ScreenView event (if `previousId` not already set).
-     * @param screenState The screen state to update.
-     */
-    public synchronized void updateScreenState(@NonNull ScreenState screenState) {
-        screenState.updateScreenState(id, name, type, transitionType, fragmentClassName, fragmentTag, activityClassName, activityTag);
-        if (previousId == null) {
-            previousId = screenState.getPreviousId();
-            previousName = screenState.getPreviousName();
-            previousType = screenState.getPreviousType();
-        }
-    }
+    // Tracker methods
 
     @Override
     public @NonNull Map<String, Object> getDataPayload() {
@@ -347,6 +207,8 @@ public class ScreenView extends AbstractSelfDescribing {
     public @NonNull String getSchema() {
         return TrackerConstants.SCHEMA_SCREEN_VIEW;
     }
+
+    // Private methods
 
     @Nullable
     private static String getSnowplowScreenId(Activity activity) {
@@ -377,5 +239,4 @@ public class ScreenView extends AbstractSelfDescribing {
         }
         return "Unknown";
     }
-
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/SelfDescribing.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/SelfDescribing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -19,71 +19,33 @@ import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Constructs an SelfDescribing event object.
+ * A SelfDescribing event.
  */
 public class SelfDescribing extends AbstractSelfDescribing {
 
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private SelfDescribingJson eventData;
-
-        /**
-         * @param eventData The properties of the event. Has two field:
-         *                  A "data" field containing the event properties and
-         *                  A "schema" field identifying the schema against which the data is validated
-         * @return itself
-         */
-        @NonNull
-        public T eventData(@NonNull SelfDescribingJson eventData) {
-            this.eventData = eventData;
-            return self();
-        }
-
-        @NonNull
-        public SelfDescribing build() {
-            return new SelfDescribing(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    protected SelfDescribing(@NonNull Builder<?> builder) {
-        super(builder);
-        Preconditions.checkNotNull(builder.eventData);
-        Map<String, Object> eventDataMap = builder.eventData.getMap();
-        Preconditions.checkNotNull(eventDataMap);
-        Map<String, Object> payload = (Map<String, Object>)eventDataMap.get(Parameters.DATA);
-        Preconditions.checkNotNull(payload);
-        this.payload = payload;
-        String schema = (String)eventDataMap.get(Parameters.SCHEMA);
-        Preconditions.checkNotNull(schema);
-        this.schema = schema;
-        this.eventData = builder.eventData;
-    }
-
+    /**
+     * The properties of the event. Has two field:
+     * * a "data" field containing the event properties,
+     * * a "schema" field identifying the schema against which the data is validated.
+     */
     @NonNull
     public final SelfDescribingJson eventData;
 
+    /** A "data" field containing the event properties. */
     @NonNull
     private final Map<String, Object> payload;
+    /** A "schema" field identifying the schema against which the data is validated. */
     @NonNull
     private final String schema;
 
+    /**
+     * Creates a SelfDescribing event.
+     * @param eventData The properties of the event. Has two field: a "data" field containing the event
+     *                  properties and a "schema" field identifying the schema against which the data is validated.
+     */
     public SelfDescribing(@NonNull SelfDescribingJson eventData) {
         Preconditions.checkNotNull(eventData);
         Map<String, Object> eventDataMap = eventData.getMap();
@@ -97,11 +59,18 @@ public class SelfDescribing extends AbstractSelfDescribing {
         this.eventData = eventData;
     }
 
+    /**
+     * Creates a SelfDescribing event.
+     * @param schema The schema against which the payload is validated.
+     * @param payload The event properties.
+     */
     public SelfDescribing(@NonNull String schema, @NonNull Map<String, Object> payload) {
         this.schema = schema;
         this.payload = payload;
         this.eventData = new SelfDescribingJson(schema, payload);
     }
+
+    // Tracker methods
 
     @Override
     public @NonNull Map<String, Object> getDataPayload() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Structured.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Structured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -23,9 +23,7 @@ import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Constructs a Structured event object.
- */
+/** A Structured event. */
 public class Structured extends AbstractPrimitive {
 
     @NonNull
@@ -38,99 +36,6 @@ public class Structured extends AbstractPrimitive {
     public String property;
     @Nullable
     public Double value;
-
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private String category;
-        private String action;
-        private String label;
-        private String property;
-        private Double value;
-
-        /**
-         * @param category Category of the event
-         * @return itself
-         */
-        @NonNull
-        public T category(@NonNull String category) {
-            this.category = category;
-            return self();
-        }
-
-        /**
-         * @param action The event itself
-         * @return itself
-         */
-        @NonNull
-        public T action(@NonNull String action) {
-            this.action = action;
-            return self();
-        }
-
-        /**
-         * @param label Refer to the object the action is performed on
-         * @return itself
-         */
-        @NonNull
-        public T label(@NonNull String label) {
-            this.label = label;
-            return self();
-        }
-
-        /**
-         * @param property Property associated with either the action or the object
-         * @return itself
-         */
-        @NonNull
-        public T property(@NonNull String property) {
-            this.property = property;
-            return self();
-        }
-
-        /**
-         * @param value A value associated with the user action
-         * @return itself
-         */
-        @NonNull
-        public T value(@NonNull Double value) {
-            this.value = value;
-            return self();
-        }
-
-        @NonNull
-        public Structured build() {
-            return new Structured(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    protected Structured(@NonNull Builder<?> builder) {
-        super(builder);
-
-        // Precondition checks
-        Preconditions.checkNotNull(builder.category);
-        Preconditions.checkNotNull(builder.action);
-        Preconditions.checkArgument(!builder.category.isEmpty(), "category cannot be empty");
-        Preconditions.checkArgument(!builder.action.isEmpty(), "action cannot be empty");
-
-        this.category = builder.category;
-        this.action = builder.action;
-        this.label = builder.label;
-        this.property = builder.property;
-        this.value = builder.value;
-    }
 
     public Structured(@NonNull String category, @NonNull String action) {
         Preconditions.checkNotNull(category);
@@ -161,7 +66,7 @@ public class Structured extends AbstractPrimitive {
         return this;
     }
 
-    // Public methods
+    // Tracker methods
 
     @NonNull
     @Override

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Timing.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Timing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -22,6 +22,7 @@ import com.snowplowanalytics.snowplow.internal.utils.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 
+/** A timing event. */
 public class Timing extends AbstractSelfDescribing {
 
     @NonNull
@@ -32,88 +33,6 @@ public class Timing extends AbstractSelfDescribing {
     public final Integer timing;
     @Nullable
     public String label;
-
-    public static abstract class Builder<T extends Builder<T>> extends AbstractEvent.Builder<T> {
-
-        private String category;
-        private String variable;
-        private Integer timing;
-        private String label;
-
-        /**
-         * @param category The category of the timed event
-         * @return itself
-         */
-        @NonNull
-        public T category(@NonNull String category) {
-            this.category = category;
-            return self();
-        }
-
-        /**
-         * @param variable Identify the timing being recorded
-         * @return itself
-         */
-        @NonNull
-        public T variable(@NonNull String variable) {
-            this.variable = variable;
-            return self();
-        }
-
-        /**
-         * @param timing The number of milliseconds in elapsed time to report
-         * @return itself
-         */
-        @NonNull
-        public T timing(@NonNull Integer timing) {
-            this.timing = timing;
-            return self();
-        }
-
-        /**
-         * @param label Optional description of this timing
-         * @return itself
-         */
-        @NonNull
-        public T label(@NonNull String label) {
-            this.label = label;
-            return self();
-        }
-
-        @NonNull
-        public Timing build() {
-            return new Timing(this);
-        }
-    }
-
-    private static class Builder2 extends Builder<Builder2> {
-        @NonNull
-        @Override
-        protected Builder2 self() {
-            return this;
-        }
-    }
-
-    @NonNull
-    public static Builder<?> builder() {
-        return new Builder2();
-    }
-
-    protected Timing(@NonNull Builder<?> builder) {
-        super(builder);
-
-        // Precondition checks
-        Preconditions.checkNotNull(builder.category);
-        Preconditions.checkNotNull(builder.timing);
-        Preconditions.checkNotNull(builder.variable);
-        Preconditions.checkArgument(!builder.category.isEmpty(), "category cannot be empty");
-        Preconditions.checkArgument(!builder.variable.isEmpty(), "variable cannot be empty");
-
-        this.category = builder.category;
-        this.variable = builder.variable;
-        this.label = builder.label;
-        this.timing = builder.timing;
-    }
 
     public Timing(@NonNull String category, @NonNull String variable, @NonNull Integer timing) {
         Preconditions.checkNotNull(category);
@@ -134,7 +53,7 @@ public class Timing extends AbstractSelfDescribing {
         return this;
     }
 
-    // Public methods
+    // Tracker methods
 
     @Override
     public @NonNull Map<String, Object> getDataPayload() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/TrackerError.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/TrackerError.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
 package com.snowplowanalytics.snowplow.event;
 
 import androidx.annotation.NonNull;
@@ -10,6 +23,7 @@ import com.snowplowanalytics.snowplow.internal.utils.Util;
 import java.util.HashMap;
 import java.util.Map;
 
+/** An error event representing an exception, error or warning message in the app. */
 public class TrackerError extends AbstractSelfDescribing {
     private static final int MAX_MESSAGE_LENGTH = 2048;
     private static final int MAX_STACK_LENGTH = 8192;
@@ -29,6 +43,8 @@ public class TrackerError extends AbstractSelfDescribing {
         this.message = message;
         this.throwable = throwable;
     }
+
+    // Tracker methods
 
     @Override
     public @NonNull Map<String, Object> getDataPayload() {
@@ -54,6 +70,8 @@ public class TrackerError extends AbstractSelfDescribing {
     public @NonNull String getSchema() {
         return TrackerConstants.SCHEMA_DIAGNOSTIC_ERROR;
     }
+
+    // Private methods
 
     private String truncate(String s, int maxLength) {
         if (s == null) return null;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/globalcontexts/ContextGenerator.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/globalcontexts/ContextGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContext.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContext.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContext.java
@@ -100,12 +100,6 @@ public class GlobalContext {
 
     @NonNull
     public  List<SelfDescribingJson> generateContexts(@NonNull InspectableEvent event) {
-        if (event == null) {
-            return new ArrayList<>();
-        }
-        if (generator == null) {
-            return new ArrayList<>();
-        }
         if (filter != null && !filter.apply(event)) {
             return new ArrayList<>();
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/globalcontexts/SchemaRuleSet.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/globalcontexts/SchemaRuleSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/Parameters.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/TrackerConstants.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/TrackerConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
@@ -14,12 +14,10 @@
 package com.snowplowanalytics.snowplow.internal.emitter;
 
 import android.content.Context;
-import android.net.Uri;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration;
 import com.snowplowanalytics.snowplow.emitter.EmitterEvent;
 import com.snowplowanalytics.snowplow.network.NetworkConnection;
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
@@ -36,7 +34,6 @@ import com.snowplowanalytics.snowplow.internal.tracker.Logger;
 import com.snowplowanalytics.snowplow.network.RequestResult;
 import com.snowplowanalytics.snowplow.internal.utils.Util;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.EnumSet;
@@ -52,14 +49,11 @@ import static com.snowplowanalytics.snowplow.network.HttpMethod.POST;
 /**
  * Build an emitter object which controls the
  * sending of events to the Snowplow Collector.
- * @deprecated It will be removed in the next major version, please use Snowplow.setup methods.
  */
-@Deprecated
 public class Emitter {
+    private final String TAG = Emitter.class.getSimpleName();
 
     private static final int POST_WRAPPER_BYTES = 88; // "schema":"iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-3","data":[]
-
-    private final String TAG = Emitter.class.getSimpleName();
 
     private Context context;
     private RequestCallback requestCallback;
@@ -88,12 +82,8 @@ public class Emitter {
 
     /**
      * Builder for the Emitter.
-     * @deprecated It will be removed in the next major version, please use {@link com.snowplowanalytics.snowplow.Snowplow} methods.
      */
-    @Deprecated
     public static class EmitterBuilder {
-        final @Nullable String uri; // Required
-        final @NonNull Context context; // Required
         @Nullable RequestCallback requestCallback = null; // Optional
         @NonNull HttpMethod httpMethod = POST; // Optional
         @NonNull BufferOption bufferOption = BufferOption.DefaultGroup; // Optional
@@ -113,17 +103,6 @@ public class Emitter {
         @Nullable EventStore eventStore = null; // Optional
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.NetworkConfiguration#NetworkConfiguration(String, HttpMethod)}.
-         * @param uri The uri of the collector
-         * @param context the android context
-         */
-        public EmitterBuilder(@Nullable String uri, @NonNull Context context) {
-            this.uri = uri;
-            this.context = context;
-        }
-
-        /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.NetworkConfiguration#NetworkConfiguration(NetworkConnection)}.
          * @param networkConnection The component in charge for sending events to the collector.
          * @return itself
          */
@@ -134,7 +113,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.EmitterConfiguration#eventStore(EventStore)}.
          * @param eventStore The component in charge for persisting events before sending.
          * @return itself
          */
@@ -145,62 +123,56 @@ public class Emitter {
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.NetworkConfiguration#NetworkConfiguration(String, HttpMethod)}.
          * @param httpMethod The method by which requests are emitted
          * @return itself
          */
         @NonNull
-        public EmitterBuilder method(@Nullable HttpMethod httpMethod) {
+        public EmitterBuilder method(@NonNull HttpMethod httpMethod) {
             this.httpMethod = httpMethod;
             return this;
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.EmitterConfiguration#bufferOption(BufferOption)}
          * @param option the buffer option for the emitter
          * @return itself
          */
         @NonNull
-        public EmitterBuilder option(@Nullable BufferOption option) {
+        public EmitterBuilder option(@NonNull BufferOption option) {
             this.bufferOption = option;
             return this;
         }
 
         /**
-         * @deprecated Use {@link NetworkConfiguration#NetworkConfiguration(String, HttpMethod)}
          * @param protocol the security chosen for requests
          * @return itself
          */
         @NonNull
-        public EmitterBuilder security(@Nullable Protocol protocol) {
+        public EmitterBuilder security(@NonNull Protocol protocol) {
             this.requestSecurity = protocol;
             return this;
         }
 
         /**
-         * @deprecated No longer needed.
          * @param version the TLS version allowed for requests
          * @return itself
          */
         @NonNull
-        public EmitterBuilder tls(@Nullable TLSVersion version) {
+        public EmitterBuilder tls(@NonNull TLSVersion version) {
             this.tlsVersions = EnumSet.of(version);
             return this;
         }
 
         /**
-         * @deprecated No longer needed.
          * @param versions the TLS versions allowed for requests
          * @return itself
          */
         @NonNull
-        public EmitterBuilder tls(@Nullable EnumSet<TLSVersion> versions) {
+        public EmitterBuilder tls(@NonNull EnumSet<TLSVersion> versions) {
             this.tlsVersions = versions;
             return this;
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.EmitterConfiguration#requestCallback(RequestCallback)}.
          * @param requestCallback Request callback function
          * @return itself
          */
@@ -211,7 +183,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated No longer needed.
          * @param emitterTick The tick count between emitter attempts
          * @return itself
          */
@@ -222,7 +193,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.EmitterConfiguration#emitRange(int)}.
          * @param sendLimit The maximum amount of events to grab for an emit attempt
          * @return itself
          */
@@ -233,7 +203,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated No longer needed.
          * @param emptyLimit The amount of emitter ticks that are performed before we shut down
          *                   due to the database being empty.
          * @return itself
@@ -245,7 +214,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.EmitterConfiguration#byteLimitGet(int)}.
          * @param byteLimitGet The maximum amount of bytes allowed to be sent in a payload
          *                     in a GET request.
          * @return itself
@@ -257,7 +225,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.EmitterConfiguration#byteLimitPost(int)}.
          * @param byteLimitPost The maximum amount of bytes allowed to be sent in a payload
          *                      in a POST request.
          * @return itself
@@ -269,7 +236,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.NetworkConfiguration#timeout(Integer)}.
          * @param emitTimeout The maximum timeout for emitting events. If emit time exceeds this value
          *                    TimeOutException will be thrown
          * @return itself
@@ -281,18 +247,16 @@ public class Emitter {
         }
 
         /**
-         * @deprecated No longer needed.
          * @param timeUnit a valid TimeUnit
          * @return itself
          */
         @NonNull
-        public EmitterBuilder timeUnit(@Nullable TimeUnit timeUnit) {
+        public EmitterBuilder timeUnit(@NonNull TimeUnit timeUnit) {
             this.timeUnit = timeUnit;
             return this;
         }
 
         /**
-         * @deprecated Use {@link NetworkConfiguration#okHttpClient(OkHttpClient)}
          * @param client An OkHttp client that will be used in the emitter, you can provide your
          *               own if you want to share your Singleton client's interceptors, connection pool etc..
          *               ,otherwise a new one is created.
@@ -305,7 +269,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.NetworkConfiguration#customPostPath(String)}.
          * @param customPostPath A custom path that is used on the endpoint to send requests.
          * @return itself
          */
@@ -316,7 +279,6 @@ public class Emitter {
         }
 
         /**
-         * @deprecated Use {@link com.snowplowanalytics.snowplow.configuration.EmitterConfiguration#threadPoolSize(int)}.
          * @param threadPoolSize The number of threads available for the tracker's operations.
          * @return itself
          */
@@ -325,27 +287,17 @@ public class Emitter {
             this.threadPoolSize = threadPoolSize;
             return this;
         }
-
-        /**
-         * Creates a new Emitter
-         *
-         * @return a new Emitter object
-         */
-        @NonNull
-        public Emitter build() {
-            return new Emitter(this);
-        }
     }
 
     /**
      * Creates an emitter object
-     *
-     * @param builder The builder that constructs an emitter
      */
-    private Emitter(@NonNull EmitterBuilder builder) {
-        this.httpMethod = builder.httpMethod;
+    public Emitter(@NonNull Context context, @NonNull String collectorUri, @Nullable EmitterBuilder builder) {
+        this.context = context;
+        if (builder == null) {
+            builder = new EmitterBuilder();
+        }
         this.requestCallback = builder.requestCallback;
-        this.context = builder.context;
         this.bufferOption = builder.bufferOption;
         this.requestSecurity = builder.requestSecurity;
         this.tlsVersions = builder.tlsVersions;
@@ -355,17 +307,16 @@ public class Emitter {
         this.byteLimitGet = builder.byteLimitGet;
         this.byteLimitPost = builder.byteLimitPost;
         this.emitTimeout = builder.emitTimeout;
-        this.uri = builder.uri;
         this.timeUnit = builder.timeUnit;
-        this.eventStore = null;
-        this.customPostPath = builder.customPostPath;
         this.client = builder.client;
         this.eventStore = builder.eventStore;
 
+        this.uri = collectorUri;
+        this.httpMethod = builder.httpMethod;
+        this.customPostPath = builder.customPostPath;
         if (builder.networkConnection == null) {
             isCustomNetworkConnection = false;
-            String endpoint = builder.uri;
-            Uri uri = Uri.parse(endpoint);
+            String endpoint = collectorUri;
             if (!endpoint.startsWith("http")) {
                 String protocol = builder.requestSecurity == Protocol.HTTPS ? "https://" : "http://";
                 endpoint = protocol + endpoint;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Executor.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Executor.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Executor.java
@@ -68,11 +68,21 @@ public class Executor {
      * @param runnable the runnable to be queued
      */
     public static void execute(boolean reportsOnDiagnostic, @Nullable String tag, @Nullable Runnable runnable) {
+        final String loggerTag;
+        if (tag == null) {
+            loggerTag = "Source not provided";
+        } else {
+            loggerTag = tag;
+        }
         execute(runnable, t -> {
+            String message = t.getLocalizedMessage();
+            if (message == null) {
+                message = "No message provided.";
+            }
             if (reportsOnDiagnostic) {
-                Logger.track(tag, t.getLocalizedMessage(), t);
+                Logger.track(loggerTag, message, t);
             } else {
-                Logger.e(tag, t.getLocalizedMessage(), t);
+                Logger.e(loggerTag, message, t);
             }
         });
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/NetworkConfigurationUpdate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/NetworkConfigurationUpdate.java
@@ -59,6 +59,7 @@ public class NetworkConfigurationUpdate implements NetworkConfigurationInterface
 
     public boolean customPostPathUpdated;
 
+    @Nullable
     public String getCustomPostPath() {
         return (sourceConfig == null || customPostPathUpdated) ? this.customPostPath : sourceConfig.customPostPath;
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/TLSArguments.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/TLSArguments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/TLSSocketFactory.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/TLSSocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/TLSVersion.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/TLSVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreHelper.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreHelper.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreHelper.java
@@ -70,6 +70,9 @@ public class EventStoreHelper extends SQLiteOpenHelper {
      */
     @NonNull
     public synchronized static List<String> removeUnsentEventsExceptForNamespaces(@NonNull Context context, @Nullable List<String> allowedNamespaces) {
+        if (allowedNamespaces == null) {
+            allowedNamespaces = new ArrayList<>();
+        }
         String[] databaseList = context.databaseList();
         if (databaseList == null) {
             return new ArrayList<>();

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/storage/SQLiteEventStore.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/storage/SQLiteEventStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/gdpr/Gdpr.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/gdpr/Gdpr.java
@@ -21,7 +21,6 @@ public class Gdpr {
     public final String documentDescription;
 
     public Gdpr(@NonNull Basis basisForProcessing, @Nullable String documentId, @Nullable String documentVersion, @Nullable String documentDescription) {
-        Preconditions.checkArgument(basisForProcessing != null, "GDPR basisForProcessiong can't be null.");
         this.basisForProcessing = basisForProcessing;
         this.documentId = documentId;
         this.documentVersion = documentVersion;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/gdpr/GdprConfigurationUpdate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/gdpr/GdprConfigurationUpdate.java
@@ -29,17 +29,17 @@ public class GdprConfigurationUpdate extends GdprConfiguration {
         return (sourceConfig == null || gdprUpdated) ? super.basisForProcessing : sourceConfig.basisForProcessing;
     }
 
-    @Nullable
+    @NonNull
     public String getDocumentId() {
         return (sourceConfig == null || gdprUpdated) ? super.documentId : sourceConfig.documentId;
     }
 
-    @Nullable
+    @NonNull
     public String getDocumentVersion() {
         return (sourceConfig == null || gdprUpdated) ? super.documentVersion : sourceConfig.documentVersion;
     }
 
-    @Nullable
+    @NonNull
     public String getDocumentDescription() {
         return (sourceConfig == null || gdprUpdated) ? super.documentDescription : sourceConfig.documentDescription;
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationFetcher.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationFetcher.java
@@ -89,6 +89,10 @@ public class ConfigurationFetcher {
     }
 
     private void exceptionHandler(@Nullable Throwable t) {
-        Logger.e(TAG, t.getMessage(), t);
+        String message = t.getMessage();
+        if (message == null) {
+            message = "no message provided";
+        }
+        Logger.e(TAG, message, t);
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/FileStore.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/FileStore.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/ProcessObserver.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/ProcessObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/ProcessObserver.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/ProcessObserver.java
@@ -15,6 +15,7 @@ package com.snowplowanalytics.snowplow.internal.session;
 
 import android.annotation.TargetApi;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.lifecycle.LifecycleObserver;
@@ -52,7 +53,9 @@ public class ProcessObserver implements LifecycleObserver {
         lifecycleContexts = contexts;
     }
 
-    public ProcessObserver() {}
+    public ProcessObserver(@NonNull Tracker tracker) {
+
+    }
 
     public static void setLifecycleContexts(@Nullable List<SelfDescribingJson> contexts) {
         lifecycleContexts = contexts;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ActivityLifecycleHandler.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ActivityLifecycleHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ActivityLifecycleHandler.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ActivityLifecycleHandler.java
@@ -16,55 +16,49 @@ package com.snowplowanalytics.snowplow.internal.tracker;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Application;
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 
 import com.snowplowanalytics.snowplow.event.ScreenView;
-import com.snowplowanalytics.snowplow.event.SelfDescribing;
-import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.internal.utils.NotificationCenter;
-import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class ActivityLifecycleHandler implements Application.ActivityLifecycleCallbacks {
     private static final String TAG = ActivityLifecycleHandler.class.getSimpleName();
-    private static List<SelfDescribingJson> contexts = new ArrayList<SelfDescribingJson>();
 
-    public ActivityLifecycleHandler(List<SelfDescribingJson> contexts) {
-        contexts = contexts;
+    private static ActivityLifecycleHandler sharedInstance;
+
+    @NonNull
+    public synchronized static ActivityLifecycleHandler getInstance(@NonNull Context context) {
+        if (sharedInstance == null) {
+            sharedInstance = new ActivityLifecycleHandler(context);
+        }
+        return sharedInstance;
     }
 
-    public ActivityLifecycleHandler() {}
-
-    public static void setContexts(List<SelfDescribingJson> contexts) {
-        contexts = contexts;
-    }
-
-    public static List<SelfDescribingJson> getLifecycleContexts() {
-        return contexts;
-    }
-
-    @Override
-    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-
+    private ActivityLifecycleHandler(@NonNull Context context) {
+        Application application = (Application) context.getApplicationContext();
+        application.registerActivityLifecycleCallbacks(this);
     }
 
     @Override
-    public void onActivityStarted(Activity activity) {
-
-    }
+    public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle savedInstanceState) {}
 
     @Override
-    public void onActivityResumed(Activity activity) {
+    public void onActivityStarted(@NonNull Activity activity) {}
+
+    @Override
+    public void onActivityResumed(@NonNull Activity activity) {
         Logger.d(TAG, "Auto screenview occurred - activity has resumed");
         try {
             ScreenView event = ScreenView.buildWithActivity(activity);
@@ -77,22 +71,14 @@ public class ActivityLifecycleHandler implements Application.ActivityLifecycleCa
     }
 
     @Override
-    public void onActivityPaused(Activity activity) {
-
-    }
+    public void onActivityPaused(@NonNull Activity activity) {}
 
     @Override
-    public void onActivityStopped(Activity activity) {
-
-    }
+    public void onActivityStopped(@NonNull Activity activity) {}
 
     @Override
-    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
-
-    }
+    public void onActivitySaveInstanceState(@NonNull Activity activity, @Nullable Bundle outState) {}
 
     @Override
-    public void onActivityDestroyed(Activity activity) {
-
-    }
+    public void onActivityDestroyed(@NonNull Activity activity) {}
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/DeepLinkStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/DeepLinkStateMachine.java
@@ -46,7 +46,7 @@ public class DeepLinkStateMachine implements StateMachineInterface {
     @NonNull
     @Override
     public List<String> subscribedEventSchemasForTransitions() {
-        return Arrays.asList(DeepLinkReceived.SCHEMA_DEEPLINKRECEIVED, TrackerConstants.SCHEMA_SCREEN_VIEW);
+        return Arrays.asList(DeepLinkReceived.SCHEMA, TrackerConstants.SCHEMA_SCREEN_VIEW);
     }
 
     @NonNull

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ExceptionHandler.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ExceptionHandler.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ExceptionHandler.java
@@ -93,10 +93,8 @@ public class ExceptionHandler implements Thread.UncaughtExceptionHandler {
         Util.addToMap(Parameters.APP_ERROR_EXCEPTION_NAME, exceptionName, data);
         Util.addToMap(Parameters.APP_ERROR_FATAL, true, data);
 
-        SelfDescribing event = SelfDescribing.builder()
-                .eventData(new SelfDescribingJson(TrackerConstants.APPLICATION_ERROR_SCHEMA, data))
-                .build();
-        Map<String, Object> notificationData = new HashMap<String, Object>();
+        SelfDescribing event = new SelfDescribing(new SelfDescribingJson(TrackerConstants.APPLICATION_ERROR_SCHEMA, data));
+        Map<String, Object> notificationData = new HashMap<>();
         notificationData.put("event", event);
         NotificationCenter.postNotification("SnowplowCrashReporting", notificationData);
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/InstallTracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/InstallTracker.java
@@ -20,18 +20,28 @@ import java.util.Map;
 import static com.snowplowanalytics.snowplow.internal.constants.TrackerConstants.INSTALLED_BEFORE;
 import static com.snowplowanalytics.snowplow.internal.constants.TrackerConstants.INSTALL_TIMESTAMP;
 
+/**
+ * Class used to keep track of install state of app.
+ * If a file does not exist, the tracker will send an `application_install` event.
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class InstallTracker {
-    /**
-     * Class used to keep track of install state of app.
-     * If a file does not exist, the tracker will send an `application_install` event.
-     */
     private static String TAG = InstallTracker.class.getSimpleName();
-    private Boolean isNewInstall;
 
+    private Boolean isNewInstall;
     private SharedPreferences sharedPreferences;
 
-    public InstallTracker(@NonNull Context context) {
+    private static InstallTracker sharedInstance;
+
+    @NonNull
+    public synchronized static InstallTracker getInstance(@NonNull Context context) {
+        if (sharedInstance == null) {
+            sharedInstance = new InstallTracker(context);
+        }
+        return sharedInstance;
+    }
+
+    private InstallTracker(@NonNull Context context) {
         new SharedPreferencesTask().execute(context);
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/LifecycleStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/LifecycleStateMachine.java
@@ -20,7 +20,7 @@ public class LifecycleStateMachine implements StateMachineInterface {
     @NonNull
     @Override
     public List<String> subscribedEventSchemasForTransitions() {
-        return Arrays.asList(Background.SCHEMA_BACKGROUND, Foreground.SCHEMA_FOREGROUND);
+        return Arrays.asList(Background.SCHEMA, Foreground.SCHEMA);
     }
 
     @NonNull

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Logger.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Logger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -181,17 +181,17 @@ public class Logger {
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 class DefaultLoggerDelegate implements LoggerDelegate {
     @Override
-    public void error(String tag, String msg) {
+    public void error(@NonNull String tag, @NonNull String msg) {
         Log.e(tag, msg);
     }
 
     @Override
-    public void debug(String tag, String msg) {
+    public void debug(@NonNull String tag, String msg) {
         Log.d(tag, msg);
     }
 
     @Override
-    public void verbose(String tag, String msg) {
+    public void verbose(@NonNull String tag, String msg) {
         Log.v(tag, msg);
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Logger.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Logger.java
@@ -186,12 +186,12 @@ class DefaultLoggerDelegate implements LoggerDelegate {
     }
 
     @Override
-    public void debug(@NonNull String tag, String msg) {
+    public void debug(@NonNull String tag, @NonNull String msg) {
         Log.d(tag, msg);
     }
 
     @Override
-    public void verbose(@NonNull String tag, String msg) {
+    public void verbose(@NonNull String tag, @NonNull String msg) {
         Log.v(tag, msg);
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/SchemaRule.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/SchemaRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ScreenStateMachine.java
@@ -5,7 +5,6 @@ import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.event.Event;
 import com.snowplowanalytics.snowplow.event.ScreenView;
-import com.snowplowanalytics.snowplow.event.SelfDescribing;
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
@@ -59,7 +58,7 @@ public class ScreenStateMachine implements StateMachineInterface {
             // - Init (SV) Screen
             screenState = new ScreenState();
         }
-        screenView.updateScreenState(screenState);
+        screenState.updateScreenState(screenView.id, screenView.name, screenView.type, screenView.transitionType, screenView.fragmentClassName, screenView.fragmentTag, screenView.activityClassName, screenView.activityTag);
         return screenState;
     }
 
@@ -94,4 +93,5 @@ public class ScreenStateMachine implements StateMachineInterface {
         }
         return null;
     }
+
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -29,6 +29,8 @@ import com.snowplowanalytics.snowplow.internal.globalcontexts.GlobalContextsCont
 import com.snowplowanalytics.snowplow.internal.session.SessionConfigurationInterface;
 import com.snowplowanalytics.snowplow.internal.session.SessionConfigurationUpdate;
 import com.snowplowanalytics.snowplow.internal.session.SessionControllerImpl;
+import com.snowplowanalytics.snowplow.network.HttpMethod;
+import com.snowplowanalytics.snowplow.network.Protocol;
 
 import java.util.List;
 import java.util.Objects;
@@ -354,10 +356,8 @@ public class ServiceProvider implements ServiceProviderInterface {
     private Emitter makeEmitter() {
         NetworkConfigurationInterface networkConfig = networkConfigurationUpdate;
         EmitterConfigurationInterface emitterConfig = emitterConfigurationUpdate;
-        Emitter.EmitterBuilder builder = new Emitter.EmitterBuilder(networkConfig.getEndpoint(), context)
+        Emitter.EmitterBuilder builder = new Emitter.EmitterBuilder()
                 .networkConnection(networkConfig.getNetworkConnection())
-                .method(networkConfig.getMethod())
-                .security(networkConfig.getProtocol())
                 .customPostPath(networkConfig.getCustomPostPath())
                 .client(networkConfig.getOkHttpClient())
                 .sendLimit(emitterConfig.getEmitRange())
@@ -367,7 +367,19 @@ public class ServiceProvider implements ServiceProviderInterface {
                 .byteLimitGet(emitterConfig.getByteLimitGet())
                 .threadPoolSize(emitterConfig.getThreadPoolSize())
                 .callback(emitterConfig.getRequestCallback());
-        return builder.build();
+        HttpMethod method = networkConfig.getMethod();
+        if (method != null) {
+            builder.method(method);
+        }
+        Protocol protocol = networkConfig.getProtocol();
+        if (protocol != null) {
+            builder.security(protocol);
+        }
+        String endpoint = networkConfig.getEndpoint();
+        if (endpoint == null) {
+            endpoint = "";
+        }
+        return new Emitter(context, endpoint, builder);
     }
 
     @NonNull

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -347,10 +347,7 @@ public class ServiceProvider implements ServiceProviderInterface {
 
     @NonNull
     private Subject makeSubject() {
-        return new Subject.SubjectBuilder()
-                .context(context)
-                .subjectConfiguration(subjectConfigurationUpdate)
-                .build();
+        return new Subject(context, subjectConfigurationUpdate);
     }
 
     @NonNull

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -403,7 +403,7 @@ public class ServiceProvider implements ServiceProviderInterface {
                     gdprConfig.getDocumentVersion(),
                     gdprConfig.getDocumentDescription());
         }
-        Tracker tracker = builder.buildAndReset();
+        Tracker tracker = Tracker.reset(new Tracker(builder));
         if (globalContextsConfiguration != null) {
             tracker.setGlobalContextGenerators(globalContextsConfiguration.contextGenerators);
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -182,6 +182,9 @@ public class ServiceProvider implements ServiceProviderInterface {
     }
 
     private void stopServices() {
+        if (tracker != null) {
+            tracker.close();
+        }
         if (emitter != null) {
             emitter.shutdown();
         }
@@ -403,7 +406,7 @@ public class ServiceProvider implements ServiceProviderInterface {
                     gdprConfig.getDocumentVersion(),
                     gdprConfig.getDocumentDescription());
         }
-        Tracker tracker = Tracker.reset(new Tracker(builder));
+        Tracker tracker = new Tracker(builder);
         if (globalContextsConfiguration != null) {
             tracker.setGlobalContextGenerators(globalContextsConfiguration.contextGenerators);
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Subject.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Subject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Subject.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Subject.java
@@ -27,16 +27,13 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 
-import com.snowplowanalytics.snowplow.configuration.SubjectConfiguration;
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.util.Size;
 
 /**
  * Provides Subject information for each
  * event sent from the Snowplow Tracker.
- * @deprecated It will be removed in the next major version, please use Snowplow.setup methods.
  */
-@Deprecated
 public class Subject {
 
     private static final String TAG = Subject.class.getSimpleName();
@@ -63,59 +60,10 @@ public class Subject {
     @Nullable
     Integer colorDepth;
 
-
-    /**
-     * Builder for the Subject
-     * @deprecated It will be removed in the next major version, please use Snowplow.setup methods.
-     */
-    @Deprecated
-    public static class SubjectBuilder {
-        private Context context = null; // Optional
-        private SubjectConfigurationInterface subjectConfiguration = null; // Optional
-
-        /**
-         * @param context The android context to pass to the subject
-         * @return itself
-         */
-        @NonNull
-        public SubjectBuilder context(@NonNull Context context) {
-            this.context = context;
-            return this;
-        }
-
-        /**
-         * @param subjectConfiguration The subjectConfiguration to configure the subject
-         * @return itself
-         */
-        @NonNull
-        public SubjectBuilder subjectConfiguration(@Nullable SubjectConfigurationInterface subjectConfiguration) {
-            this.subjectConfiguration = subjectConfiguration;
-            return this;
-        }
-
-        /**
-         * Creates a new Subject
-         *
-         * @return a new Subject object
-         */
-        @NonNull
-        public Subject build() {
-            return new Subject(this);
-        }
-    }
-
-    /**
-     * Creates a Subject which will add extra data to each event.
-     *
-     * @param builder The builder that constructs a subject
-     */
-    private Subject(@NonNull SubjectBuilder builder) {
+    public Subject(@NonNull Context context, @Nullable SubjectConfigurationInterface config) {
         setDefaultTimezone();
         setDefaultLanguage();
-        if (builder.context != null) {
-            setDefaultScreenResolution(builder.context);
-        }
-        SubjectConfigurationInterface config = builder.subjectConfiguration;
+        setDefaultScreenResolution(context);
         if (config != null) {
             if (config.getUserId() != null) setUserId(config.getUserId());
             if (config.getNetworkUserId() != null) setNetworkUserId(config.getNetworkUserId());
@@ -177,7 +125,6 @@ public class Subject {
 
     /**
      * Sets the subjects userId
-     * @deprecated Use {@link SubjectConfiguration#userId(String)}
      * @param userId a user id string
      */
     public void setUserId(@NonNull String userId) {
@@ -186,18 +133,10 @@ public class Subject {
     }
 
     /**
-     * Sets the subjects userId
-     * @deprecated Use {@link SubjectConfiguration#userId(String)}
-     * @param userId a user id string
-     */
-    public void identifyUser(@NonNull String userId) { this.setUserId(userId); }
-
-    /**
      * Sets a custom screen resolution based
      * on user inputted width and height.
      *
      * Measured in pixels: 1920x1080
-     * @deprecated Use {@link SubjectConfiguration#screenResolution(Size)} 
      * @param width the width of the screen
      * @param height the height of the screen
      */
@@ -211,7 +150,6 @@ public class Subject {
      * Sets the view port resolution
      *
      * Measured in pixels: 1280x1024
-     * @deprecated Use {@link SubjectConfiguration#screenViewPort(Size)} 
      * @param width the width of the viewport
      * @param height the height of the viewport
      */
@@ -225,7 +163,6 @@ public class Subject {
      * user defined color depth.
      *
      * Measure as an integer
-     * @deprecated Use {@link SubjectConfiguration#colorDepth(Integer)} 
      * @param depth the color depth
      */
     public void setColorDepth(int depth) {
@@ -235,7 +172,6 @@ public class Subject {
 
     /**
      * User inputted timezone
-     * @deprecated Use {@link SubjectConfiguration#timezone(String)} 
      * @param timezone a valid timezone
      */
     public void setTimezone(@NonNull String timezone) {
@@ -246,7 +182,6 @@ public class Subject {
     /**
      * User inputted language for the
      * subject.
-     * @deprecated Use {@link SubjectConfiguration#language(String)} 
      * @param language language setting
      */
     public void setLanguage(@NonNull String language) {
@@ -257,7 +192,6 @@ public class Subject {
     /**
      * User inputted ip address for the
      * subject.
-     * @deprecated Use {@link SubjectConfiguration#ipAddress(String)} 
      * @param ipAddress an ip address
      */
     public void setIpAddress(@NonNull String ipAddress) {
@@ -268,7 +202,6 @@ public class Subject {
     /**
      * User inputted useragent for the
      * subject.
-     * @deprecated Use {@link SubjectConfiguration#useragent(String)} 
      * @param useragent a useragent
      */
     public void setUseragent(@NonNull String useragent) {
@@ -279,7 +212,6 @@ public class Subject {
     /**
      * User inputted Network User Id for the
      * subject.
-     * @deprecated Use {@link SubjectConfiguration#networkUserId(String)} 
      * @param networkUserId a network user id
      */
     public void setNetworkUserId(@NonNull String networkUserId) {
@@ -290,7 +222,6 @@ public class Subject {
     /**
      * User inputted Domain User Id for the
      * subject.
-     * @deprecated Use {@link SubjectConfiguration#domainUserId(String)}
      * @param domainUserId a domain user id
      */
     public void setDomainUserId(@NonNull String domainUserId) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.snowplowanalytics.snowplow.entity.DeepLink;
 import com.snowplowanalytics.snowplow.event.DeepLinkReceived;
 import com.snowplowanalytics.snowplow.internal.utils.NotificationCenter;
 import com.snowplowanalytics.snowplow.tracker.BuildConfig;
@@ -747,9 +746,9 @@ public class Tracker {
      will be SelfDescribing.
     */
     private void workaroundForCampaignAttributionEnrichment(@NonNull Payload payload, @NonNull TrackerEvent event) {
-        if (event.schema.equals(DeepLinkReceived.SCHEMA_DEEPLINKRECEIVED) && event.payload != null) {
-            String url = (String)event.payload.get(DeepLinkReceived.PARAM_DEEPLINKRECEIVED_URL);
-            String referrer = (String)event.payload.get(DeepLinkReceived.PARAM_DEEPLINKRECEIVED_REFERRER);
+        if (event.schema.equals(DeepLinkReceived.SCHEMA) && event.payload != null) {
+            String url = (String)event.payload.get(DeepLinkReceived.PARAM_URL);
+            String referrer = (String)event.payload.get(DeepLinkReceived.PARAM_REFERRER);
             payload.add(Parameters.PAGE_URL, url);
             payload.add(Parameters.PAGE_REFR, referrer);
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerEvent.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Preconditions.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Preconditions.java
@@ -92,6 +92,7 @@
 
 package com.snowplowanalytics.snowplow.internal.utils;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -118,7 +119,7 @@ public final class Preconditions {
      *     string using {@link String#valueOf(Object)}
      * @throws IllegalArgumentException if {@code expression} is false
      */
-    public static void checkArgument(boolean expression, Object errorMessage) {
+    public static void checkArgument(boolean expression, @Nullable Object errorMessage) {
         if (!expression) {
             throw new IllegalArgumentException(String.valueOf(errorMessage));
         }
@@ -131,7 +132,7 @@ public final class Preconditions {
      *     string using {@link String#valueOf(Object)}
      * @throws IllegalArgumentException
      */
-    public static void fail(Object errorMessage) {
+    public static void fail(@Nullable Object errorMessage) {
         throw new IllegalArgumentException(String.valueOf(errorMessage));
     }
 
@@ -160,7 +161,7 @@ public final class Preconditions {
      * @return the non-null reference that was validated
      * @throws NullPointerException if {@code reference} is null
      */
-    public static <T> T checkNotNull(T reference, Object errorMessage) {
+    public static <T> T checkNotNull(T reference, @Nullable Object errorMessage) {
         if (reference == null) {
             throw new NullPointerException(String.valueOf(errorMessage));
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
@@ -13,6 +13,7 @@
 
 package com.snowplowanalytics.snowplow.internal.utils;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -21,7 +22,6 @@ import android.location.LocationManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
-import android.telephony.TelephonyManager;
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
@@ -30,12 +30,7 @@ import androidx.annotation.Nullable;
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.internal.tracker.Logger;
-import com.snowplowanalytics.snowplow.internal.tracker.PlatformContext;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -44,16 +39,10 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.lang.reflect.Array;
-import java.lang.reflect.Method;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
-
-import okhttp3.internal.platform.Platform;
 
 /**
  * Provides basic Utilities for the Snowplow Tracker.
@@ -93,20 +82,6 @@ public class Util {
     @NonNull
     public static String getUUIDString() {
         return UUID.randomUUID().toString();
-    }
-
-    /**
-     * Check the passed string is a UUID code.
-     *
-     * @param uuid a UUID code string.
-     * @return true if it's a UUID code.
-     */
-    public static boolean isUUIDString(@NonNull String uuid) {
-        try {
-            return UUID.fromString(uuid) != null;
-        } catch (Exception e) {
-            return false;
-        }
     }
 
     /**
@@ -163,26 +138,6 @@ public class Util {
     }
 
     /**
-     * The startTime must be greater than the endTime minus the
-     * interval to be within an acceptable range.
-     *
-     * Example:
-     * - Start Time = 1425060000000 // Fri, 27 Feb 2015 18:00:00 GMT
-     * - Check Time = 1425060300000 // Fri, 27 Feb 2015 18:05:00 GMT
-     * - Range = 600000 // 10 minutes
-     *
-     * If the start time is greater than 17:55:00 then it is in range.
-     *
-     * @param startTime the startTime of the check
-     * @param checkTime the time of the check
-     * @param range the allowed range the startTime must be in
-     * @return whether the time is in range or not
-     */
-    public static boolean isTimeInRange(long startTime, long checkTime, long range) {
-        return startTime > (checkTime - range);
-    }
-
-    /**
      * Joins a list of Longs into a single string
      *
      * @param list the list to join
@@ -190,23 +145,23 @@ public class Util {
      */
     @NonNull
     public static String joinLongList(@NonNull List<Long> list) {
-        String s = "";
+        StringBuilder s = new StringBuilder();
 
         for (int i = 0; i < list.size(); i++) {
             Long longVal = list.get(i);
             if (longVal != null) {
-                s += Long.toString(list.get(i));
+                s.append(list.get(i));
                 if (i < list.size() - 1) {
-                    s += ",";
+                    s.append(",");
                 }
             }
         }
 
-        if (s.substring(s.length() - 1).equals(",")) {
-            s = s.substring(0, s.length() - 1);
+        if (s.toString().endsWith(",")) {
+            s = new StringBuilder(s.substring(0, s.length() - 1));
         }
 
-        return s;
+        return s.toString();
     }
 
     // --- Geo-Location Context
@@ -247,6 +202,7 @@ public class Util {
      * @param context the android context
      * @return the phones Location
      */
+    @SuppressLint("MissingPermission") // Suppressed as it's caught by SecurityException catch block.
     @Nullable
     public static Location getLastKnownLocation(@NonNull Context context) {
         LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
@@ -285,7 +241,7 @@ public class Util {
         try {
             PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
             String versionName = pInfo.versionName;
-            String versionCode = "";
+            String versionCode;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 versionCode = String.valueOf(pInfo.getLongVersionCode());
             } else {
@@ -303,103 +259,6 @@ public class Util {
             Logger.e(TAG, "Failed to find application context: %s", e.getMessage());
         }
         return null;
-    }
-
-    // --- Mobile Context
-
-    /**
-     * @deprecated Will be removed in v3.
-     * @return the OS Type
-     */
-    @NonNull @Deprecated
-    public static String getOsType() {
-        return new DeviceInfoMonitor().getOsType();
-    }
-
-    /**
-     * @deprecated Will be removed in v3.
-     * @return the OS Version
-     */
-    @NonNull @Deprecated
-    public static String getOsVersion() {
-        return new DeviceInfoMonitor().getOsVersion();
-    }
-
-    /**
-     * @deprecated Will be removed in v3.
-     * @return the device model
-     */
-    @NonNull @Deprecated
-    public static String getDeviceModel() {
-        return new DeviceInfoMonitor().getDeviceModel();
-    }
-
-    /**
-     * @deprecated Will be removed in v3.
-     * @return the device vendor
-     */
-    @NonNull @Deprecated
-    public static String getDeviceVendor() {
-        return new DeviceInfoMonitor().getDeviceVendor();
-    }
-
-    /**
-     * @deprecated Will be removed in v3.
-     * @param context the android context
-     * @return a carrier name or null
-     */
-    @Nullable @Deprecated
-    public static String getCarrier(@NonNull Context context) {
-        return new DeviceInfoMonitor().getCarrier(context);
-    }
-
-    /**
-     * @deprecated Will be removed in v3.
-     * The function that actually fetches the Advertising ID.
-     * - If called from the UI Thread will throw an Exception
-     *
-     * @param context the android context
-     * @return an empty string if limited tracking is on otherwise the advertising id or null
-     */
-    @Nullable @Deprecated
-    public static String getAndroidIdfa(@NonNull Context context) {
-        return new DeviceInfoMonitor().getAndroidIdfa(context);
-    }
-
-    /**
-     * @deprecated Will be removed in v3.
-     * Returns the network type that the device is connected to
-     *
-     * @param networkInfo The NetworkInformation object
-     * @return the type of the network
-     */
-    @NonNull @Deprecated
-    public static String getNetworkType(@Nullable NetworkInfo networkInfo) {
-        return new DeviceInfoMonitor().getNetworkType(networkInfo);
-    }
-
-    /**
-     * @deprecated Will be removed in v3.
-     * Returns the network technology
-     *
-     * @param networkInfo The NetworkInformation object
-     * @return the technology of the network
-     */
-    @Nullable @Deprecated
-    public static String getNetworkTechnology(@Nullable NetworkInfo networkInfo) {
-        return new DeviceInfoMonitor().getNetworkTechnology(networkInfo);
-    }
-
-    /**
-     * @deprecated Will be removed in v3.
-     * Returns an instance that represents the current network connection
-     *
-     * @param context the android context
-     * @return the representation of the current network connection or null
-     */
-    @Nullable @Deprecated
-    public static NetworkInfo getNetworkInfo(@NonNull Context context) {
-        return new DeviceInfoMonitor().getNetworkInfo(context);
     }
 
     // --- Context Helpers

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/HttpMethod.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/NetworkConnection.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/NetworkConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/Protocol.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/Protocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/Request.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/Request.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/Request.java
@@ -14,6 +14,7 @@
 package com.snowplowanalytics.snowplow.network;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
@@ -86,7 +87,7 @@ public class Request {
      * @param payload The payload where to get the `ua` parameter.
      * @return User-Agent string from subject settings or the default one.
      */
-    @NonNull
+    @Nullable
     private String getUserAgent(@NonNull Payload payload) {
         HashMap hashMap = (HashMap) payload.getMap();
         return (String) hashMap.get(Parameters.USERAGENT);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/RequestCallback.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/RequestCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/RequestResult.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/RequestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/payload/Payload.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/payload/Payload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/payload/SelfDescribingJson.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/payload/SelfDescribingJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/payload/TrackerPayload.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/payload/TrackerPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/DevicePlatform.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/DevicePlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/LogLevel.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/LogLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/LoggerDelegate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/LoggerDelegate.java
@@ -1,28 +1,40 @@
+/*
+ * Copyright (c) 2015-2021 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
 package com.snowplowanalytics.snowplow.tracker;
+
+import androidx.annotation.NonNull;
 
 public interface LoggerDelegate {
 
     /**
      * Error Level Logging
-     *
      * @param tag the log tag
      * @param msg the log message
      */
-    void error(String tag, String msg);
+    void error(@NonNull String tag, @NonNull String msg);
 
     /**
      * Debug Level Logging
-     *
      * @param tag the log tag
      * @param msg the log message
      */
-    void debug(String tag, String msg);
+    void debug(@NonNull String tag, @NonNull String msg);
 
     /**
      * Verbose Level Logging
-     *
      * @param tag the log tag
      * @param msg the log message
      */
-    void verbose(String tag, String msg);
+    void verbose(@NonNull String tag, @NonNull String msg);
 }


### PR DESCRIPTION
The purpose of this PR is to remove the old v1 API.
I haven't introduced big changes in the internal classes. The main goal is just to avoid their exposure in order to refactor them more in deep in future minor releases.

Changes:
- Removed builders for events
- Removed `getScreenState` and `updateWithPreviousState` on ScreenView
- EcommerceTransactionItem has orderId rather than itemId
- Session removed setIsBackground (internal only)

I've also removed the callbacks from Session (they were deprecated) but a recent discussion on Discourse make me think they are needed for hybrid apps. I'm considering to add them back (maybe with a different format).
