### PR TITLE
Attach LifecycleEntity before the first Background event (close #512) 

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/LifecycleStateMachine.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/LifecycleStateMachine.java
@@ -17,6 +17,16 @@ import java.util.Map;
 
 public class LifecycleStateMachine implements StateMachineInterface {
 
+    /*
+     States: Visible, NotVisible
+     Events: FG (Foreground), BG (Background)
+     Transitions:
+      - Visible (BG) NotVisible
+      - NotVisible (FG) Visible
+     Entity Generation:
+      - Visible, NotVisible
+     */
+
     @NonNull
     @Override
     public List<String> subscribedEventSchemasForTransitions() {


### PR DESCRIPTION
For issue #512.

Fixes the problem of LifecycleEntities not being attached to all events when LifecycleAutotracking is turned on.