### PR TITLE
Do not allow multiple state machines with the same ID (close #489)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -36,7 +36,7 @@ public class StateManagerTest {
     @Test
     public void testStateManager() {
         StateManager stateManager = new StateManager();
-        stateManager.addStateMachine(new MockStateMachine(), "identifier");
+        stateManager.addOrReplaceStateMachine(new MockStateMachine(), "identifier");
 
         SelfDescribing eventInc = new SelfDescribing("inc", new HashMap() {{ put("value", 1); }});
         SelfDescribing eventDec = new SelfDescribing("dec", new HashMap() {{ put("value", 2); }});
@@ -86,7 +86,7 @@ public class StateManagerTest {
     @Test
     public void testAddRemoveStateMachine() {
         StateManager stateManager = new StateManager();
-        stateManager.addStateMachine(new MockStateMachine(), "identifier");
+        stateManager.addOrReplaceStateMachine(new MockStateMachine(), "identifier");
         stateManager.removeStateMachine("identifier");
 
         SelfDescribing eventInc = new SelfDescribing("inc", new HashMap() {{ put("value", 1); }});
@@ -156,6 +156,34 @@ public class StateManagerTest {
         eventStore.removeAllEvents();
         entities = (String) payload.getMap().get("co");
         assertTrue(entities.contains("screen2"));
+    }
+
+    @Test
+    public void testAllowsMultipleStateMachines() throws InterruptedException {
+        StateManager stateManager = new StateManager();
+        stateManager.addOrReplaceStateMachine(new MockStateMachine(), "identifier1");
+        stateManager.addOrReplaceStateMachine(new MockStateMachine(), "identifier2");
+
+        SelfDescribing eventInc = new SelfDescribing("inc", new HashMap() {{ put("value", 1); }});
+        TrackerStateSnapshot trackerState = stateManager.trackerStateForProcessedEvent(eventInc);
+
+        InspectableEvent e = new TrackerEvent(eventInc, trackerState);
+        List<SelfDescribingJson> entities = stateManager.entitiesForProcessedEvent(e);
+        assertEquals(2, entities.size());
+    }
+
+    @Test
+    public void testDoesntDuplicateStateFromStateMachinesWithSameId() throws InterruptedException {
+        StateManager stateManager = new StateManager();
+        stateManager.addOrReplaceStateMachine(new MockStateMachine(), "identifier");
+        stateManager.addOrReplaceStateMachine(new MockStateMachine(), "identifier");
+
+        SelfDescribing eventInc = new SelfDescribing("inc", new HashMap() {{ put("value", 1); }});
+        TrackerStateSnapshot trackerState = stateManager.trackerStateForProcessedEvent(eventInc);
+
+        InspectableEvent e = new TrackerEvent(eventInc, trackerState);
+        List<SelfDescribingJson> entities = stateManager.entitiesForProcessedEvent(e);
+        assertEquals(1, entities.size());
     }
 }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -185,6 +185,38 @@ public class StateManagerTest {
         List<SelfDescribingJson> entities = stateManager.entitiesForProcessedEvent(e);
         assertEquals(1, entities.size());
     }
+
+    @Test
+    public void testReplacingStateMachineDoesntResetTrackerState() {
+        StateManager stateManager = new StateManager();
+
+        stateManager.addOrReplaceStateMachine(new MockStateMachine(), "identifier");
+        stateManager.trackerStateForProcessedEvent(new SelfDescribing("inc", new HashMap() {{ put("value", 1); }}));
+        State state1 = stateManager.trackerState.getState("identifier");
+
+        stateManager.addOrReplaceStateMachine(new MockStateMachine(), "identifier");
+        State state2 = stateManager.trackerState.getState("identifier");
+
+        assertNotNull(state1);
+        assertSame(state1, state2);
+    }
+
+    @Test
+    public void testReplacingStateMachineWithDifferentOneResetsTrackerState() {
+        class MockStateMachine1 extends MockStateMachine {}
+        class MockStateMachine2 extends MockStateMachine {}
+
+        StateManager stateManager = new StateManager();
+        stateManager.addOrReplaceStateMachine(new MockStateMachine1(), "identifier");
+        stateManager.trackerStateForProcessedEvent(new SelfDescribing("inc", new HashMap() {{ put("value", 1); }}));
+        State state1 = stateManager.trackerState.getState("identifier");
+
+        stateManager.addOrReplaceStateMachine(new MockStateMachine2(), "identifier");
+        State state2 = stateManager.trackerState.getState("identifier");
+
+        assertNotNull(state1);
+        assertNotSame(state1, state2);
+    }
 }
 
 // Mock classes

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class StateManager {
 
@@ -23,7 +24,11 @@ public class StateManager {
 
 
     public synchronized void addOrReplaceStateMachine(@NonNull StateMachineInterface stateMachine, @NonNull String identifier) {
-        if (identifierToStateMachine.containsKey(identifier)) {
+        StateMachineInterface previousStateMachine = identifierToStateMachine.get(identifier);
+        if (previousStateMachine != null) {
+            if (Objects.equals(stateMachine.getClass(), previousStateMachine.getClass())) {
+                return;
+            }
             removeStateMachine(identifier);
         }
         identifierToStateMachine.put(identifier, stateMachine);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
@@ -22,7 +22,10 @@ public class StateManager {
     final TrackerState trackerState = new TrackerState();
 
 
-    public synchronized void addStateMachine(@NonNull StateMachineInterface stateMachine, @NonNull String identifier) {
+    public synchronized void addOrReplaceStateMachine(@NonNull StateMachineInterface stateMachine, @NonNull String identifier) {
+        if (identifierToStateMachine.containsKey(identifier)) {
+            removeStateMachine(identifier);
+        }
         identifierToStateMachine.put(identifier, stateMachine);
         stateMachineToIdentifier.put(stateMachine, identifier);
         addToSchemaRegistry(eventSchemaToStateMachine, stateMachine.subscribedEventSchemasForTransitions(), stateMachine);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -575,7 +575,7 @@ public class Tracker {
         if (lifecycleEvents) {
             ProcessObserver.initialize(context);
             // Initialize LifecycleStateMachine for lifecycle entities
-            stateManager.addStateMachine(new LifecycleStateMachine(), "Lifecycle");
+            stateManager.addOrReplaceStateMachine(new LifecycleStateMachine(), "Lifecycle");
         }
     }
 
@@ -938,7 +938,7 @@ public class Tracker {
     public void setScreenContext(boolean screenContext) {
         this.screenContext = screenContext;
         if (screenContext) {
-            stateManager.addStateMachine(new ScreenStateMachine(), "ScreenContext");
+            stateManager.addOrReplaceStateMachine(new ScreenStateMachine(), "ScreenContext");
         } else {
             stateManager.removeStateMachine("ScreenContext");
         }
@@ -948,7 +948,7 @@ public class Tracker {
     public void setDeepLinkContext(boolean deepLinkContext) {
         this.deepLinkContext = deepLinkContext;
         if (this.deepLinkContext) {
-            stateManager.addStateMachine(new DeepLinkStateMachine(), "DeepLinkContext");
+            stateManager.addOrReplaceStateMachine(new DeepLinkStateMachine(), "DeepLinkContext");
         } else {
             stateManager.removeStateMachine("DeepLinkContext");
         }


### PR DESCRIPTION
Addresses issue #489 

The change automatically removes previous state machine (if any) with the same identifier when adding a new one. This prevents multiple of the same context being added to events in case the same state machine is registered multiple times.