### PR TITLE
Check session for background event using foreground timeout (close #499)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -18,14 +18,17 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.test.AndroidTestCase;
 
+import com.snowplowanalytics.snowplow.event.Foreground;
 import com.snowplowanalytics.snowplow.internal.emitter.Emitter;
 import com.snowplowanalytics.snowplow.internal.session.Session;
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
 import com.snowplowanalytics.snowplow.internal.tracker.Tracker;
+import com.snowplowanalytics.snowplow.internal.utils.NotificationCenter;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.internal.session.FileStore;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +68,7 @@ public class SessionTest extends AndroidTestCase {
     public void testFirstSession() {
         Session session = getSession(3, 3);
 
-        Map<String, Object> sessionContext = getSessionContext(session,"event_1");
+        Map<String, Object> sessionContext = getSessionContext(session, "event_1");
         assertNotNull(sessionContext.get(Parameters.SESSION_USER_ID));
         assertEquals(1, session.getSessionIndex());
         assertNotNull(sessionContext.get(Parameters.SESSION_INDEX));
@@ -73,11 +76,11 @@ public class SessionTest extends AndroidTestCase {
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
     }
 
-    public void testEventsOnSameSession() throws InterruptedException {
+    public void testForegroundEventsOnSameSession() throws InterruptedException {
         Session session = getSession(15, 0);
 
         Map<String, Object> sessionContext = getSessionContext(session, "event_1");
-        String sessionId = (String)sessionContext.get(Parameters.SESSION_ID);
+        String sessionId = (String) sessionContext.get(Parameters.SESSION_ID);
         assertNotNull(sessionId);
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
@@ -85,14 +88,14 @@ public class SessionTest extends AndroidTestCase {
         Thread.sleep(100);
 
         sessionContext = getSessionContext(session, "event_2");
-        assertEquals(sessionId, (String)sessionContext.get(Parameters.SESSION_ID));
+        assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_ID));
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
 
         Thread.sleep(15100);
 
         sessionContext = getSessionContext(session, "event_3");
-        assertEquals(sessionId, (String)sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
+        assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals(2, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
     }
@@ -100,10 +103,10 @@ public class SessionTest extends AndroidTestCase {
     public void testBackgroundEventsOnSameSession() throws InterruptedException {
         Session session = getSession(0, 15);
 
-        session.updateLifecycleNotification(false);
+        session.setBackground(true);
 
         Map<String, Object> sessionContext = getSessionContext(session, "event_1");
-        String sessionId = (String)sessionContext.get(Parameters.SESSION_ID);
+        String sessionId = (String) sessionContext.get(Parameters.SESSION_ID);
         assertNotNull(sessionId);
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
@@ -112,14 +115,14 @@ public class SessionTest extends AndroidTestCase {
 
         sessionContext = getSessionContext(session, "event_2");
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
-        assertEquals(sessionId, (String)sessionContext.get(Parameters.SESSION_ID));
+        assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_ID));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
 
         Thread.sleep(15100);
 
         sessionContext = getSessionContext(session, "event_3");
         assertEquals(2, sessionContext.get(Parameters.SESSION_INDEX));
-        assertEquals(sessionId, (String)sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
+        assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
     }
 
@@ -127,37 +130,37 @@ public class SessionTest extends AndroidTestCase {
         Session session = getSession(1, 1);
 
         Map<String, Object> sessionContext = getSessionContext(session, "event_1");
-        String sessionId = (String)sessionContext.get(Parameters.SESSION_ID);
+        String sessionId = (String) sessionContext.get(Parameters.SESSION_ID);
         assertNotNull(sessionId);
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         String oldSessionId = sessionId;
 
-        session.updateLifecycleNotification(false);
+        session.setBackground(true);
         Thread.sleep(1100);
 
         sessionContext = getSessionContext(session, "event_2");
-        sessionId = (String)sessionContext.get(Parameters.SESSION_ID);
-        assertEquals(oldSessionId, (String)sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
+        sessionId = (String) sessionContext.get(Parameters.SESSION_ID);
+        assertEquals(oldSessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals(2, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_2", sessionContext.get(Parameters.SESSION_FIRST_ID));
         oldSessionId = sessionId;
 
-        session.updateLifecycleNotification(true);
+        session.setBackground(false);
         Thread.sleep(1100);
 
         sessionContext = getSessionContext(session, "event_3");
-        sessionId = (String)sessionContext.get(Parameters.SESSION_ID);
-        assertEquals(oldSessionId, (String)sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
+        sessionId = (String) sessionContext.get(Parameters.SESSION_ID);
+        assertEquals(oldSessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals(3, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
         oldSessionId = sessionId;
 
-        session.updateLifecycleNotification(false);
+        session.setBackground(true);
         Thread.sleep(1100);
 
         sessionContext = getSessionContext(session, "event_4");
-        assertEquals(oldSessionId, (String)sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
+        assertEquals(oldSessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals(4, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_4", sessionContext.get(Parameters.SESSION_FIRST_ID));
     }
@@ -166,8 +169,8 @@ public class SessionTest extends AndroidTestCase {
         Session session = getSession(1, 1);
 
         Map<String, Object> sessionContext = getSessionContext(session, "event_1");
-        Integer oldSessionIndex = (Integer)sessionContext.get(Parameters.SESSION_INDEX);
-        String prevSessionId = (String)sessionContext.get(Parameters.SESSION_ID);
+        Integer oldSessionIndex = (Integer) sessionContext.get(Parameters.SESSION_INDEX);
+        String prevSessionId = (String) sessionContext.get(Parameters.SESSION_ID);
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
 
         session.setIsSuspended(true);
@@ -175,23 +178,94 @@ public class SessionTest extends AndroidTestCase {
 
         sessionContext = getSessionContext(session, "event_2");
         assertEquals(oldSessionIndex, sessionContext.get(Parameters.SESSION_INDEX));
-        assertEquals(prevSessionId, (String)sessionContext.get(Parameters.SESSION_ID));
+        assertEquals(prevSessionId, (String) sessionContext.get(Parameters.SESSION_ID));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
-        prevSessionId = (String)sessionContext.get(Parameters.SESSION_ID);
+        prevSessionId = (String) sessionContext.get(Parameters.SESSION_ID);
 
         session.setIsSuspended(false);
 
         sessionContext = getSessionContext(session, "event_3");
         assertEquals(oldSessionIndex + 1, sessionContext.get(Parameters.SESSION_INDEX));
-        assertEquals(prevSessionId, (String)sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
+        assertEquals(prevSessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
+    }
+
+    public void testBackgroundTimeBiggerThanBackgroundTimeoutCausesNewSession() throws InterruptedException {
+        cleanSharedPreferences(getContext(), TrackerConstants.SNOWPLOW_SESSION_VARS + "_tracker");
+
+        Emitter emitter = new Emitter(getContext(), "", null);
+        Tracker tracker = new Tracker(new Tracker.TrackerBuilder(emitter, "tracker", "app", getContext())
+                .sessionContext(true)
+                .lifecycleEvents(true)
+                .foregroundTimeout(100)
+                .backgroundTimeout(2)
+        );
+        Session session = tracker.getSession();
+
+        getSessionContext(session, "event_1");
+        SessionState sessionState = session.getState();
+        assertNotNull(sessionState);
+        assertEquals(1, sessionState.getSessionIndex());
+        assertEquals("event_1", sessionState.getFirstEventId());
+        String oldSessionId = sessionState.getSessionId();
+
+        Thread.sleep(1000); // Smaller than background timeout
+        Map<String, Object> notificationData = new HashMap<>();
+        notificationData.put("isForeground", Boolean.FALSE);
+        NotificationCenter.postNotification("SnowplowLifecycleTracking", notificationData);
+
+        Thread.sleep(3000); // Bigger than background timeout
+        notificationData = new HashMap<>();
+        notificationData.put("isForeground", Boolean.TRUE);
+        NotificationCenter.postNotification("SnowplowLifecycleTracking", notificationData);
+
+        sessionState = session.getState();
+        assertEquals(2, sessionState.getSessionIndex());
+        assertEquals(oldSessionId, sessionState.getPreviousSessionId());
+        assertFalse(session.isBackground());
+    }
+
+    public void testBackgroundTimeSmallerThanBackgroundTimeoutDoesntCauseNewSession() throws InterruptedException {
+        cleanSharedPreferences(getContext(), TrackerConstants.SNOWPLOW_SESSION_VARS + "_tracker");
+
+        Emitter emitter = new Emitter(getContext(), "", null);
+        Tracker tracker = new Tracker(new Tracker.TrackerBuilder(emitter, "tracker", "app", getContext())
+                .sessionContext(true)
+                .lifecycleEvents(true)
+                .foregroundTimeout(100)
+                .backgroundTimeout(2)
+        );
+        Session session = tracker.getSession();
+
+        getSessionContext(session, "event_1");
+        SessionState sessionState = session.getState();
+        assertNotNull(sessionState);
+        assertEquals(1, sessionState.getSessionIndex());
+        assertEquals("event_1", sessionState.getFirstEventId());
+        String oldSessionId = sessionState.getSessionId();
+
+
+        Thread.sleep(3000); // Bigger than background timeout
+        Map<String, Object> notificationData = new HashMap<>();
+        notificationData.put("isForeground", Boolean.FALSE);
+        NotificationCenter.postNotification("SnowplowLifecycleTracking", notificationData);
+
+        Thread.sleep(1000); // Smaller than background timeout
+        notificationData = new HashMap<>();
+        notificationData.put("isForeground", Boolean.TRUE);
+        NotificationCenter.postNotification("SnowplowLifecycleTracking", notificationData);
+
+        sessionState = session.getState();
+        assertEquals(1, sessionState.getSessionIndex());
+        assertEquals(oldSessionId, sessionState.getSessionId());
+        assertFalse(session.isBackground());
     }
 
     public void testNoEventsForLongTimeDontIncreaseSessionIndexMultipleTimes() throws InterruptedException {
         Session session = getSession(1, 1);
 
         Map<String, Object> sessionContext = getSessionContext(session, "event_1");
-        Integer oldSessionIndex = (Integer)sessionContext.get(Parameters.SESSION_INDEX);
+        Integer oldSessionIndex = (Integer) sessionContext.get(Parameters.SESSION_INDEX);
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
 
         Thread.sleep(4000);
@@ -219,7 +293,7 @@ public class SessionTest extends AndroidTestCase {
         Session session = getSession(3, 3);
 
         Map<String, Object> sessionContext = getSessionContext(session, "event_1");
-        String sessionId = (String)sessionContext.get(Parameters.SESSION_ID);
+        String sessionId = (String) sessionContext.get(Parameters.SESSION_ID);
         assertNotNull(sessionId);
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
@@ -228,14 +302,14 @@ public class SessionTest extends AndroidTestCase {
         session.startNewSession();
 
         sessionContext = getSessionContext(session, "event_2");
-        assertEquals(sessionId, (String)sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
+        assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals(2, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_2", sessionContext.get(Parameters.SESSION_FIRST_ID));
     }
 
     public void testMultipleTrackersUpdateDifferentSessions() throws InterruptedException {
-        cleanSharedPreferences(getContext(), "tracker1");
-        cleanSharedPreferences(getContext(), "tracker2");
+        cleanSharedPreferences(getContext(), TrackerConstants.SNOWPLOW_SESSION_VARS + "_tracker1");
+        cleanSharedPreferences(getContext(), TrackerConstants.SNOWPLOW_SESSION_VARS + "_tracker2");
 
         Emitter emitter = new Emitter(getContext(), "", null);
         Tracker tracker1 = new Tracker(new Tracker.TrackerBuilder(emitter, "tracker1", "app", getContext())
@@ -298,7 +372,7 @@ public class SessionTest extends AndroidTestCase {
     }
 
     private Map<String, Object> getSessionContext(Session session, String eventId) {
-        return (Map<String, Object>)session.getSessionContext(eventId).getMap().get(Parameters.DATA);
+        return (Map<String, Object>) session.getSessionContext(eventId).getMap().get(Parameters.DATA);
     }
 
     private void cleanSharedPreferences(Context context, String sharedPreferencesName) {
@@ -306,15 +380,10 @@ public class SessionTest extends AndroidTestCase {
         if (Build.VERSION.SDK_INT >= 24) {
             context.deleteSharedPreferences(sharedPreferencesName);
         } else {
-            SharedPreferences.Editor editor =
-                    context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE).edit();
-            editor.remove(Parameters.SESSION_USER_ID);
-            editor.remove(Parameters.SESSION_ID);
-            editor.remove(Parameters.SESSION_PREVIOUS_ID);
-            editor.remove(Parameters.SESSION_INDEX);
-            editor.remove(Parameters.SESSION_FIRST_ID);
-            editor.remove(Parameters.SESSION_STORAGE);
-            editor.commit();
+            context.getSharedPreferences(sharedPreferencesName, Context.MODE_PRIVATE)
+                    .edit()
+                    .clear()
+                    .commit();
         }
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -56,15 +56,15 @@ public class Session {
 
     // Session Variables
     private String userId;
-    private int backgroundIndex = 0;
-    private int foregroundIndex = 0;
+    private volatile int backgroundIndex = 0;
+    private volatile int foregroundIndex = 0;
     private SessionState state = null;
 
     // Variables to control Session Updates
     private final AtomicBoolean isBackground = new AtomicBoolean(false);
     private long lastSessionCheck;
     private final AtomicBoolean isNewSession = new AtomicBoolean(true);
-    private boolean isSessionCheckerEnabled;
+    private volatile boolean isSessionCheckerEnabled;
     private long foregroundTimeout;
     private long backgroundTimeout;
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -258,22 +258,17 @@ public class Session {
     }
 
     /**
-     * Updates the session with information about lifecycle tracking.
+     * Updates the session timeout and the indexes.
      * Note: Internal use only.
-     * @param isForeground whether or not the application moved to foreground.
-     * @return foreground or background index. Returns -1 if the lifecycle state is not changed.
+     * @param isBackground whether or not the application moved to background.
      */
-    public synchronized int updateLifecycleNotification(boolean isForeground) {
-        boolean toBackground = !isForeground;
-        // if the new lifecycle state confirms the session state, there isn't any lifecycle transition
-        if (isBackground.get() == toBackground) {
-            return -1;
+    public void setBackground(boolean isBackground) {
+        if (!this.isBackground.compareAndSet(!isBackground, isBackground)) {
+            return;
         }
-        Logger.d(TAG, "Application is in the background: %s", toBackground);
-        isBackground.set(toBackground);
 
-        if (!toBackground) {
-            Logger.d(TAG, "Application moved to foreground, starting session checking...");
+        if (!isBackground) {
+            Logger.d(TAG, "Application moved to foreground");
             this.executeEventCallback(this.foregroundTransitionCallback);
             try {
                 setIsSuspended(false);
@@ -281,12 +276,10 @@ public class Session {
                 Logger.e(TAG, "Could not resume checking as tracker not setup. Exception: %s", e);
             }
             foregroundIndex++;
-            return foregroundIndex;
         } else {
             Logger.d(TAG, "Application moved to background");
             this.executeEventCallback(this.backgroundTransitionCallback);
             backgroundIndex++;
-            return backgroundIndex;
         }
     }
 
@@ -306,11 +299,11 @@ public class Session {
         isSessionCheckerEnabled = !isSuspended;
     }
 
-    int getBackgroundIndex() {
+    public int getBackgroundIndex() {
         return backgroundIndex;
     }
 
-    int getForegroundIndex() {
+    public int getForegroundIndex() {
         return foregroundIndex;
     }
 


### PR DESCRIPTION
Not much to add to what is already described in the related issue (#499).

For Android this fix is much more complex because the event processing and the session management is different.
This is another part that should be fixed with the implementation of the session manager above the already implemented FSM system used for ScreenView management.

The solution I've adopted here is to move the session context attribution in an early stage of the event processing in order to avoid any race condition due to parallel processing of the events. Doing that we are able to reliably manage the sequence of the events. In particular we can check the session for `application_foreground` and `application_background` with the correct session timeout. It wouldn't be possible in a pure asynchronous approach that doesn't take care of the order the events enter in the tracker.


Suggested documentation:

---

## Session Context

Client session tracking is activated by default but it can be disabled through the TrackerConfiguration as explained above. When enabled the tracker appends a client_session context to each event it sends and it maintains this session information as long as the application is installed on the device.

Sessions correspond to tracked user activity. A session expires when no tracking events have occurred for the amount of time defined in a timeout (by default 30 minutes). The session timeout check is executed for each event tracked. If the gap between two consecutive events is longer than the timeout the session is renewed. There are two timeouts since a session can timeout in the foreground (while the app is visible) or in the background (when the app has been suspended, but not closed).

--added part--

The lifecycle events (`application_foreground` and `application_background` events) have a role in the session expiration. The lifecycle events can be enabled in the [TrackerConfiguration](https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/mobile-trackers/mobile-trackers-v3-0/introduction/#TrackerConfiguration) enabling `lifecycleAutotracking` (Note: on Android it requires `androidx.lifecycle:lifecycle-extensions`). Once enabled they will be fired automatically when the app moves from foreground state to background state and vice versa.

When the app moves from foreground to background the `application_background` event is fired. If session tracking is enabled, the session context will be attached to the event checking the session expiration using the foreground timeout.
When the app moves from background to foreground the `application_foreground` event is fired. If session tracking is enabled, the session context will be attached to the event checking the session expiration using the background timeout.

For instance, with this configuration:

```
SessionConfiguration(
    TimeMeasure(360L, TimeUnit.SECONDS),
    TimeMeasure(15L, TimeUnit.SECONDS)
)
```

the session would expire if the app is backgrounded for more than 15 seconds, like in this example:

```
time: 0s - screen_view event - foreground timeout session check - session 1
time: 3s - application_background event - foreground timeout session check (3 < 360) - session 1
time: 30s - application_foreground event - background timeout session check (30 > 15) - session 2
```

In the above example the `application_foreground` event triggers a new session because the time spent on background (without tracked events) is bigger than the background timeout for the session.
