### PR TITLE
Enable updating collector endpoint while Emitter is running (close #508)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.java
@@ -206,9 +206,9 @@ public class EmitterTest extends AndroidTestCase {
 
         assertTrue(emitter.getEmitterStatus());
         emitter.setHttpMethod(POST);
-        assertEquals("https://com.acme/i", emitter.getEmitterUri());
-        emitter.setEmitterUri("com/foo");
-        assertEquals("https://com.acme/i", emitter.getEmitterUri());
+        assertEquals("https://com.acme/com.snowplowanalytics.snowplow/tp2", emitter.getEmitterUri());
+        emitter.setEmitterUri("com.foo");
+        assertEquals("https://com.foo/com.snowplowanalytics.snowplow/tp2", emitter.getEmitterUri());
         emitter.setBufferOption(DefaultGroup);
         assertEquals(HeavyGroup, emitter.getBufferOption());
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.java
@@ -377,6 +377,18 @@ public class EmitterTest extends AndroidTestCase {
         emitter.flush();
     }
 
+    public void testUpdatesNetworkConnectionWhileRunning() throws InterruptedException {
+        Emitter emitter = new Emitter(getContext(), "com.acme", new Emitter.EmitterBuilder()
+                .eventStore(new MockEventStore()));
+
+        emitter.flush();
+        Thread.sleep(100);
+        assertTrue(emitter.getEmitterStatus()); // is running
+        emitter.setEmitterUri("new.uri"); // update while running
+        assertTrue(emitter.getEmitterStatus()); // is running
+        assertTrue(emitter.getEmitterUri().contains("new.uri"));
+    }
+
     // Emitter Builder
 
     public Emitter getEmitter(NetworkConnection networkConnection, BufferOption option) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
@@ -728,8 +728,6 @@ public class Emitter {
                     .customPostPath(customPostPath)
                     .client(client)
                     .build());
-        } else {
-            System.out.println("Failed to set emitter uri");
         }
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
@@ -525,6 +525,7 @@ public class Emitter {
      *
      * @param events a list of EmittableEvents pulled
      *               from the database.
+     * @param httpMethod HTTP method to use (passed in order to ensure consistency within attemptEmit)
      * @return a list of ready to send requests
      */
     @NonNull


### PR DESCRIPTION
This PR addresses issue #508 which reported that updating the network endpoint doesn't have any effect. I found that there are two possible reasons for this:

1. the Emitter is currently running, or
2. it uses a custom network connection.

I don't think that anything should happen in the second case. It sounds reasonable that custom network connections are not updated by setting the endpoint in tracker controller (let me know if you think otherwise).

But the first case is less intuitive and can be a problem for several reasons:

- the Tracker calls `flush()` on Emitter right after initialisation which means that the Emitter starts running and it is not possible to update the endpoint right after the tracker is initialised, and
- Emitters can be running for quite a long time. Even when all events are sent, `attemptEmit()` function goes to sleep a number of times checking for new events.

So I think it's reasonable to enable updating the network configuration while the Emitter is running. This PR enables that and removes the check from setters for network configuration in Emitter. I didn't want to have the network connection change during emitting and so I made the `attemptEmit` function accept a `NetworkConnection` to be used while it is running. The network connection is only refreshed in the `attemptEmit` after the sleep while waiting for new events.

I wrapped the `networkConnection` instance variable in an atomic reference. I don't think it's extra necessary in this case, probably it's overly cautious.