### PR TITLE
Add a customizable set of failure HTTP status codes for which collector requests should not be retried (close #518)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.java
@@ -14,14 +14,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 class MockNetworkConnection implements NetworkConnection {
-    public boolean successfulConnection;
+    public int statusCode;
     public HttpMethod httpMethod;
 
     public final List<List<RequestResult>> previousResults = new ArrayList<>();
 
-    public MockNetworkConnection(HttpMethod httpMethod, boolean successfulConnection) {
+    public MockNetworkConnection(HttpMethod httpMethod, int statusCode) {
         this.httpMethod = httpMethod;
-        this.successfulConnection = successfulConnection;
+        this.statusCode = statusCode;
     }
 
     public int sendingCount() {
@@ -33,9 +33,8 @@ class MockNetworkConnection implements NetworkConnection {
     public List<RequestResult> sendRequests(@NonNull List<Request> requests) {
         List<RequestResult> requestResults = new ArrayList<>(requests.size());
         for (Request request : requests) {
-            boolean isSuccessful = request.oversize || successfulConnection;
-            RequestResult result = new RequestResult(isSuccessful, request.emitterEventIds);
-            Logger.v("MockNetworkConnection", "Sent: %s with success: %s", request.emitterEventIds, Boolean.valueOf(isSuccessful).toString());
+            RequestResult result = new RequestResult(statusCode, request.oversize, request.emitterEventIds);
+            Logger.v("MockNetworkConnection", "Sent: %s with success: %s", request.emitterEventIds, Boolean.valueOf(result.isSuccessful()).toString());
             requestResults.add(result);
         }
         previousResults.add(requestResults);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/NetworkConnectionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/NetworkConnectionTest.java
@@ -69,7 +69,7 @@ public class NetworkConnectionTest extends AndroidTestCase {
 
         // Check successful result
         RequestResult result = results.get(0);
-        assertTrue(result.getSuccess());
+        assertTrue(result.isSuccessful());
         assertEquals(1, result.getEventIds().get(0).longValue());
 
         mockServer.shutdown();
@@ -94,7 +94,7 @@ public class NetworkConnectionTest extends AndroidTestCase {
 
         // Check unsuccessful result
         RequestResult result = results.get(0);
-        assertFalse(result.getSuccess());
+        assertFalse(result.isSuccessful());
         assertEquals(1, result.getEventIds().get(0).longValue());
 
         mockServer.shutdown();
@@ -125,7 +125,7 @@ public class NetworkConnectionTest extends AndroidTestCase {
 
         // Check successful result
         RequestResult result = results.get(0);
-        assertTrue(result.getSuccess());
+        assertTrue(result.isSuccessful());
         assertEquals(1, result.getEventIds().get(0).longValue());
 
         mockServer.shutdown();
@@ -151,7 +151,7 @@ public class NetworkConnectionTest extends AndroidTestCase {
 
         // Check unsuccessful result
         RequestResult result = results.get(0);
-        assertFalse(result.getSuccess());
+        assertFalse(result.isSuccessful());
         assertEquals(1, result.getEventIds().get(0).longValue());
 
         mockServer.shutdown();

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/RequestResultTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/RequestResultTest.java
@@ -1,16 +1,25 @@
 package com.snowplowanalytics.snowplow.tracker;
 
-import android.test.AndroidTestCase;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.snowplowanalytics.snowplow.network.RequestResult;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-public class RequestResultTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class RequestResultTest {
 
+    @Test
     public void testSuccessfulRequest() {
         RequestResult result = new RequestResult(200, false, Arrays.asList(100L));
         assertTrue(result.isSuccessful());
@@ -19,24 +28,28 @@ public class RequestResultTest extends AndroidTestCase {
         assertEquals(result.getEventIds(), Arrays.asList(100L));
     }
 
+    @Test
     public void testFailedRequest() {
         RequestResult result = new RequestResult(500, false, new ArrayList<>());
         assertFalse(result.isSuccessful());
         assertTrue(result.shouldRetry(new HashMap<>()));
     }
 
+    @Test
     public void testOversizedFailedRequest() {
         RequestResult result = new RequestResult(500, true, new ArrayList<>());
         assertFalse(result.isSuccessful());
         assertFalse(result.shouldRetry(new HashMap<>()));
     }
 
+    @Test
     public void testFailedRequestWithNoRetryStatus() {
         RequestResult result = new RequestResult(403, false, new ArrayList<>());
         assertFalse(result.isSuccessful());
         assertFalse(result.shouldRetry(new HashMap<>()));
     }
 
+    @Test
     public void testFailedRequestWithCustomRetryRules() {
         Map<Integer, Boolean> customRetry = new HashMap<>();
         customRetry.put(403, true);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/RequestResultTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/RequestResultTest.java
@@ -1,0 +1,54 @@
+package com.snowplowanalytics.snowplow.tracker;
+
+import android.test.AndroidTestCase;
+
+import com.snowplowanalytics.snowplow.network.RequestResult;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RequestResultTest extends AndroidTestCase {
+
+    public void testSuccessfulRequest() {
+        RequestResult result = new RequestResult(200, false, Arrays.asList(100L));
+        assertTrue(result.isSuccessful());
+        assertFalse(result.isOversize());
+        assertFalse(result.shouldRetry(new HashMap<>()));
+        assertEquals(result.getEventIds(), Arrays.asList(100L));
+    }
+
+    public void testFailedRequest() {
+        RequestResult result = new RequestResult(500, false, new ArrayList<>());
+        assertFalse(result.isSuccessful());
+        assertTrue(result.shouldRetry(new HashMap<>()));
+    }
+
+    public void testOversizedFailedRequest() {
+        RequestResult result = new RequestResult(500, true, new ArrayList<>());
+        assertFalse(result.isSuccessful());
+        assertFalse(result.shouldRetry(new HashMap<>()));
+    }
+
+    public void testFailedRequestWithNoRetryStatus() {
+        RequestResult result = new RequestResult(403, false, new ArrayList<>());
+        assertFalse(result.isSuccessful());
+        assertFalse(result.shouldRetry(new HashMap<>()));
+    }
+
+    public void testFailedRequestWithCustomRetryRules() {
+        Map<Integer, Boolean> customRetry = new HashMap<>();
+        customRetry.put(403, true);
+        customRetry.put(500, false);
+
+        RequestResult result = new RequestResult(403, false, new ArrayList<>());
+        assertFalse(result.isSuccessful());
+        assertTrue(result.shouldRetry(customRetry));
+
+        result = new RequestResult(500, false, new ArrayList<>());
+        assertFalse(result.isSuccessful());
+        assertFalse(result.shouldRetry(customRetry));
+    }
+
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/ServiceProviderTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/ServiceProviderTest.java
@@ -36,7 +36,7 @@ public class ServiceProviderTest extends AndroidTestCase {
         trackerConfig.lifecycleAutotracking = false;
         trackerConfig.screenViewAutotracking = false;
         trackerConfig.diagnosticAutotracking = false;
-        MockNetworkConnection networkConnection = new MockNetworkConnection(POST, true);
+        MockNetworkConnection networkConnection = new MockNetworkConnection(POST, 200);
         networkConfig.networkConnection = networkConnection;
         List<Configuration> configurations = new ArrayList<>();
         configurations.add(trackerConfig);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.java
@@ -8,6 +8,8 @@ import com.snowplowanalytics.snowplow.internal.emitter.EmitterConfigurationInter
 import com.snowplowanalytics.snowplow.network.RequestCallback;
 import com.snowplowanalytics.snowplow.emitter.EventStore;
 
+import java.util.Map;
+
 /**
  * It allows the tracker configuration from the emission perspective.
  * The EmitterConfiguration can be used to setup details about how the tracker should treat the events
@@ -52,6 +54,12 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
      */
     @Nullable
     public EventStore eventStore;
+
+    /**
+     * @see #customRetryForStatusCodes(Map)
+     */
+    @Nullable
+    public Map<Integer, Boolean> customRetryForStatusCodes;
 
     // Constructor
 
@@ -141,6 +149,16 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
         this.requestCallback = requestCallback;
     }
 
+    @Nullable
+    @Override
+    public Map<Integer, Boolean> getCustomRetryForStatusCodes() {
+        return customRetryForStatusCodes;
+    }
+
+    @Override
+    public void setCustomRetryForStatusCodes(@Nullable Map<Integer, Boolean> customRetryForStatusCodes) {
+        this.customRetryForStatusCodes = customRetryForStatusCodes;
+    }
 
     // Builders
 
@@ -209,6 +227,16 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
         return this;
     }
 
+    /**
+     * Custom retry rules for HTTP status codes returned from the Collector.
+     * The dictionary is a mapping of integers (status codes) to booleans (true for retry and false for not retry).
+     */
+    @NonNull
+    public EmitterConfiguration customRetryForStatusCodes(@Nullable Map<Integer, Boolean> customRetryForStatusCodes) {
+        this.customRetryForStatusCodes = customRetryForStatusCodes;
+        return this;
+    }
+
     // Copyable
 
     @Override
@@ -222,6 +250,7 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
         copy.byteLimitPost = byteLimitPost;
         copy.eventStore = eventStore;
         copy.requestCallback = requestCallback;
+        copy.customRetryForStatusCodes = customRetryForStatusCodes;
         return copy;
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterConfigurationInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterConfigurationInterface.java
@@ -7,6 +7,8 @@ import com.snowplowanalytics.snowplow.emitter.BufferOption;
 import com.snowplowanalytics.snowplow.emitter.EventStore;
 import com.snowplowanalytics.snowplow.network.RequestCallback;
 
+import java.util.Map;
+
 public interface EmitterConfigurationInterface {
 
     /**
@@ -74,4 +76,17 @@ public interface EmitterConfigurationInterface {
      * Callback called for each request performed by the tracker to the collector.
      */
     void setRequestCallback(@Nullable RequestCallback requestCallback);
+
+    /**
+     * Custom retry rules for HTTP status codes returned from the Collector.
+     * The dictionary is a mapping of integers (status codes) to booleans (true for retry and false for not retry).
+     */
+    @Nullable
+    Map<Integer, Boolean> getCustomRetryForStatusCodes();
+
+    /**
+     * Custom retry rules for HTTP status codes returned from the Collector.
+     * The dictionary is a mapping of integers (status codes) to booleans (true for retry and false for not retry).
+     */
+    void setCustomRetryForStatusCodes(@Nullable Map<Integer, Boolean> customRetryForStatusCodes);
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterConfigurationUpdate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterConfigurationUpdate.java
@@ -8,6 +8,8 @@ import com.snowplowanalytics.snowplow.emitter.BufferOption;
 import com.snowplowanalytics.snowplow.emitter.EventStore;
 import com.snowplowanalytics.snowplow.network.RequestCallback;
 
+import java.util.Map;
+
 public class EmitterConfigurationUpdate extends EmitterConfiguration {
 
     @Nullable
@@ -64,5 +66,13 @@ public class EmitterConfigurationUpdate extends EmitterConfiguration {
 
     public long getByteLimitPost() {
         return (sourceConfig == null || byteLimitPostUpdated) ? super.byteLimitPost : sourceConfig.byteLimitPost;
+    }
+
+    // customRetryForStatusCodes flag
+
+    public boolean customRetryForStatusCodesUpdated;
+
+    public Map<Integer, Boolean> getCustomRetryForStatusCodes() {
+        return (sourceConfig == null || customRetryForStatusCodesUpdated) ? super.customRetryForStatusCodes : sourceConfig.customRetryForStatusCodes;
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterControllerImpl.java
@@ -12,6 +12,8 @@ import com.snowplowanalytics.snowplow.internal.tracker.Logger;
 import com.snowplowanalytics.snowplow.internal.tracker.ServiceProviderInterface;
 import com.snowplowanalytics.snowplow.network.RequestCallback;
 
+import java.util.Map;
+
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class EmitterControllerImpl extends Controller implements EmitterController {
     private final static String TAG = EmitterControllerImpl.class.getSimpleName();
@@ -95,6 +97,17 @@ public class EmitterControllerImpl extends Controller implements EmitterControll
     @Override
     public void setRequestCallback(@Nullable RequestCallback requestCallback) {
         getEmitter().setRequestCallback(requestCallback);
+    }
+
+    @Nullable
+    @Override
+    public Map<Integer, Boolean> getCustomRetryForStatusCodes() {
+        return getEmitter().getCustomRetryForStatusCodes();
+    }
+
+    @Override
+    public void setCustomRetryForStatusCodes(@Nullable Map<Integer, Boolean> customRetryForStatusCodes) {
+        getEmitter().setCustomRetryForStatusCodes(customRetryForStatusCodes);
     }
 
     @Override

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -369,7 +369,8 @@ public class ServiceProvider implements ServiceProviderInterface {
                 .byteLimitPost(emitterConfig.getByteLimitPost())
                 .byteLimitGet(emitterConfig.getByteLimitGet())
                 .threadPoolSize(emitterConfig.getThreadPoolSize())
-                .callback(emitterConfig.getRequestCallback());
+                .callback(emitterConfig.getRequestCallback())
+                .customRetryForStatusCodes(emitterConfig.getCustomRetryForStatusCodes());
         HttpMethod method = networkConfig.getMethod();
         if (method != null) {
             builder.method(method);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.java
@@ -243,11 +243,9 @@ public class OkHttpNetworkConnection implements NetworkConnection {
 
             Request request = requests.get(i);
             List<Long> eventIds = request.emitterEventIds;
+            results.add(new RequestResult(code, request.oversize, eventIds));
             if (request.oversize) {
                 Logger.track(TAG, "Request is oversized for emitter event IDs: %s", eventIds.toString());
-                results.add(new RequestResult(true, eventIds));
-            } else {
-                results.add(new RequestResult(isSuccessfulSend(code), eventIds));
             }
         }
         return results;


### PR DESCRIPTION
This PR addresses issue #518 .

It adds a set of 5 HTTP status codes (400, 401, 403, 410, and 422) for which sending events should not be retried and the events should be dropped. This is in line with the strategy for handling HTTP status codes that we [outlined here](https://github.com/snowplow-incubator/data-value-resources/blob/main/30%20Tracker%20Architecture/emitter_architecture/handling_http_status_codes.md).

It also makes the retry behaviour configurable. It adds the `customRetryForStatusCodes` property to `EmitterConfiguration`. This is a dictionary mapping status codes (int) to booleans stating whether to retry or not.

The only change in the documentation was to add a short note about the property – [here is the PR in data-value-resources](https://github.com/snowplow-incubator/data-value-resources/pull/112).