### PR TITLE
Add session callback (close #500)

### DIFF
--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/Demo.java
@@ -61,6 +61,7 @@ import com.snowplowanalytics.snowplow.network.RequestCallback;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.LogLevel;
 import com.snowplowanalytics.snowplow.internal.utils.Util;
+import com.snowplowanalytics.snowplow.tracker.SessionState;
 import com.snowplowanalytics.snowplow.util.Basis;
 import com.snowplowanalytics.snowplow.util.TimeMeasure;
 import com.snowplowanalytics.snowplowtrackerdemo.utils.DemoUtils;
@@ -265,9 +266,16 @@ public class Demo extends Activity implements LoggerDelegate {
                 .installAutotracking(true)
                 .diagnosticAutotracking(true);
         SessionConfiguration sessionConfiguration = new SessionConfiguration(
-                new TimeMeasure(60, TimeUnit.SECONDS),
+                new TimeMeasure(6, TimeUnit.SECONDS),
                 new TimeMeasure(30, TimeUnit.SECONDS)
-        );
+        )
+                .onSessionUpdate(state -> updateLogger(
+                        "Session: " + state.getSessionId()
+                                + "\r\nprevious: " + state.getPreviousSessionId()
+                                + "\r\neventId: " + state.getFirstEventId()
+                                + "\r\nindex: " + state.getSessionIndex()
+                                + "\r\nuserId: " + state.getUserId()
+                ));
         GdprConfiguration gdprConfiguration = new GdprConfiguration(
                 Basis.CONSENT,
                 "someId",
@@ -421,7 +429,7 @@ public class Demo extends Activity implements LoggerDelegate {
                 boolean isRunning = e.isSending();
                 long dbSize = e.getDbCount();
                 SessionController session = tracker.getSession();
-                int sessionIndex = session != null ? -1 : session.getSessionIndex();
+                int sessionIndex = session == null ? -1 : session.getSessionIndex();
                 updateEmitterStats(isOnline, isRunning, dbSize, sessionIndex);
             }
         }, 1, 1, TimeUnit.SECONDS);

--- a/snowplow-demo-app/src/main/res/values/strings.xml
+++ b/snowplow-demo-app/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="emitter_config_text">Config:</string>
     <string name="emitter_type_text">Type:</string>
     <string name="data_collection_text">Collection:</string>
-    <string name="emitter_logging_text">Emitter Callback:</string>
+    <string name="emitter_logging_text">App logging:</string>
     <string name="emitter_statistics">Metrics:</string>
     <string name="created_events">Made: 0</string>
     <string name="sent_events">Sent: 0</string>

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/SessionConfiguration.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/SessionConfiguration.java
@@ -1,8 +1,11 @@
 package com.snowplowanalytics.snowplow.configuration;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
 
 import com.snowplowanalytics.snowplow.internal.session.SessionConfigurationInterface;
+import com.snowplowanalytics.snowplow.tracker.SessionState;
 import com.snowplowanalytics.snowplow.util.TimeMeasure;
 
 import org.json.JSONObject;
@@ -38,6 +41,12 @@ public class SessionConfiguration implements SessionConfigurationInterface, Conf
      */
     @NonNull
     public TimeMeasure backgroundTimeout;
+
+    /**
+     * The callback called everytime the session is updated.
+     */
+    @Nullable
+    public Consumer<SessionState> onSessionUpdate;
 
     // Constructors
 
@@ -85,6 +94,34 @@ public class SessionConfiguration implements SessionConfigurationInterface, Conf
     @Override
     public void setBackgroundTimeout(@NonNull TimeMeasure backgroundTimeout) {
         this.backgroundTimeout = backgroundTimeout;
+    }
+
+    /**
+     * @see #onSessionUpdate
+     */
+    @Nullable
+    @Override
+    public Consumer<SessionState> getOnSessionUpdate() {
+        return onSessionUpdate;
+    }
+
+    /**
+     * @see #onSessionUpdate
+     */
+    @Override
+    public void setOnSessionUpdate(@Nullable Consumer<SessionState> onSessionUpdate) {
+        this.onSessionUpdate = onSessionUpdate;
+    }
+
+    // Builders
+
+    /**
+     * @see #onSessionUpdate
+     */
+    @NonNull
+    public SessionConfiguration onSessionUpdate(@Nullable Consumer<SessionState> onSessionUpdate) {
+        this.onSessionUpdate = onSessionUpdate;
+        return this;
     }
 
     // Copyable

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/TrackerConstants.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/TrackerConstants.java
@@ -47,6 +47,7 @@ public class TrackerConstants {
     public static final String EVENT_ECOMM = "tr";
     public static final String EVENT_ECOMM_ITEM = "ti";
 
+    public static final String SESSION_STATE = "session_state";
     public static final String SNOWPLOW_SESSION_VARS = "snowplow_session_vars";
     public static final String SNOWPLOW_GENERAL_VARS = "snowplow_general_vars";
     public static final String INSTALLATION_USER_ID = "SPInstallationUserId";

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/FileStore.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/FileStore.java
@@ -16,11 +16,13 @@ package com.snowplowanalytics.snowplow.internal.session;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 
 import com.snowplowanalytics.snowplow.internal.tracker.Logger;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -49,7 +51,7 @@ public class FileStore {
      * @param context The android context object
      * @return success statement
      */
-    public static boolean saveMapToFile(String filename, Map objects, Context context) {
+    public static boolean saveMapToFile(@NonNull String filename, @NonNull Map objects, @NonNull Context context) {
         FileOutputStream fos;
         try {
             Logger.d(TAG, "Attempting to save: %s", objects);
@@ -74,11 +76,14 @@ public class FileStore {
      * @return the map of vars or null
      */
     @Nullable
-    public static Map<String, Object> getMapFromFile(String filename, Context context) {
-        FileInputStream fis;
+    public synchronized static Map<String, Object> getMapFromFile(@NonNull String filename, @NonNull Context context) {
         try {
+            File file = context.getFileStreamPath(filename);
+            if (file == null || !file.exists()) {
+                return null;
+            }
             Logger.d(TAG, "Attempting to retrieve map from: %s", filename);
-            fis = context.openFileInput(filename);
+            FileInputStream fis = new FileInputStream(file);
             ObjectInputStream ois = new ObjectInputStream(fis);
             Map<String, Object> varsMap = (HashMap<String, Object>) ois.readObject();
             ois.close();
@@ -97,7 +102,7 @@ public class FileStore {
      * @param context The android context object
      * @return the success of the operation
      */
-    public static boolean deleteFile(String filename, Context context) {
+    public static boolean deleteFile(@NonNull String filename, @NonNull Context context) {
         boolean isSuccess = context.deleteFile(filename);
         Logger.d(TAG, "Deleted %s from internal storage: %s", filename, isSuccess);
         return isSuccess;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -155,8 +155,11 @@ public class Session {
 
     private synchronized static String retrieveUserId(Context context, SessionState state) {
         String userId = state != null ? state.getUserId() : Util.getUUIDString();
-        // Get or Set the Session UserID
-        //$ Specify why this mess with the userId
+        // With v2 we designed a new identifier: Installation ID.
+        // It should be created by the tracker at first execution and it should be constant until the app deletion.
+        // It behaves as the SessionUserID but it should be available even if the session context is disabled.
+        // At the moment we store it separately from the session in order to fully implement it in one of the
+        // future versions.
         SharedPreferences generalPref = context.getSharedPreferences(TrackerConstants.SNOWPLOW_GENERAL_VARS, Context.MODE_PRIVATE);
         String storedUserId = generalPref.getString(TrackerConstants.INSTALLATION_USER_ID, null);
         if (storedUserId != null) {
@@ -182,7 +185,6 @@ public class Session {
                 Logger.d(TAG, "Update session information.");
                 updateSession(eventId);
 
-                //$ Refactor these callbacks
                 if (isBackground.get()) { // timed out in background
                     this.executeEventCallback(backgroundTimeoutCallback);
                 } else { // timed out in foreground

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -26,8 +26,13 @@ import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.internal.tracker.Logger;
 import com.snowplowanalytics.snowplow.internal.utils.Util;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+import com.snowplowanalytics.snowplow.tracker.SessionState;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,13 +55,9 @@ public class Session {
 
     // Session Variables
     private String userId;
-    private String currentSessionId = null;
-    private String previousSessionId;
-    private int sessionIndex = 0;
     private int backgroundIndex = 0;
     private int foregroundIndex = 0;
-    private final String sessionStorage = "LOCAL_STORAGE";
-    private String firstId = null;
+    private SessionState state = null;
 
     // Variables to control Session Updates
     private final AtomicBoolean isBackground = new AtomicBoolean(false);
@@ -72,6 +73,7 @@ public class Session {
     private Runnable foregroundTimeoutCallback = null;
     private Runnable backgroundTimeoutCallback = null;
 
+    // Session values persistence
     private SharedPreferences sharedPreferences;
 
     /**
@@ -123,45 +125,45 @@ public class Session {
 
         StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
         try {
-            sharedPreferences = getSessionFromSharedPreferences(context, sessionVarsName);
-            if (sharedPreferences != null) {
-                userId = sharedPreferences.getString(Parameters.SESSION_USER_ID, Util.getUUIDString());
-                currentSessionId = sharedPreferences.getString(Parameters.SESSION_ID, null);
-                sessionIndex = sharedPreferences.getInt(Parameters.SESSION_INDEX, 0);
-            } else {
-                Map<String, Object> sessionInfo = getSessionFromFile(context);
-                if (sessionInfo != null) {
+            Map<String, Object> sessionInfo = getSessionMapFromLegacyTrackerV3(context, sessionVarsName);
+            if (sessionInfo == null) {
+                sessionInfo = getSessionMapFromLegacyTrackerV2(context, sessionVarsName);
+                if (sessionInfo == null) {
                     try {
-                        userId = sessionInfo.get(Parameters.SESSION_USER_ID).toString();
-                        currentSessionId = sessionInfo.get(Parameters.SESSION_ID).toString();
-                        sessionIndex = (int) sessionInfo.get(Parameters.SESSION_INDEX);
+                        sessionInfo = getSessionMapFromLegacyTrackerV1(context);
                     } catch (Exception e) {
                         Logger.track(TAG, String.format("Exception occurred retrieving session info from file: %s", e), e);
-                        userId = Util.getUUIDString();
                     }
-                } else {
-                    userId = Util.getUUIDString();
                 }
             }
-            // Force sharedPreferences to be the correct one.
-            sharedPreferences = context.getSharedPreferences(TrackerConstants.SNOWPLOW_SESSION_VARS, Context.MODE_PRIVATE);
+            if (sessionInfo == null) {
+                Logger.track(TAG, "No previous session info available");
+            } else {
+                state = SessionState.build(sessionInfo);
+            }
+            userId = retrieveUserId(context, state);
+            sharedPreferences = context.getSharedPreferences(sessionVarsName, Context.MODE_PRIVATE);
             lastSessionCheck = System.currentTimeMillis();
         } finally {
             StrictMode.setThreadPolicy(oldPolicy);
         }
+        Logger.v(TAG, "Tracker Session Object created.");
+    }
 
+    private synchronized static String retrieveUserId(Context context, SessionState state) {
+        String userId = state != null ? state.getUserId() : Util.getUUIDString();
         // Get or Set the Session UserID
+        //$ Specify why this mess with the userId
         SharedPreferences generalPref = context.getSharedPreferences(TrackerConstants.SNOWPLOW_GENERAL_VARS, Context.MODE_PRIVATE);
         String storedUserId = generalPref.getString(TrackerConstants.INSTALLATION_USER_ID, null);
         if (storedUserId != null) {
             userId = storedUserId;
-        } else if (userId != null) {
+        } else {
             generalPref.edit()
                     .putString(TrackerConstants.INSTALLATION_USER_ID, userId)
                     .commit();
         }
-
-        Logger.v(TAG, "Tracker Session Object created.");
+        return userId;
     }
 
     /**
@@ -172,25 +174,21 @@ public class Session {
     @NonNull
     public synchronized SelfDescribingJson getSessionContext(@NonNull String eventId) {
         Logger.v(TAG, "Getting session context...");
-        if (!isSessionCheckerEnabled) {
-            return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, getSessionValues());
-        }
-        if (shouldUpdateSession()) {
-            Logger.d(TAG, "Update session information.");
-            updateSession(eventId);
-        }
-        lastSessionCheck = System.currentTimeMillis();
-        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, getSessionValues());
-    }
+        if (isSessionCheckerEnabled) {
+            if (shouldUpdateSession()) {
+                Logger.d(TAG, "Update session information.");
+                updateSession(eventId);
 
-    private void executeEventCallback(Runnable callback) {
-        if (callback != null) {
-            try {
-                callback.run();
-            } catch (Exception e) {
-                Logger.e(TAG, "Session event callback failed");
+                //$ Refactor these callbacks
+                if (isBackground.get()) { // timed out in background
+                    this.executeEventCallback(backgroundTimeoutCallback);
+                } else { // timed out in foreground
+                    this.executeEventCallback(foregroundTimeoutCallback);
+                }
             }
+            lastSessionCheck = System.currentTimeMillis();
         }
+        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, state.getSessionValues());
     }
 
     private boolean shouldUpdateSession() {
@@ -204,31 +202,31 @@ public class Session {
 
     private synchronized void updateSession(String eventId) {
         isNewSession.set(false);
-        firstId = eventId;
-        previousSessionId = this.currentSessionId;
-        currentSessionId = Util.getUUIDString();
-        sessionIndex++;
-
-        Logger.d(TAG, "Session information is updated:");
-        Logger.d(TAG, " + Session ID: %s", currentSessionId);
-        Logger.d(TAG, " + Previous Session ID: %s", previousSessionId);
-        Logger.d(TAG, " + Session Index: %s", sessionIndex);
-
-        boolean isBackground = this.isBackground.get();
-
-        if (isBackground) { // timed out in background
-            this.executeEventCallback(backgroundTimeoutCallback);
-        } else { // timed out in foreground
-            this.executeEventCallback(foregroundTimeoutCallback);
+        String currentSessionId = Util.getUUIDString();
+        int sessionIndex = 1;
+        String previousSessionId = null;
+        String storage = "LOCAL_STORAGE";
+        if (state != null) {
+            sessionIndex = state.getSessionIndex() + 1;
+            previousSessionId = state.getSessionId();
+            storage = state.getStorage();
         }
+        state = new SessionState(eventId, currentSessionId, previousSessionId, sessionIndex, userId, storage);
 
+        JSONObject jsonObject = new JSONObject(state.getSessionValues());
+        String jsonString = jsonObject.toString();
         SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(Parameters.SESSION_ID, currentSessionId);
-        editor.putString(Parameters.SESSION_PREVIOUS_ID, previousSessionId);
-        editor.putInt(Parameters.SESSION_INDEX, sessionIndex);
-        editor.putString(Parameters.SESSION_FIRST_ID, firstId);
-        editor.putString(Parameters.SESSION_STORAGE, sessionStorage);
+        editor.putString(TrackerConstants.SESSION_STATE, jsonString);
         editor.apply();
+    }
+
+    private void executeEventCallback(Runnable callback) {
+        if (callback == null) return;
+        try {
+            callback.run();
+        } catch (Exception e) {
+            Logger.e(TAG, "Session event callback failed");
+        }
     }
 
     public void startNewSession() {
@@ -293,46 +291,74 @@ public class Session {
     }
 
     /**
-     * Returns the values for the session context.
-     * @return a map containing all session values
-     */
-    @NonNull
-    public Map<String, Object> getSessionValues() {
-        Map<String, Object> sessionValues = new HashMap<>();
-        sessionValues.put(Parameters.SESSION_USER_ID,this.userId);
-        sessionValues.put(Parameters.SESSION_ID, this.currentSessionId);
-        sessionValues.put(Parameters.SESSION_PREVIOUS_ID, this.previousSessionId);
-        sessionValues.put(Parameters.SESSION_INDEX, this.sessionIndex);
-        sessionValues.put(Parameters.SESSION_STORAGE, this.sessionStorage);
-        sessionValues.put(Parameters.SESSION_FIRST_ID, this.firstId);
-        return sessionValues;
-    }
-
-    /**
      * Gets the session information from a file.
      *
      * @return a map or null.
      */
     @Nullable
-    private Map<String, Object> getSessionFromFile(@NonNull Context context) {
-        return FileStore.getMapFromFile(
+    private Map<String, Object> getSessionMapFromLegacyTrackerV1(@NonNull Context context) {
+        Map<String, Object> sessionMap = FileStore.getMapFromFile(
                 TrackerConstants.SNOWPLOW_SESSION_VARS,
                 context);
+        sessionMap.put(Parameters.SESSION_FIRST_ID, "");
+        sessionMap.put(Parameters.SESSION_PREVIOUS_ID, null);
+        sessionMap.put(Parameters.SESSION_STORAGE, "LOCAL_STORAGE");
+        return sessionMap;
     }
 
     @Nullable
-    private SharedPreferences getSessionFromSharedPreferences(@NonNull Context context, @NonNull String sessionVarsName) {
+    private Map<String, Object> getSessionMapFromLegacyTrackerV2(@NonNull Context context, @NonNull String sessionVarsName) {
         StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
         try {
             SharedPreferences sharedPreferences = context.getSharedPreferences(sessionVarsName, Context.MODE_PRIVATE);
-            if (sharedPreferences.contains(Parameters.SESSION_ID)) {
-                return sharedPreferences;
-            } else {
+            if (!sharedPreferences.contains(Parameters.SESSION_ID)) {
                 sharedPreferences = context.getSharedPreferences(TrackerConstants.SNOWPLOW_SESSION_VARS, Context.MODE_PRIVATE);
-                if (sharedPreferences.contains(Parameters.SESSION_ID)) {
-                    return sharedPreferences;
+                if (!sharedPreferences.contains(Parameters.SESSION_ID)) {
+                    return null;
                 }
             }
+            // Create map used as initial session state
+            Map<String, Object> sessionMap = new HashMap<>();
+            String sessionId = sharedPreferences.getString(Parameters.SESSION_ID, null);
+            if (sessionId == null) return null;
+            sessionMap.put(Parameters.SESSION_ID, sessionId);
+
+            String userId = sharedPreferences.getString(Parameters.SESSION_USER_ID, null);
+            if (userId == null) return null;
+            sessionMap.put(Parameters.SESSION_USER_ID, userId);
+
+            int sessionIndex = sharedPreferences.getInt(Parameters.SESSION_INDEX, 0);
+            sessionMap.put(Parameters.SESSION_INDEX, sessionIndex);
+
+            sessionMap.put(Parameters.SESSION_FIRST_ID, "");
+            sessionMap.put(Parameters.SESSION_PREVIOUS_ID, null);
+            sessionMap.put(Parameters.SESSION_STORAGE, "LOCAL_STORAGE");
+            return sessionMap;
+        } finally {
+            StrictMode.setThreadPolicy(oldPolicy);
+        }
+    }
+
+    @Nullable
+    private Map<String, Object> getSessionMapFromLegacyTrackerV3(@NonNull Context context, @NonNull String sessionVarsName) {
+        StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
+        try {
+            SharedPreferences sharedPreferences = context.getSharedPreferences(sessionVarsName, Context.MODE_PRIVATE);
+            if (!sharedPreferences.contains(TrackerConstants.SESSION_STATE)) {
+                return null;
+            }
+            Map<String, Object> sessionMap = new HashMap<>();
+            String jsonString = sharedPreferences.getString(TrackerConstants.SESSION_STATE, null);
+            JSONObject jsonObject = new JSONObject(jsonString);
+            Iterator<String> iterator = jsonObject.keys();
+            while (iterator.hasNext()) {
+                String key = iterator.next();
+                Object value = jsonObject.get(key);
+                sessionMap.put(key, value);
+            }
+            return sessionMap;
+        } catch (JSONException e) {
+            e.printStackTrace();
         } finally {
             StrictMode.setThreadPolicy(oldPolicy);
         }
@@ -342,8 +368,8 @@ public class Session {
     /**
      * @return the session index
      */
-    public int getSessionIndex() {
-        return this.sessionIndex;
+    public int getSessionIndex() { //$ to remove
+        return this.state.getSessionIndex();
     }
 
     /**
@@ -355,35 +381,11 @@ public class Session {
     }
 
     /**
-     * @return the current session id
-     */
-    @NonNull
-    public String getCurrentSessionId() {
-        return this.currentSessionId;
-    }
-
-    /**
-     * @return the previous session id or an empty String
+     * @return the session state
      */
     @Nullable
-    public String getPreviousSessionId() {
-        return this.previousSessionId;
-    }
-
-    /**
-     * @return the session storage type
-     */
-    @NonNull
-    public String getSessionStorage() {
-        return this.sessionStorage;
-    }
-
-    /**
-     * @return the first event id
-     */
-    @Nullable
-    public String getFirstId() {
-        return this.firstId;
+    public SessionState getState() {
+        return state;
     }
 
     /**

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionConfigurationInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionConfigurationInterface.java
@@ -1,7 +1,10 @@
 package com.snowplowanalytics.snowplow.internal.session;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
 
+import com.snowplowanalytics.snowplow.tracker.SessionState;
 import com.snowplowanalytics.snowplow.util.TimeMeasure;
 
 public interface SessionConfigurationInterface {
@@ -35,4 +38,15 @@ public interface SessionConfigurationInterface {
      * background.
      */
     void setBackgroundTimeout(@NonNull TimeMeasure backgroundTimeout);
+
+    /**
+     * The callback called everytime the session is updated.
+     */
+    @Nullable
+    Consumer<SessionState> getOnSessionUpdate();
+
+    /**
+     * The callback called everytime the session is updated.
+     */
+    void setOnSessionUpdate(@Nullable Consumer<SessionState> onSessionUpdate);
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionConfigurationUpdate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionConfigurationUpdate.java
@@ -2,8 +2,11 @@ package com.snowplowanalytics.snowplow.internal.session;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Consumer;
 
 import com.snowplowanalytics.snowplow.configuration.SessionConfiguration;
+import com.snowplowanalytics.snowplow.network.RequestCallback;
+import com.snowplowanalytics.snowplow.tracker.SessionState;
 import com.snowplowanalytics.snowplow.util.TimeMeasure;
 
 import java.util.concurrent.TimeUnit;
@@ -21,6 +24,11 @@ public class SessionConfigurationUpdate extends SessionConfiguration {
 
     public SessionConfigurationUpdate(@NonNull TimeMeasure foregroundTimeout, @NonNull TimeMeasure backgroundTimeout) {
         super(foregroundTimeout, backgroundTimeout);
+    }
+
+    @Nullable
+    public Consumer<SessionState> getOnSessionUpdate() {
+        return (sourceConfig == null) ? null : sourceConfig.getOnSessionUpdate();
     }
 
     // foregroundTimeout flag

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionControllerImpl.java
@@ -3,12 +3,14 @@ package com.snowplowanalytics.snowplow.internal.session;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
+import androidx.core.util.Consumer;
 
 import com.snowplowanalytics.snowplow.controller.SessionController;
 import com.snowplowanalytics.snowplow.internal.Controller;
 import com.snowplowanalytics.snowplow.internal.tracker.ServiceProviderInterface;
 import com.snowplowanalytics.snowplow.internal.tracker.Tracker;
 import com.snowplowanalytics.snowplow.internal.tracker.Logger;
+import com.snowplowanalytics.snowplow.tracker.SessionState;
 import com.snowplowanalytics.snowplow.util.TimeMeasure;
 
 import java.util.concurrent.TimeUnit;
@@ -155,6 +157,33 @@ public class SessionControllerImpl extends Controller implements SessionControll
         getDirtyConfig().backgroundTimeout = backgroundTimeout;
         getDirtyConfig().backgroundTimeoutUpdated = true;
         session.setBackgroundTimeout(backgroundTimeout.convert(TimeUnit.MILLISECONDS));
+    }
+
+    /**
+     * The callback called everytime the session is updated.
+     */
+    @Nullable
+    @Override
+    public Consumer<SessionState> getOnSessionUpdate() {
+        Session session = getSession();
+        if (session == null) {
+            Logger.track(TAG, "Attempt to access SessionController fields when disabled");
+            return null;
+        }
+        return session.onSessionUpdate;
+    }
+
+    /**
+     * The callback called everytime the session is updated.
+     */
+    @Override
+    public void setOnSessionUpdate(@Nullable Consumer<SessionState> onSessionUpdate) {
+        Session session = getSession();
+        if (session == null) {
+            Logger.track(TAG, "Attempt to access SessionController fields when disabled");
+            return;
+        }
+        session.onSessionUpdate = onSessionUpdate;
     }
 
     // Service method

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionControllerImpl.java
@@ -67,7 +67,7 @@ public class SessionControllerImpl extends Controller implements SessionControll
             Logger.track(TAG, "Attempt to access SessionController fields when disabled");
             return "";
         }
-        return session.getCurrentSessionId();
+        return session.getState().getSessionId();
     }
 
     @NonNull

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
+import androidx.core.util.Consumer;
 
 import com.snowplowanalytics.snowplow.configuration.Configuration;
 import com.snowplowanalytics.snowplow.configuration.EmitterConfiguration;
@@ -26,11 +27,13 @@ import com.snowplowanalytics.snowplow.internal.gdpr.GdprConfigurationInterface;
 import com.snowplowanalytics.snowplow.internal.gdpr.GdprConfigurationUpdate;
 import com.snowplowanalytics.snowplow.internal.gdpr.GdprControllerImpl;
 import com.snowplowanalytics.snowplow.internal.globalcontexts.GlobalContextsControllerImpl;
+import com.snowplowanalytics.snowplow.internal.session.Session;
 import com.snowplowanalytics.snowplow.internal.session.SessionConfigurationInterface;
 import com.snowplowanalytics.snowplow.internal.session.SessionConfigurationUpdate;
 import com.snowplowanalytics.snowplow.internal.session.SessionControllerImpl;
 import com.snowplowanalytics.snowplow.network.HttpMethod;
 import com.snowplowanalytics.snowplow.network.Protocol;
+import com.snowplowanalytics.snowplow.tracker.SessionState;
 
 import java.util.List;
 import java.util.Objects;
@@ -424,6 +427,13 @@ public class ServiceProvider implements ServiceProviderInterface {
         }
         if (sessionConfigurationUpdate.isPaused) {
             tracker.pauseSessionChecking();
+        }
+        Session session = tracker.getSession();
+        if (session != null) {
+            Consumer<SessionState> onSessionUpdate = sessionConfigurationUpdate.getOnSessionUpdate();
+            if (onSessionUpdate != null) {
+                session.onSessionUpdate = onSessionUpdate;
+            }
         }
         return tracker;
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.java
@@ -1,0 +1,119 @@
+package com.snowplowanalytics.snowplow.tracker;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.internal.constants.Parameters;
+import com.snowplowanalytics.snowplow.internal.tracker.State;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SessionState implements State {
+
+    @NonNull
+    private final String firstEventId;
+    @Nullable
+    private final String previousSessionId;
+    @NonNull
+    private final String sessionId;
+    private final int sessionIndex;
+    @NonNull
+    private final String storage;
+    @NonNull
+    private final String userId;
+
+    @NonNull
+    private Map<String, Object> sessionContext;
+
+    public SessionState(
+            @NonNull String firstEventId,
+            @NonNull String currentSessionId,
+            @Nullable String previousSessionId, //$ On iOS it has to be set nullable on constructor
+            int sessionIndex,
+            @NonNull String userId,
+            @NonNull String storage
+    ) {
+        this.firstEventId = firstEventId;
+        this.sessionId = currentSessionId;
+        this.previousSessionId = previousSessionId;
+        this.sessionIndex = sessionIndex;
+        this.userId = userId;
+        this.storage = storage;
+
+        sessionContext = new HashMap<String, Object>();
+        sessionContext.put(Parameters.SESSION_PREVIOUS_ID, previousSessionId);
+        sessionContext.put(Parameters.SESSION_ID, sessionId);
+        sessionContext.put(Parameters.SESSION_FIRST_ID, firstEventId);
+        sessionContext.put(Parameters.SESSION_INDEX, sessionIndex); //$ should be Number?!
+        sessionContext.put(Parameters.SESSION_STORAGE, storage);
+        sessionContext.put(Parameters.SESSION_USER_ID, userId);
+    }
+
+    @Nullable
+    public static SessionState build(@NonNull Map<String, Object> storedState) {
+        Object value = storedState.get(Parameters.SESSION_FIRST_ID);
+        if (!(value instanceof String)) return null;
+        String firstEventId = (String) value;
+
+        value = storedState.get(Parameters.SESSION_ID);
+        if (!(value instanceof String)) return null;
+        String sessionId = (String) value;
+
+        value = storedState.get(Parameters.SESSION_PREVIOUS_ID);
+        if (!(value instanceof String)) {
+            value = null;
+        };
+        String previousSessionId = (String) value;
+
+        value = storedState.get(Parameters.SESSION_INDEX);
+        if (!(value instanceof Integer)) return null;
+        int sessionIndex = (Integer) value;
+
+        value = storedState.get(Parameters.SESSION_USER_ID);
+        if (!(value instanceof String)) return null;
+        String userId = (String) value;
+
+        value = storedState.get(Parameters.SESSION_STORAGE);
+        if (!(value instanceof String)) return null;
+        String storage = (String) value;
+
+        return new SessionState(firstEventId, sessionId, previousSessionId, sessionIndex, userId, storage);
+    }
+
+    // Getters
+
+    @NonNull
+    public String getFirstEventId() {
+        return firstEventId;
+    }
+
+    @Nullable
+    public String getPreviousSessionId() {
+        return previousSessionId;
+    }
+
+    @NonNull
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public int getSessionIndex() {
+        return sessionIndex;
+    }
+
+    @NonNull
+    public String getStorage() {
+        return storage;
+    }
+
+    @NonNull
+    public String getUserId() {
+        return userId;
+    }
+
+    @NonNull
+    public Map<String, Object> getSessionValues() {
+        return sessionContext;
+    }
+}


### PR DESCRIPTION
Issue: #500 

The proposed session callback makes use of the SessionState which contains all the information normally available in the session context.
The current implementation is tailor-made on the specific problem of getting session information but in a further enhancement it could be generalised as callback that returns information about any internal tracker state currently kept private (e.g: ScreenState, LifecycleState, etc.).

Proposed documentation:

--

## Session Context

Client session tracking is activated by default but it can be disabled through the TrackerConfiguration as explained above. When enabled the tracker appends a [client_session](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1) context to each event it sends and it maintains this session information as long as the application is installed on the device.

Sessions correspond to tracked user activity. A session expires when no tracking events have occurred for the amount of time defined in a timeout (by default 30 minutes). The session timeout check is executed for each event tracked. If the gap between two consecutive events is longer than the timeout the session is renewed. There are two timeouts since a session can timeout in the foreground (while the app is visible) or in the background (when the app has been suspended, but not closed).

### Session callback

(Available from v3.1)

The tracker allows the configuration of a callback to inform the app everytime a new session is created (in correspondence of a session timeout check). 
This can be configured in the `SessionConfiguration` and it provides the `SessionState` where can be accessed all the info already tracked in the `SessionContext`.

Below an example of where the session callback is used to print out the values of session every time a new session is generated by the tracker:

```
...
SessionConfiguration sessionConfig = new SessionConfiguration(
                new TimeMeasure(6, TimeUnit.SECONDS),
                new TimeMeasure(30, TimeUnit.SECONDS)
        )
                .onSessionUpdate(state -> log("Session: " + state.getSessionId()));
...
Snowplow.createTracker(getApplicationContext(),
                namespace,
                networkConfiguration,
                sessionConfiguration
);
```
