### PR TITLE
Fix multiple ScreenContexts on ScreenView events (close #495)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.java
@@ -129,6 +129,7 @@ public class StateManagerTest {
         entities = (String) payload.getMap().get("co");
         assertNotNull(entities);
         assertTrue(entities.contains("screen1"));
+        assertEquals(1, entities.split("screen1", -1).length - 1);
 
         tracker.track(new Timing("category", "variable", 123));
         Thread.sleep(1000);
@@ -137,6 +138,7 @@ public class StateManagerTest {
         eventStore.removeAllEvents();
         entities = (String) payload.getMap().get("co");
         assertTrue(entities.contains("screen1"));
+        assertEquals(1, entities.split("screen1", -1).length - 1);
 
         tracker.track(new ScreenView("screen2"));
         Thread.sleep(1000);
@@ -145,6 +147,7 @@ public class StateManagerTest {
         eventStore.removeAllEvents();
         entities = (String) payload.getMap().get("co");
         assertTrue(entities.contains("screen2"));
+        assertEquals(1, entities.split("screen2", -1).length - 1);
         String eventPayload = (String) payload.getMap().get("ue_pr");
         assertTrue(eventPayload.contains("screen1"));
         assertTrue(eventPayload.contains("screen2"));
@@ -156,6 +159,16 @@ public class StateManagerTest {
         eventStore.removeAllEvents();
         entities = (String) payload.getMap().get("co");
         assertTrue(entities.contains("screen2"));
+        assertEquals(1, entities.split("screen2", -1).length - 1);
+
+        tracker.track(new Timing("category", "variable", 123));
+        Thread.sleep(1000);
+        if (eventStore.lastInsertedRow == -1) fail();
+        payload = eventStore.db.get(eventStore.lastInsertedRow);
+        eventStore.removeAllEvents();
+        entities = (String) payload.getMap().get("co");
+        assertTrue(entities.contains("screen2"));
+        assertEquals(1, entities.split("screen2", -1).length - 1);
     }
 
     @Test

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/StateManager.java
@@ -55,9 +55,10 @@ public class StateManager {
     synchronized TrackerStateSnapshot trackerStateForProcessedEvent(@NonNull Event event) {
         if (event instanceof AbstractSelfDescribing) {
             AbstractSelfDescribing sdEvent = (AbstractSelfDescribing) event;
-            List<StateMachineInterface> stateMachines = eventSchemaToStateMachine.get(sdEvent.getSchema());
-            if (stateMachines == null) {
-                stateMachines = new LinkedList<>();
+            List<StateMachineInterface> stateMachines = new LinkedList<>();
+            List<StateMachineInterface> stateMachinesForSchema = eventSchemaToStateMachine.get(sdEvent.getSchema());
+            if (stateMachinesForSchema != null) {
+                stateMachines.addAll(stateMachinesForSchema);
             }
             List<StateMachineInterface> stateMachinesGeneral = eventSchemaToStateMachine.get("*");
             if (stateMachinesGeneral != null) {
@@ -88,9 +89,10 @@ public class StateManager {
     @NonNull
     synchronized List<SelfDescribingJson> entitiesForProcessedEvent(@NonNull InspectableEvent event) {
         List<SelfDescribingJson> result = new LinkedList<>();
-        List<StateMachineInterface> stateMachines = eventSchemaToEntitiesGenerator.get(event.getSchema());
-        if (stateMachines == null) {
-            stateMachines = new LinkedList<>();
+        List<StateMachineInterface> stateMachines = new LinkedList<>();
+        List<StateMachineInterface> stateMachinesForSchema = eventSchemaToEntitiesGenerator.get(event.getSchema());
+        if (stateMachinesForSchema != null) {
+            stateMachines.addAll(stateMachinesForSchema);
         }
         List<StateMachineInterface> stateMachinesGeneral = eventSchemaToEntitiesGenerator.get("*");
         if (stateMachinesGeneral != null) {
@@ -109,9 +111,10 @@ public class StateManager {
 
     public synchronized boolean addPayloadValuesToEvent(@NonNull InspectableEvent event) {
         int failures = 0;
-        List<StateMachineInterface> stateMachines = eventSchemaToPayloadUpdater.get(event.getSchema());
-        if (stateMachines == null) {
-            stateMachines = new LinkedList<>();
+        List<StateMachineInterface> stateMachines = new LinkedList<>();
+        List<StateMachineInterface> stateMachinesForSchema = eventSchemaToPayloadUpdater.get(event.getSchema());
+        if (stateMachinesForSchema != null) {
+            stateMachines.addAll(stateMachinesForSchema);
         }
         List<StateMachineInterface> stateMachinesGeneral = eventSchemaToPayloadUpdater.get("*");
         if (stateMachinesGeneral != null) {


### PR DESCRIPTION
As described in the #495 issue the ScreenView events could be tracked with multiple ScreenContexts.
This is caused by the erroneous management of the list of state machines.
During the computation of the entities to add to the event, the tracker gets a list of state machines for the specific event schema, then it gets a list of state machines that can be used with each event (filter: "*"). Unfortunately, the latter was added directly to the first list causing duplication. More ScreenView tracked caused even more duplications.

I've fixed it making a clone of the list rather than using that directly.
The iOS tracker is not affected because it correctly makes a clone.