### PR TITLE
 Add eventIndex and firstEventTimestamp properties to client sessions (close #517) 

### DIFF
--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
@@ -46,16 +46,16 @@ import java.util.UUID;
 public class TrackerEvents {
 
     public static void trackAll(@NonNull TrackerController tracker) {
-//        trackDeepLink(tracker);
+        trackDeepLink(tracker);
         trackPageView(tracker);
         trackStructuredEvent(tracker);
-//        trackScreenView(tracker);
-//        trackTimings(tracker);
-//        trackUnstructuredEvent(tracker);
-//        trackEcommerceEvent(tracker);
-//        trackConsentGranted(tracker);
-//        trackConsentWithdrawn(tracker);
-//        trackMessageNotification(tracker);
+        trackScreenView(tracker);
+        trackTimings(tracker);
+        trackUnstructuredEvent(tracker);
+        trackEcommerceEvent(tracker);
+        trackConsentGranted(tracker);
+        trackConsentWithdrawn(tracker);
+        trackMessageNotification(tracker);
     }
     
     private static void trackDeepLink(TrackerController tracker) {

--- a/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
+++ b/snowplow-demo-app/src/main/java/com/snowplowanalytics/snowplowtrackerdemo/utils/TrackerEvents.java
@@ -46,16 +46,16 @@ import java.util.UUID;
 public class TrackerEvents {
 
     public static void trackAll(@NonNull TrackerController tracker) {
-        trackDeepLink(tracker);
+//        trackDeepLink(tracker);
         trackPageView(tracker);
         trackStructuredEvent(tracker);
-        trackScreenView(tracker);
-        trackTimings(tracker);
-        trackUnstructuredEvent(tracker);
-        trackEcommerceEvent(tracker);
-        trackConsentGranted(tracker);
-        trackConsentWithdrawn(tracker);
-        trackMessageNotification(tracker);
+//        trackScreenView(tracker);
+//        trackTimings(tracker);
+//        trackUnstructuredEvent(tracker);
+//        trackEcommerceEvent(tracker);
+//        trackConsentGranted(tracker);
+//        trackConsentWithdrawn(tracker);
+//        trackMessageNotification(tracker);
     }
     
     private static void trackDeepLink(TrackerController tracker) {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
@@ -15,7 +15,7 @@ public class UtilTest extends AndroidTestCase {
 
     public void testGetDateTimeFromTimestamp() {
         long timestamp = 1653923456266L;
-        assertEquals("2022-05-30T16:10:56.266Z", Util.getDateTimeFromTimestamp(timestamp));
+        assertEquals("2022-05-30T15:10:56.266Z", Util.getDateTimeFromTimestamp(timestamp));
     }
 
     public void testBase64Encode() {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
@@ -15,7 +15,7 @@ public class UtilTest extends AndroidTestCase {
 
     public void testGetDateTimeFromTimestamp() {
         long timestamp = 1653923456266L;
-        assertEquals("2022-05-30T16:10:56Z", Util.getDateTimeFromTimestamp(timestamp));
+        assertEquals("2022-05-30T16:10:56.266Z", Util.getDateTimeFromTimestamp(timestamp));
     }
 
     public void testBase64Encode() {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
@@ -13,6 +13,11 @@ public class UtilTest extends AndroidTestCase {
         assertEquals(13, Util.getTimestamp().length());
     }
 
+    public void testGetDateTimeFromTimestamp() {
+        long timestamp = 1653923456266L;
+        assertEquals("2022-05-30T16:10:56Z", Util.getDateTimeFromTimestamp(timestamp));
+    }
+
     public void testBase64Encode() {
         assertEquals("Zm9v", Util.base64Encode("foo"));
     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertNotEquals;
 public class SessionTest extends AndroidTestCase {
 
     long timestamp = 1234567891012L;
-    String timestampDateTime = "2009-02-13T23:31:31Z";
+    String timestampDateTime = "2009-02-13T23:31:31.012Z";
 
     @Override
     protected void setUp() throws Exception {
@@ -83,7 +83,7 @@ public class SessionTest extends AndroidTestCase {
 
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
         assertEquals("LOCAL_STORAGE", sessionContext.get(Parameters.SESSION_STORAGE));
     }
 
@@ -96,7 +96,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
 
         Thread.sleep(100);
 
@@ -105,7 +105,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-//        assertEquals(2, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+        assertEquals(2, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
 
         Thread.sleep(15100);
 
@@ -113,8 +113,8 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals(2, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
-        assertEquals("2009-02-13T23:31:41Z", sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+        assertEquals("2009-02-13T23:31:41.012Z", sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
+        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
     }
 
     public void testBackgroundEventsOnSameSession() throws InterruptedException {
@@ -128,7 +128,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
 
         Thread.sleep(100);
 
@@ -137,7 +137,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_ID));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-//        assertEquals(2, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+        assertEquals(2, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
 
         Thread.sleep(15100);
 
@@ -145,8 +145,8 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(2, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
-        assertEquals("2009-02-13T23:31:41Z", sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+        assertEquals("2009-02-13T23:31:41.012Z", sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
+        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
     }
 
     public void testMixedEventsOnManySessions() throws InterruptedException {
@@ -158,7 +158,6 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
         String oldSessionId = sessionId;
 
         session.setBackground(true);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -357,11 +357,13 @@ public class SessionTest extends AndroidTestCase {
         long initialValue2 = session2.getSessionIndex();
 
         // Retrigger session in tracker1
+        // The timeout is 20s, this sleep is only 2s - it's still the same session
         Thread.sleep(2000);
         session1.getSessionContext("fake-id2", timestamp);
         Thread.sleep(18000);
 
         // Retrigger timedout session in tracker2
+        // 20s has passed. Session must be updated, increasing the sessionIndex by 1
         session2.getSessionContext("fake-id2", timestamp);
 
         // Check sessions have the correct state

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -349,8 +349,8 @@ public class SessionTest extends AndroidTestCase {
         Session session1 = tracker1.getSession();
         Session session2 = tracker2.getSession();
 
-        session1.getSessionContext("fake-id1", timestamp);
-        session2.getSessionContext("fake-id1", timestamp);
+        session1.getSessionContext("session1-fake-id1", timestamp);
+        session2.getSessionContext("session2-fake-id1", timestamp);
 
         long initialValue1 = session1.getSessionIndex();
         String id1 = session1.getState().getSessionId();
@@ -359,12 +359,12 @@ public class SessionTest extends AndroidTestCase {
         // Retrigger session in tracker1
         // The timeout is 20s, this sleep is only 2s - it's still the same session
         Thread.sleep(2000);
-        session1.getSessionContext("fake-id2", timestamp);
-        Thread.sleep(18000);
+        session1.getSessionContext("session1-fake-id2", timestamp);
 
         // Retrigger timedout session in tracker2
-        // 20s has passed. Session must be updated, increasing the sessionIndex by 1
-        session2.getSessionContext("fake-id2", timestamp);
+        // 20s has then passed. Session must be updated, increasing the sessionIndex by 1
+        Thread.sleep(18000);
+        session2.getSessionContext("session2-fake-id2", timestamp);
 
         // Check sessions have the correct state
         assertEquals(0, session1.getSessionIndex() - initialValue1);
@@ -377,7 +377,7 @@ public class SessionTest extends AndroidTestCase {
                 .foregroundTimeout(20)
                 .backgroundTimeout(20)
         );
-        tracker2b.getSession().getSessionContext("fake-id3", timestamp);
+        tracker2b.getSession().getSessionContext("session2b-fake-id3", timestamp);
         long initialValue2b = tracker2b.getSession().getSessionIndex();
         String previousId2b = tracker2b.getSession().getState().getPreviousSessionId();
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -62,12 +62,10 @@ public class SessionTest extends AndroidTestCase {
         assertNotNull(sessionState);
         assertEquals("first-id-1", sessionState.getFirstEventId());
         assertEquals(timestampDateTime, sessionState.getFirstEventTimestamp());
-        assertEquals(1, sessionState.getEventIndex());
 
         session.getSessionContext("second-id-2", timestamp + 10000);
         assertEquals("first-id-1", sessionState.getFirstEventId());
         assertEquals(timestampDateTime, sessionState.getFirstEventTimestamp());
-        assertEquals(2, sessionState.getEventIndex());
 
         assertEquals(TrackerConstants.SESSION_SCHEMA, sdj.getMap().get("schema"));
     }
@@ -85,7 +83,7 @@ public class SessionTest extends AndroidTestCase {
 
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
         assertEquals("LOCAL_STORAGE", sessionContext.get(Parameters.SESSION_STORAGE));
     }
 
@@ -98,7 +96,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
 
         Thread.sleep(100);
 
@@ -107,7 +105,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-        assertEquals(2, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+//        assertEquals(2, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
 
         Thread.sleep(15100);
 
@@ -116,7 +114,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(2, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals("2009-02-13T23:31:41Z", sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
     }
 
     public void testBackgroundEventsOnSameSession() throws InterruptedException {
@@ -130,7 +128,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
 
         Thread.sleep(100);
 
@@ -139,7 +137,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_ID));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-        assertEquals(2, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+//        assertEquals(2, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
 
         Thread.sleep(15100);
 
@@ -148,7 +146,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(sessionId, (String) sessionContext.get(Parameters.SESSION_PREVIOUS_ID));
         assertEquals("event_3", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals("2009-02-13T23:31:41Z", sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
     }
 
     public void testMixedEventsOnManySessions() throws InterruptedException {
@@ -160,7 +158,7 @@ public class SessionTest extends AndroidTestCase {
         assertEquals(1, sessionContext.get(Parameters.SESSION_INDEX));
         assertEquals("event_1", sessionContext.get(Parameters.SESSION_FIRST_ID));
         assertEquals(timestampDateTime, sessionContext.get(Parameters.SESSION_FIRST_TIMESTAMP));
-        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
+//        assertEquals(1, sessionContext.get(Parameters.SESSION_EVENT_INDEX));
         String oldSessionId = sessionId;
 
         session.setBackground(true);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -106,7 +106,7 @@ public class EventSendingTest extends AndroidTestCase {
 
     public void testSendGet() throws Exception {
         MockWebServer mockServer = getMockServer(14);
-        Tracker tracker = getTracker(getMockServerURI(mockServer), HttpMethod.GET);
+        Tracker tracker = getTracker("namespace", getMockServerURI(mockServer), HttpMethod.GET);
 
         trackStructuredEvent(tracker);
         trackUnstructuredEvent(tracker);
@@ -125,7 +125,7 @@ public class EventSendingTest extends AndroidTestCase {
 
     public void testSendPost() throws Exception {
         MockWebServer mockServer = getMockServer(14);
-        Tracker tracker = getTracker(getMockServerURI(mockServer), HttpMethod.POST);
+        Tracker tracker = getTracker("namespace", getMockServerURI(mockServer), HttpMethod.POST);
 
         trackStructuredEvent(tracker);
         trackUnstructuredEvent(tracker);
@@ -144,7 +144,7 @@ public class EventSendingTest extends AndroidTestCase {
 
     public void testSessionContext() throws Exception {
         MockWebServer mockServer = getMockServer(14);
-        Tracker tracker = getTracker(getMockServerURI(mockServer), HttpMethod.POST);
+        Tracker tracker = getTracker("namespaceSessionTest", getMockServerURI(mockServer), HttpMethod.POST);
 
         tracker.track(new ScreenView("screenName_1"));
         tracker.track(new Structured("category_1", "action_1"));
@@ -212,8 +212,7 @@ public class EventSendingTest extends AndroidTestCase {
     // Helpers
 
     @NonNull
-    public Tracker getTracker(String uri, HttpMethod method) {
-        String namespace = "myNamespace";
+    public Tracker getTracker(String namespace, String uri, HttpMethod method) {
         TestUtils.createSessionSharedPreferences(getContext(), namespace);
 
         Emitter emitter = new Emitter(getContext(), uri, new Emitter.EmitterBuilder()

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -106,7 +106,7 @@ public class EventSendingTest extends AndroidTestCase {
 
     public void testSendGet() throws Exception {
         MockWebServer mockServer = getMockServer(14);
-        Tracker tracker = getTracker("namespace", getMockServerURI(mockServer), HttpMethod.GET);
+        Tracker tracker = getTracker("myNamespace", getMockServerURI(mockServer), HttpMethod.GET);
 
         trackStructuredEvent(tracker);
         trackUnstructuredEvent(tracker);
@@ -125,7 +125,7 @@ public class EventSendingTest extends AndroidTestCase {
 
     public void testSendPost() throws Exception {
         MockWebServer mockServer = getMockServer(14);
-        Tracker tracker = getTracker("namespace", getMockServerURI(mockServer), HttpMethod.POST);
+        Tracker tracker = getTracker("myNamespace", getMockServerURI(mockServer), HttpMethod.POST);
 
         trackStructuredEvent(tracker);
         trackUnstructuredEvent(tracker);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -148,14 +148,8 @@ public class EventSendingTest extends AndroidTestCase {
         MockWebServer mockServer = getMockServer(14);
         Tracker tracker = getTracker(getMockServerURI(mockServer), HttpMethod.POST);
 
-
-        EcommerceTransactionItem item = new EcommerceTransactionItem("sku-1", 35.00, 1).name("Acme 1").category("Stuff").currency("AUD");
-        List<EcommerceTransactionItem> items = new LinkedList<>();
-        items.add(item);
-
         tracker.track(new ScreenView("screenName_1"));
         tracker.track(new Structured("category_1", "action_1"));
-        tracker.track(new EcommerceTransaction("order-1", 42.50, items));
         tracker.startNewSession();
         Thread.sleep(1000);
         tracker.track(new Structured("category_2", "action_2"));
@@ -163,12 +157,10 @@ public class EventSendingTest extends AndroidTestCase {
 
         waitForTracker(tracker);
 
-        LinkedList<RecordedRequest> requests = getRequests(mockServer, 6);
+        LinkedList<RecordedRequest> requests = getRequests(mockServer, 4);
 
         JSONObject screenViewSessionData = null;
         JSONObject structSessionData_1 = null;
-        JSONObject transactionSessionData = null;
-        JSONObject transactionItemSessionData = null;
         JSONObject structSessionData_2 = null;
         JSONObject structSessionData_3 = null;
 
@@ -190,10 +182,6 @@ public class EventSendingTest extends AndroidTestCase {
                         structSessionData_3 = getSessionData(contexts);
                     }
                     break;
-                case "tr" : transactionSessionData = getSessionData(contexts);
-                    break;
-                case "ti" : transactionItemSessionData = getSessionData(contexts);
-                    break;
                 default : break;
             }
 
@@ -201,7 +189,6 @@ public class EventSendingTest extends AndroidTestCase {
 
         Logger.d("test ❗️", String.valueOf(screenViewSessionData));
         Logger.d("test ❗❗️", String.valueOf(structSessionData_1));
-        Logger.d("test ❗❗❗️", String.valueOf(transactionSessionData));
         Logger.d("test ❗x❗️", String.valueOf(structSessionData_2));
         Logger.d("test ❗x❗x️❗", String.valueOf(structSessionData_3));
 
@@ -216,7 +203,6 @@ public class EventSendingTest extends AndroidTestCase {
 
         assertEquals(1, screenViewSessionData.get("eventIndex"));
         assertEquals(2, structSessionData_1.get("eventIndex"));
-        assertEquals(3, transactionSessionData.get("eventIndex"));
         assertEquals(1, structSessionData_2.get("eventIndex"));
         assertEquals(2, structSessionData_3.get("eventIndex"));
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -23,7 +23,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.TestUtils;
-import com.snowplowanalytics.snowplow.internal.tracker.Logger;
 import com.snowplowanalytics.snowplow.tracker.BuildConfig;
 import com.snowplowanalytics.snowplow.internal.emitter.Emitter;
 import com.snowplowanalytics.snowplow.internal.tracker.Subject;
@@ -57,7 +56,6 @@ import org.json.JSONObject;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -158,7 +156,6 @@ public class EventSendingTest extends AndroidTestCase {
         waitForTracker(tracker);
 
         LinkedList<RecordedRequest> requests = getRequests(mockServer, 4);
-
         JSONObject screenViewSessionData = null;
         JSONObject structSessionData_1 = null;
         JSONObject structSessionData_2 = null;
@@ -190,13 +187,6 @@ public class EventSendingTest extends AndroidTestCase {
             }
 
         }
-
-        Logger.d("test ❗️", String.valueOf(screenViewSessionData));
-        Logger.d("test ❗❗️", String.valueOf(structSessionData_1));
-        Logger.d("test ❗x❗️", String.valueOf(structSessionData_2));
-        Logger.d("test ❗xx️❗", String.valueOf(structSessionData_3));
-
-//        Thread.sleep(500);
 
         assertEquals(1, screenViewSessionData.get("sessionIndex"));
         assertEquals(2, structSessionData_2.get("sessionIndex"));
@@ -302,14 +292,6 @@ public class EventSendingTest extends AndroidTestCase {
         }
         Thread.sleep(500);
         tracker.pauseEventTracking();
-    }
-
-    public Map<String, JSONArray> getContextsFromTrackedEvent(RecordedRequest request) throws Exception {
-        JSONObject data = new JSONObject(request.getBody().readUtf8()).getJSONArray("data").getJSONObject(0);
-        JSONArray contexts = new JSONObject((String) data.get("co")).getJSONArray("data");
-        String eventType = (String) data.get("e");
-
-        return Collections.singletonMap(eventType, contexts);
     }
 
     public JSONObject getSessionData(JSONArray contexts) throws JSONException {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.java
@@ -174,12 +174,16 @@ public class EventSendingTest extends AndroidTestCase {
                     break;
                 case "se" :
                     String category = (String) data.get("se_ca");
-                    if (category.equals("category_1")) {
-                        structSessionData_1 = getSessionData(contexts);
-                    } else if (category.equals("category_2"))  {
-                        structSessionData_2 = getSessionData(contexts);
-                    } else {
-                        structSessionData_3 = getSessionData(contexts);
+                    switch (category) {
+                        case "category_1":
+                            structSessionData_1 = getSessionData(contexts);
+                            break;
+                        case "category_2":
+                            structSessionData_2 = getSessionData(contexts);
+                            break;
+                        case "category_3":
+                            structSessionData_3 = getSessionData(contexts);
+                            break;
                     }
                     break;
                 default : break;
@@ -190,7 +194,7 @@ public class EventSendingTest extends AndroidTestCase {
         Logger.d("test ❗️", String.valueOf(screenViewSessionData));
         Logger.d("test ❗❗️", String.valueOf(structSessionData_1));
         Logger.d("test ❗x❗️", String.valueOf(structSessionData_2));
-        Logger.d("test ❗x❗x️❗", String.valueOf(structSessionData_3));
+        Logger.d("test ❗xx️❗", String.valueOf(structSessionData_3));
 
 //        Thread.sleep(500);
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/Parameters.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/Parameters.java
@@ -138,8 +138,10 @@ public class Parameters {
     public static final String SESSION_ID = "sessionId";
     public static final String SESSION_PREVIOUS_ID = "previousSessionId";
     public static final String SESSION_INDEX = "sessionIndex";
+    public static final String SESSION_EVENT_INDEX = "eventIndex";
     public static final String SESSION_STORAGE = "storageMechanism";
     public static final String SESSION_FIRST_ID = "firstEventId";
+    public static final String SESSION_FIRST_TIMESTAMP = "firstEventTimestamp";
 
     // Screen Context
     public static final String SCREEN_NAME = "name";

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/TrackerConstants.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/constants/TrackerConstants.java
@@ -31,7 +31,7 @@ public class TrackerConstants {
     public static final String SCHEMA_CONSENT_DOCUMENT = "iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0";
     public static final String GEOLOCATION_SCHEMA = "iglu:com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-1-0";
     public static final String MOBILE_SCHEMA = "iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2";
-    public static final String SESSION_SCHEMA = "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-1";
+    public static final String SESSION_SCHEMA = "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2";
     public static final String APPLICATION_ERROR_SCHEMA = "iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-0";
     public static final String SCHEMA_SCREEN = "iglu:com.snowplowanalytics.mobile/screen/jsonschema/1-0-0";
     public static final String SCHEMA_APPLICATION_INSTALL = "iglu:com.snowplowanalytics.mobile/application_install/jsonschema/1-0-0";

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -37,7 +37,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Component that generate a Session context
@@ -200,9 +199,9 @@ public class Session {
         eventIndex += 1;
 
         Map<String, Object> sessionValues = state.getSessionValues();
-        sessionValues.put(Parameters.SESSION_EVENT_INDEX, eventIndex);
         Map<String, Object> sessionCopy = new HashMap<>();
         sessionCopy.putAll(sessionValues);
+        sessionCopy.put(Parameters.SESSION_EVENT_INDEX, eventIndex);
 
         return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionCopy);
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -204,7 +204,7 @@ public class Session {
         Map<String, Object> sessionCopy = new HashMap<>();
         sessionCopy.putAll(sessionValues);
 
-        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionCopy);
+        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionValues);
     }
 
     private boolean shouldUpdateSession() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -201,7 +201,10 @@ public class Session {
 
         Map<String, Object> sessionValues = state.getSessionValues();
         sessionValues.put(Parameters.SESSION_EVENT_INDEX, eventIndex);
-        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionValues);
+        Map<String, Object> sessionCopy = new HashMap<>();
+        sessionCopy.putAll(sessionValues);
+
+        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionCopy);
     }
 
     private boolean shouldUpdateSession() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -204,7 +204,7 @@ public class Session {
         Map<String, Object> sessionCopy = new HashMap<>();
         sessionCopy.putAll(sessionValues);
 
-        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionValues);
+        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionCopy);
     }
 
     private boolean shouldUpdateSession() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -59,6 +59,7 @@ public class Session {
     private String userId;
     private volatile int backgroundIndex = 0;
     private volatile int foregroundIndex = 0;
+    private int eventIndex = 0;
     private SessionState state = null;
 
     // Variables to control Session Updates
@@ -194,10 +195,13 @@ public class Session {
                     this.executeEventCallback(foregroundTimeoutCallback);
                 }
             }
-            state.incrementEventIndex();
             lastSessionCheck = System.currentTimeMillis();
         }
-        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, state.getSessionValues());
+        eventIndex += 1;
+
+        Map<String, Object> sessionValues = state.getSessionValues();
+        sessionValues.put(Parameters.SESSION_EVENT_INDEX, eventIndex);
+        return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionValues);
     }
 
     private boolean shouldUpdateSession() {
@@ -215,7 +219,7 @@ public class Session {
         String eventTimestampDateTime = Util.getDateTimeFromTimestamp(eventTimestamp);
 
         int sessionIndex = 1;
-        int eventIndex = 0;
+        eventIndex = 0;
         String previousSessionId = null;
         String storage = "LOCAL_STORAGE";
         if (state != null) {
@@ -223,7 +227,7 @@ public class Session {
             previousSessionId = state.getSessionId();
             storage = state.getStorage();
         }
-        state = new SessionState(eventId, eventTimestampDateTime, currentSessionId, previousSessionId, sessionIndex, eventIndex, userId, storage);
+        state = new SessionState(eventId, eventTimestampDateTime, currentSessionId, previousSessionId, sessionIndex, userId, storage);
         storeSessionState(state);
         callOnSessionUpdateCallback(state);
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Component that generate a Session context

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -714,12 +714,13 @@ public class Tracker {
     private void workaroundForIncoherentSessionContext(@NonNull TrackerEvent event) {
         if (!event.isService && sessionContext) {
             String eventId = event.eventId.toString();
+            long eventTimestamp = event.timestamp;
             Session sessionManager = trackerSession;
             if (sessionManager == null) {
                 Logger.track(TAG, "Session not ready or method getHasLoadedFromFile returned false with eventId: %s", eventId);
                 return;
             }
-            SelfDescribingJson sessionContextJson = sessionManager.getSessionContext(eventId);
+            SelfDescribingJson sessionContextJson = sessionManager.getSessionContext(eventId, eventTimestamp);
             event.contexts.add(sessionContextJson);
         }
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -721,7 +721,6 @@ public class Tracker {
                 return;
             }
             SelfDescribingJson sessionContextJson = sessionManager.getSessionContext(eventId, eventTimestamp);
-            Logger.d("Tracker ❗️", String.valueOf(sessionContextJson));
             event.contexts.add(sessionContextJson);
         }
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -721,6 +721,7 @@ public class Tracker {
                 return;
             }
             SelfDescribingJson sessionContextJson = sessionManager.getSessionContext(eventId, eventTimestamp);
+            Logger.d("Tracker ❗️", String.valueOf(sessionContextJson));
             event.contexts.add(sessionContextJson);
         }
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
@@ -39,6 +39,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +63,12 @@ public class Util {
     @NonNull
     public static String getTimestamp() {
         return Long.toString(System.currentTimeMillis());
+    }
+
+    public static String getDateTimeFromTimestamp(long timestamp) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        Date date = new Date(timestamp);
+        return dateFormat.format(date);
     }
 
     /**

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
@@ -66,7 +66,7 @@ public class Util {
     }
 
     public static String getDateTimeFromTimestamp(long timestamp) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
         Date date = new Date(timestamp);
         return dateFormat.format(date);
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.java
@@ -22,7 +22,6 @@ public class SessionState implements State {
     @Nullable
     private final String previousSessionId;
     private final int sessionIndex;
-    private AtomicInteger eventIndex;
     @NonNull
     private final String userId;
     @NonNull
@@ -37,7 +36,6 @@ public class SessionState implements State {
             @NonNull String currentSessionId,
             @Nullable String previousSessionId, //$ On iOS it has to be set nullable on constructor
             int sessionIndex,
-            int eventIndex,
             @NonNull String userId,
             @NonNull String storage
     ) {
@@ -46,7 +44,6 @@ public class SessionState implements State {
         this.sessionId = currentSessionId;
         this.previousSessionId = previousSessionId;
         this.sessionIndex = sessionIndex;
-        this.eventIndex = new AtomicInteger(eventIndex);
         this.userId = userId;
         this.storage = storage;
 
@@ -56,7 +53,6 @@ public class SessionState implements State {
         sessionContext.put(Parameters.SESSION_ID, sessionId);
         sessionContext.put(Parameters.SESSION_PREVIOUS_ID, previousSessionId);
         sessionContext.put(Parameters.SESSION_INDEX, sessionIndex); //$ should be Number?!
-        sessionContext.put(Parameters.SESSION_EVENT_INDEX, this.eventIndex.get());
         sessionContext.put(Parameters.SESSION_USER_ID, userId);
         sessionContext.put(Parameters.SESSION_STORAGE, storage);
     }
@@ -85,10 +81,6 @@ public class SessionState implements State {
         if (!(value instanceof Integer)) return null;
         int sessionIndex = (Integer) value;
 
-        value = storedState.get(Parameters.SESSION_EVENT_INDEX);
-        if (!(value instanceof Integer)) return null;
-        int eventIndex = (Integer) value;
-
         value = storedState.get(Parameters.SESSION_USER_ID);
         if (!(value instanceof String)) return null;
         String userId = (String) value;
@@ -97,12 +89,7 @@ public class SessionState implements State {
         if (!(value instanceof String)) return null;
         String storage = (String) value;
 
-        return new SessionState(firstEventId, firstEventTimestamp, sessionId, previousSessionId, sessionIndex, eventIndex, userId, storage);
-    }
-
-    public void incrementEventIndex() {
-        Logger.d("SessionState ❌", "incrementEventIndex called. EventIndex is: " + eventIndex.get());
-        sessionContext.put(Parameters.SESSION_EVENT_INDEX, eventIndex.incrementAndGet());
+        return new SessionState(firstEventId, firstEventTimestamp, sessionId, previousSessionId, sessionIndex, userId, storage);
     }
 
     // Getters
@@ -130,8 +117,6 @@ public class SessionState implements State {
     public int getSessionIndex() {
         return sessionIndex;
     }
-
-    public int getEventIndex() { return eventIndex.get(); }
 
     @NonNull
     public String getStorage() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.java
@@ -4,12 +4,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.internal.constants.Parameters;
-import com.snowplowanalytics.snowplow.internal.tracker.Logger;
 import com.snowplowanalytics.snowplow.internal.tracker.State;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class SessionState implements State {
 
@@ -28,7 +26,7 @@ public class SessionState implements State {
     private final String storage;
 
     @NonNull
-    private Map<String, Object> sessionContext;
+    private final Map<String, Object> sessionContext;
 
     public SessionState(
             @NonNull String firstEventId,
@@ -47,7 +45,7 @@ public class SessionState implements State {
         this.userId = userId;
         this.storage = storage;
 
-        sessionContext = new HashMap<String, Object>();
+        sessionContext = new HashMap<>();
         sessionContext.put(Parameters.SESSION_FIRST_ID, firstEventId);
         sessionContext.put(Parameters.SESSION_FIRST_TIMESTAMP, firstEventTimestamp);
         sessionContext.put(Parameters.SESSION_ID, sessionId);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.java
@@ -62,7 +62,7 @@ public class SessionState implements State {
         String firstEventId = (String) value;
 
         value = storedState.get(Parameters.SESSION_FIRST_TIMESTAMP);
-        if (!(value instanceof Long)) return null;
+        if (!(value instanceof String)) return null;
         String firstEventTimestamp = (String) value;
 
         value = storedState.get(Parameters.SESSION_ID);


### PR DESCRIPTION
For issue #517.

Adds the new properties of the 1-0-2 version of the client_session schema.

- EventIndex – Index of the current event in the session, starting from 1.
- FirstEventTimestamp – Datetime timestamp of when the first event in the session was tracked.

This change also adds a test for the session context entity.