### PR TITLE
Fix updating IDFA during app runtime (close #492)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/MockDeviceInfoMonitor.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/MockDeviceInfoMonitor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 public class MockDeviceInfoMonitor extends DeviceInfoMonitor {
     @NonNull private Map<String, Integer> methodAccessCounts = new HashMap<String, Integer>();
+    @Nullable public String customIdfa = "XJKLJSALFKJ";
 
     @NonNull
     @Override
@@ -67,7 +68,7 @@ public class MockDeviceInfoMonitor extends DeviceInfoMonitor {
     @Override
     public String getAndroidIdfa(@NonNull Context context) {
         increaseMethodAccessCount("getAndroidIdfa");
-        return "XJKLJSALFKJ";
+        return customIdfa;
     }
 
     @NonNull

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContextTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContextTest.java
@@ -132,6 +132,28 @@ public class PlatformContextTest {
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getTotalStorage"));
     }
 
+    @Test
+    public void doesntUpdateIdfaIfNotNull() {
+        MockDeviceInfoMonitor deviceInfoMonitor = new MockDeviceInfoMonitor();
+        PlatformContext platformContext = new PlatformContext(0, 1, deviceInfoMonitor, getContext());
+        assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
+        platformContext.getMobileContext();
+        assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
+    }
+
+    @Test
+    public void updatesIdfaIfEmptyOrNull() {
+        MockDeviceInfoMonitor deviceInfoMonitor = new MockDeviceInfoMonitor();
+        deviceInfoMonitor.customIdfa = "";
+        PlatformContext platformContext = new PlatformContext(0, 1, deviceInfoMonitor, getContext());
+        assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
+        deviceInfoMonitor.customIdfa = null;
+        platformContext.getMobileContext();
+        assertEquals(2, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
+        platformContext.getMobileContext();
+        assertEquals(3, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
+    }
+
     // --- PRIVATE
 
     private Context getContext() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContext.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContext.java
@@ -98,7 +98,6 @@ public class PlatformContext {
         Util.addToMap(Parameters.DEVICE_MODEL, deviceInfoMonitor.getDeviceModel(), pairs);
         Util.addToMap(Parameters.DEVICE_MANUFACTURER, deviceInfoMonitor.getDeviceVendor(), pairs);
         Util.addToMap(Parameters.CARRIER, deviceInfoMonitor.getCarrier(context), pairs);
-        Util.addToMap(Parameters.ANDROID_IDFA, deviceInfoMonitor.getAndroidIdfa(context), pairs);
         Util.addToMap(Parameters.PHYSICAL_MEMORY, deviceInfoMonitor.getPhysicalMemory(context), pairs);
         Util.addToMap(Parameters.TOTAL_STORAGE, deviceInfoMonitor.getTotalStorage(), pairs);
 
@@ -108,6 +107,11 @@ public class PlatformContext {
 
     private void setEphemeralPlatformDict() {
         lastUpdatedEphemeralPlatformDict = System.currentTimeMillis();
+
+        Object currentIdfa = pairs.get(Parameters.ANDROID_IDFA);
+        if (currentIdfa == null || currentIdfa.toString().isEmpty()) {
+            Util.addToMap(Parameters.ANDROID_IDFA, deviceInfoMonitor.getAndroidIdfa(context), pairs);
+        }
 
         Pair<String, Integer> batteryInfo = deviceInfoMonitor.getBatteryStateAndLevel(context);
         if (batteryInfo != null) {


### PR DESCRIPTION
Addresses issue #492 by updating the Android IDFA while it is null or empty. Once a value for it is found, it will no longer be updated.