### PR TITLE
Bump okhttp3 to 4.10.0, play-services-analytics to 18.0.1, and gson to 2.9.0 (close #520)

### DIFF
--- a/snowplow-demo-app/build.gradle
+++ b/snowplow-demo-app/build.gradle
@@ -48,6 +48,6 @@ dependencies {
     implementation project(':snowplow-android-tracker')
     implementation 'androidx.browser:browser:1.3.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.google.code.gson:gson:2.9.0'
 }

--- a/snowplow-tracker/build.gradle
+++ b/snowplow-tracker/build.gradle
@@ -82,14 +82,14 @@ dependencies {
     compileOnly "androidx.lifecycle:lifecycle-extensions:$project.archLifecycleVersion"
     compileOnly "com.android.installreferrer:installreferrer:2.2"
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     // test
     testImplementation "androidx.lifecycle:lifecycle-extensions:$project.archLifecycleVersion"
     testImplementation "com.android.installreferrer:installreferrer:2.2"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation 'com.google.android.gms:play-services-analytics:17.0.1'
+    androidTestImplementation 'com.google.android.gms:play-services-analytics:18.0.1'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.7.2'
 }
 


### PR DESCRIPTION
Updates dependencies in tracker:

* `com.squareup.okhttp3:okhttp` from 4.9.1 to 4.10.0
* `com.google.android.gms:play-services-analytics` from 17.0.1 to 18.0.1

In demo app:

* `com.squareup.okhttp3:okhttp` from 4.9.1 to 4.10.0
* `com.google.code.gson:gson` from 2.8.9 to 2.9.0