### PR TITLE
Add interface to subscribe for events tracked in Web views (close #531)

### DIFF
--- a/snowplow-demo-app/src/main/res/layout/activity_demo.xml
+++ b/snowplow-demo-app/src/main/res/layout/activity_demo.xml
@@ -8,6 +8,21 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context=".Demo">
 
+    <EditText
+        android:id="@+id/uri_field3"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
+        android:layout_weight="23"
+        android:hint="@string/uri_hint"
+        android:inputType="textUri"
+        android:paddingStart="5dp"
+        android:paddingLeft="5dp"
+        android:paddingEnd="5dp"
+        android:textSize="13sp" />
+
     <TextView
         android:id="@+id/header"
         android:layout_width="match_parent"
@@ -221,15 +236,15 @@
             android:id="@+id/metrics"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_toRightOf="@+id/log_output"
             android:layout_toEndOf="@+id/log_output"
+            android:layout_toRightOf="@+id/log_output"
             android:orientation="vertical">
 
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
                 android:paddingStart="10dp"
+                android:paddingLeft="10dp"
                 android:paddingEnd="10dp"
                 android:text="@string/emitter_statistics"
                 android:textColor="@android:color/black"
@@ -240,8 +255,8 @@
                 android:id="@+id/created_events"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
                 android:paddingStart="10dp"
+                android:paddingLeft="10dp"
                 android:paddingEnd="10dp"
                 android:text="@string/created_events"
                 android:textColor="@android:color/black"
@@ -251,8 +266,8 @@
                 android:id="@+id/sent_events"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
                 android:paddingStart="10dp"
+                android:paddingLeft="10dp"
                 android:paddingEnd="10dp"
                 android:text="@string/sent_events"
                 android:textColor="@android:color/black"
@@ -262,8 +277,8 @@
                 android:id="@+id/online_status"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
                 android:paddingStart="10dp"
+                android:paddingLeft="10dp"
                 android:paddingEnd="10dp"
                 android:text="@string/online_status"
                 android:textColor="@android:color/black"
@@ -273,8 +288,8 @@
                 android:id="@+id/emitter_status"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
                 android:paddingStart="10dp"
+                android:paddingLeft="10dp"
                 android:paddingEnd="10dp"
                 android:text="@string/emitter_status"
                 android:textColor="@android:color/black"
@@ -284,8 +299,8 @@
                 android:id="@+id/database_size"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
                 android:paddingStart="10dp"
+                android:paddingLeft="10dp"
                 android:paddingEnd="10dp"
                 android:text="@string/database_size"
                 android:textColor="@android:color/black"
@@ -295,12 +310,46 @@
                 android:id="@+id/session_index"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
                 android:paddingStart="10dp"
+                android:paddingLeft="10dp"
                 android:paddingEnd="10dp"
                 android:text="@string/session_index"
                 android:textColor="@android:color/black"
                 android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="10dp"
+                android:paddingLeft="10dp"
+                android:paddingEnd="10dp"
+                android:text="@string/emitter_statistics"
+                android:textColor="@android:color/black"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                tools:text="Web view:" />
+
+            <EditText
+                android:id="@+id/web_view_uri_field"
+                style="@style/Widget.AppCompat.EditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:hint="Web view URI"
+                android:inputType="textPersonName"
+                android:textSize="13sp" />
+
+            <Button
+                android:id="@+id/btn_load_webview"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Load WebView" />
+
+            <WebView
+                android:id="@+id/web_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
         </LinearLayout>
 
     </RelativeLayout>

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.java
@@ -17,6 +17,7 @@ class MockNetworkConnection implements NetworkConnection {
     public int statusCode;
     public HttpMethod httpMethod;
 
+    public final List<List<Request>> previousRequests = new ArrayList<>();
     public final List<List<RequestResult>> previousResults = new ArrayList<>();
 
     public MockNetworkConnection(HttpMethod httpMethod, int statusCode) {
@@ -37,6 +38,7 @@ class MockNetworkConnection implements NetworkConnection {
             Logger.v("MockNetworkConnection", "Sent: %s with success: %s", request.emitterEventIds, Boolean.valueOf(result.isSuccessful()).toString());
             requestResults.add(result);
         }
+        previousRequests.add(requests);
         previousResults.add(requestResults);
         return requestResults;
     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.java
@@ -54,4 +54,16 @@ class MockNetworkConnection implements NetworkConnection {
     public Uri getUri() {
         return Uri.parse("http://fake-url.com");
     }
+
+    public List<Request> getAllRequests() {
+        List<Request> flattened = new ArrayList<>();
+        for (List<Request> requests : previousRequests) {
+            flattened.addAll(requests);
+        }
+        return flattened;
+    }
+
+    public int countRequests() {
+        return getAllRequests().size();
+    }
 }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/TrackerWebViewInterfaceTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/TrackerWebViewInterfaceTest.java
@@ -35,7 +35,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.util.Base64;
 import java.util.Map;
 
 @RunWith(AndroidJUnit4.class)
@@ -53,6 +52,7 @@ public class TrackerWebViewInterfaceTest {
         TrackerConfiguration trackerConfig = new TrackerConfiguration("app1");
         trackerConfig.sessionContext = false;
         trackerConfig.platformContext = false;
+        trackerConfig.base64encoding = false;
 
         String trackerNamespace = String.valueOf(Math.random());
         Snowplow.removeAllTrackers();
@@ -121,8 +121,7 @@ public class TrackerWebViewInterfaceTest {
         assertEquals(1, networkConnection.sendingCount());
         assertEquals(1, networkConnection.previousRequests.get(0).size());
         Request request = networkConnection.previousRequests.get(0).get(0);
-        String encodedContext = (String) request.payload.getMap().get("cx");
-        JSONObject parsedEntity = decodeJSONFromBase64(encodedContext)
+        JSONObject parsedEntity = new JSONObject((String) request.payload.getMap().get("co"))
                 .getJSONArray("data")
                 .getJSONObject(0);
         assertEquals("http://context-schema.com", parsedEntity.getString("schema"));
@@ -133,10 +132,6 @@ public class TrackerWebViewInterfaceTest {
 
     private Context getContext() {
         return InstrumentationRegistry.getInstrumentation().getTargetContext();
-    }
-
-    private JSONObject decodeJSONFromBase64(String encoded) throws JSONException {
-        return new JSONObject(new String(Base64.decode(encoded, Base64.NO_WRAP)));
     }
 
 }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/TrackerWebViewInterfaceTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/TrackerWebViewInterfaceTest.java
@@ -72,13 +72,12 @@ public class TrackerWebViewInterfaceTest {
                 "cat", "act", "lbl", "prop", 10.0, null, null
         );
 
-        for (int i = 0; i < 10 && (networkConnection.sendingCount() == 0); i++) {
+        for (int i = 0; i < 10 && (networkConnection.countRequests() == 0); i++) {
             Thread.sleep(1000);
         }
 
-        assertEquals(1, networkConnection.sendingCount());
-        assertEquals(1, networkConnection.previousRequests.get(0).size());
-        Request request = networkConnection.previousRequests.get(0).get(0);
+        assertEquals(1, networkConnection.countRequests());
+        Request request = networkConnection.getAllRequests().get(0);
         Map payload = request.payload.getMap();
         assertEquals("cat", payload.get("se_ca"));
         assertEquals("act", payload.get("se_ac"));
@@ -98,12 +97,11 @@ public class TrackerWebViewInterfaceTest {
         webInterface.trackPageView("http://localhost", null, null, null, new String[]{"ns2"});
 
         // wait and check for the event
-        for (int i = 0; i < 10 && (networkConnection2.sendingCount() == 0); i++) {
+        for (int i = 0; i < 10 && (networkConnection2.countRequests() == 0); i++) {
             Thread.sleep(1000);
         }
-        assertEquals(0, networkConnection.sendingCount());
-        assertEquals(1, networkConnection2.previousRequests.size());
-        assertEquals(1, networkConnection2.previousRequests.get(0).size());
+        assertEquals(0, networkConnection.countRequests());
+        assertEquals(1, networkConnection2.countRequests());
     }
 
     @Test
@@ -114,13 +112,12 @@ public class TrackerWebViewInterfaceTest {
                 "[{\"schema\":\"http://context-schema.com\",\"data\":{\"a\":\"b\"}}]",
                 null);
 
-        for (int i = 0; i < 10 && (networkConnection.sendingCount() == 0); i++) {
+        for (int i = 0; i < 10 && (networkConnection.countRequests() == 0); i++) {
             Thread.sleep(1000);
         }
 
-        assertEquals(1, networkConnection.sendingCount());
-        assertEquals(1, networkConnection.previousRequests.get(0).size());
-        Request request = networkConnection.previousRequests.get(0).get(0);
+        assertEquals(1, networkConnection.countRequests());
+        Request request = networkConnection.getAllRequests().get(0);
         JSONObject parsedEntity = new JSONObject((String) request.payload.getMap().get("co"))
                 .getJSONArray("data")
                 .getJSONObject(0);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/TrackerWebViewInterfaceTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/TrackerWebViewInterfaceTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.tracker;
+
+import static com.snowplowanalytics.snowplow.network.HttpMethod.GET;
+
+import static junit.framework.TestCase.assertEquals;
+
+import android.content.Context;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.snowplowanalytics.snowplow.Snowplow;
+import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration;
+import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration;
+import com.snowplowanalytics.snowplow.internal.tracker.TrackerWebViewInterface;
+import com.snowplowanalytics.snowplow.network.Request;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.util.Base64;
+import java.util.Map;
+
+@RunWith(AndroidJUnit4.class)
+public class TrackerWebViewInterfaceTest {
+
+    private TrackerWebViewInterface webInterface;
+    private MockNetworkConnection networkConnection;
+
+    @Before
+    public void setUp() throws Exception {
+        webInterface = new TrackerWebViewInterface();
+        networkConnection = new MockNetworkConnection(GET,200);
+
+        NetworkConfiguration networkConfig = new NetworkConfiguration(networkConnection);
+        TrackerConfiguration trackerConfig = new TrackerConfiguration("app1");
+        trackerConfig.sessionContext = false;
+        trackerConfig.platformContext = false;
+
+        String trackerNamespace = String.valueOf(Math.random());
+        Snowplow.removeAllTrackers();
+        Snowplow.createTracker(getContext(), trackerNamespace, networkConfig, trackerConfig);
+    }
+
+    @After
+    public void tearDown() {
+        Snowplow.removeAllTrackers();
+    }
+
+    // --- TESTS
+
+    @Test
+    public void tracksStructuredEventWithAllProperties() throws JSONException, InterruptedException {
+        webInterface.trackStructEvent(
+                "cat", "act", "lbl", "prop", 10.0, null, null
+        );
+
+        for (int i = 0; i < 10 && (networkConnection.sendingCount() == 0); i++) {
+            Thread.sleep(1000);
+        }
+
+        assertEquals(1, networkConnection.sendingCount());
+        assertEquals(1, networkConnection.previousRequests.get(0).size());
+        Request request = networkConnection.previousRequests.get(0).get(0);
+        Map payload = request.payload.getMap();
+        assertEquals("cat", payload.get("se_ca"));
+        assertEquals("act", payload.get("se_ac"));
+        assertEquals("prop", payload.get("se_pr"));
+        assertEquals("lbl", payload.get("se_la"));
+        assertEquals("10.0", payload.get("se_va"));
+    }
+
+    @Test
+    public void tracksEventWithCorrectTracker() throws JSONException, InterruptedException {
+        // create the second tracker
+        MockNetworkConnection networkConnection2 = new MockNetworkConnection(GET,200);
+        NetworkConfiguration networkConfig = new NetworkConfiguration(networkConnection2);
+        Snowplow.createTracker(getContext(), "ns2", networkConfig);
+
+        // track an event using the second tracker
+        webInterface.trackPageView("http://localhost", null, null, null, new String[]{"ns2"});
+
+        // wait and check for the event
+        for (int i = 0; i < 10 && (networkConnection2.sendingCount() == 0); i++) {
+            Thread.sleep(1000);
+        }
+        assertEquals(0, networkConnection.sendingCount());
+        assertEquals(1, networkConnection2.previousRequests.size());
+        assertEquals(1, networkConnection2.previousRequests.get(0).size());
+    }
+
+    @Test
+    public void tracksEventWithContext() throws JSONException, InterruptedException {
+        webInterface.trackSelfDescribingEvent(
+                "http://schema.com",
+                "{\"key\":\"val\"}",
+                "[{\"schema\":\"http://context-schema.com\",\"data\":{\"a\":\"b\"}}]",
+                null);
+
+        for (int i = 0; i < 10 && (networkConnection.sendingCount() == 0); i++) {
+            Thread.sleep(1000);
+        }
+
+        assertEquals(1, networkConnection.sendingCount());
+        assertEquals(1, networkConnection.previousRequests.get(0).size());
+        Request request = networkConnection.previousRequests.get(0).get(0);
+        String encodedContext = (String) request.payload.getMap().get("cx");
+        JSONObject parsedEntity = decodeJSONFromBase64(encodedContext)
+                .getJSONArray("data")
+                .getJSONObject(0);
+        assertEquals("http://context-schema.com", parsedEntity.getString("schema"));
+        assertEquals("b", parsedEntity.getJSONObject("data").getString("a"));
+    }
+
+    // --- PRIVATE
+
+    private Context getContext() {
+        return InstrumentationRegistry.getInstrumentation().getTargetContext();
+    }
+
+    private JSONObject decodeJSONFromBase64(String encoded) throws JSONException {
+        return new JSONObject(new String(Base64.decode(encoded, Base64.NO_WRAP)));
+    }
+
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/Snowplow.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/Snowplow.java
@@ -1,6 +1,7 @@
 package com.snowplowanalytics.snowplow;
 
 import android.content.Context;
+import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -15,6 +16,7 @@ import com.snowplowanalytics.snowplow.internal.remoteconfiguration.Configuration
 import com.snowplowanalytics.snowplow.internal.remoteconfiguration.ConfigurationProvider;
 import com.snowplowanalytics.snowplow.internal.remoteconfiguration.FetchedConfigurationBundle;
 import com.snowplowanalytics.snowplow.internal.tracker.ServiceProvider;
+import com.snowplowanalytics.snowplow.internal.tracker.TrackerWebViewInterface;
 import com.snowplowanalytics.snowplow.network.HttpMethod;
 
 import java.util.ArrayList;
@@ -278,6 +280,14 @@ public class Snowplow {
     @NonNull
     public static Set<String> getInstancedTrackerNamespaces() {
         return serviceProviderInstances.keySet();
+    }
+
+    /**
+     * Add a JavaScript interface to the Web view that listens for events tracked using the Snowplow library for Web views.
+     * @param webView Web view instance in which to subscribe for events
+     */
+    public static void subscribeToWebViewEvents(@NonNull WebView webView) {
+        webView.addJavascriptInterface(new TrackerWebViewInterface(), TrackerWebViewInterface.TAG);
     }
 
     // Private methods

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerWebViewInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerWebViewInterface.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.internal.tracker;
+
+import android.webkit.JavascriptInterface;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.snowplowanalytics.snowplow.Snowplow;
+import com.snowplowanalytics.snowplow.controller.TrackerController;
+import com.snowplowanalytics.snowplow.event.AbstractEvent;
+import com.snowplowanalytics.snowplow.event.PageView;
+import com.snowplowanalytics.snowplow.event.ScreenView;
+import com.snowplowanalytics.snowplow.event.SelfDescribing;
+import com.snowplowanalytics.snowplow.event.Structured;
+import com.snowplowanalytics.snowplow.internal.utils.JsonUtils;
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * JavaScript interface used to provide an API for tracking events from Web views.
+ */
+public class TrackerWebViewInterface {
+
+    public final static String TAG = "SnowplowWebInterface";
+
+    /**
+     * Track a self-describing event from the Web view
+     * @param schema Schema of the self-describing event
+     * @param data JSON string with the self-describing event data
+     * @param context Optional JSON string with a list of context entities
+     * @param trackers Optional list of tracker namespaces to track with
+     * @throws JSONException In case of JSON parsing failures
+     */
+    @JavascriptInterface
+    public void trackSelfDescribingEvent(@NonNull String schema, @NonNull String data, @Nullable String context, @Nullable String[] trackers) throws JSONException {
+        JSONObject json = new JSONObject(data);
+        Map<String, Object> payload = JsonUtils.jsonToMap(json);
+
+        SelfDescribing event = new SelfDescribing(schema, payload);
+        trackEvent(event, context, trackers);
+    }
+
+    /**
+     * Track a structured event from the Web view
+     * @param category Name you for the group of objects you want to track e.g. "media", "ecomm"
+     * @param action Defines the type of user interaction for the web object
+     * @param label Identifies the specific object being actioned
+     * @param property Describes the object or the action performed on it
+     * @param value Quantifies or further describes the user action
+     * @param context Optional JSON string with a list of context entities
+     * @param trackers Optional list of tracker namespaces to track with
+     * @throws JSONException In case of JSON parsing failures
+     */
+    @JavascriptInterface
+    public void trackStructEvent(@NonNull String category, @NonNull String action, @Nullable String label, @Nullable String property, @Nullable Double value, @Nullable String context, @Nullable String[] trackers) throws JSONException {
+        Structured event = new Structured(category, action);
+        event.label = label;
+        event.property = property;
+        event.value = value;
+        trackEvent(event, context, trackers);
+    }
+
+    /**
+     * Track a screen view event from the Web view
+     * @param name The name of the screen viewed
+     * @param id The id (UUID v4) of screen that was viewed
+     * @param type The type of screen that was viewed
+     * @param previousName The name of the previous screen that was viewed
+     * @param previousId The id (UUID v4) of the previous screen that was viewed
+     * @param previousType The type of screen that was viewed
+     * @param transitionType The type of transition that led to the screen being viewed
+     * @param context Optional JSON string with a list of context entities
+     * @param trackers Optional list of tracker namespaces to track with
+     * @throws JSONException In case of JSON parsing failures
+     */
+    @JavascriptInterface
+    public void trackScreenView(
+            @NonNull String name,
+            @NonNull String id,
+            @Nullable String type,
+            @Nullable String previousName,
+            @Nullable String previousId,
+            @Nullable String previousType,
+            @Nullable String transitionType,
+            @Nullable String context,
+            @Nullable String[] trackers) throws JSONException {
+        ScreenView event = new ScreenView(name, UUID.fromString(id))
+                .type(type)
+                .previousId(previousId)
+                .previousName(previousName)
+                .previousType(previousType)
+                .transitionType(transitionType);
+        trackEvent(event, context, trackers);
+    }
+
+    /**
+     * Track a page view event from the Web view
+     * @param pageUrl Page URL
+     * @param pageTitle Page title
+     * @param referrer Referrer URL
+     * @param context Optional JSON string with a list of context entities
+     * @param trackers Optional list of tracker namespaces to track with
+     * @throws JSONException In case of JSON parsing failures
+     */
+    @JavascriptInterface
+    public void trackPageView(@NonNull String pageUrl, @Nullable String pageTitle, @Nullable String referrer, @Nullable String context, @Nullable String[] trackers) throws JSONException {
+        PageView event = new PageView(pageUrl)
+                .pageTitle(pageTitle)
+                .referrer(referrer);
+        trackEvent(event, context, trackers);
+    }
+
+    private void trackEvent(@NonNull AbstractEvent event, @Nullable String context, @Nullable String[] trackers) throws JSONException {
+        if (context != null) {
+            List<SelfDescribingJson> contextEntities = parseContext(context);
+            if (!contextEntities.isEmpty()) {
+                event.contexts(contextEntities);
+            }
+        }
+
+        if (trackers == null || trackers.length == 0) {
+            TrackerController tracker = Snowplow.getDefaultTracker();
+            if (tracker != null) {
+                tracker.track(event);
+            } else {
+                Logger.e(TAG,"Tracker not initialized.");
+            }
+        } else {
+            for (String namespace : trackers) {
+                TrackerController tracker = Snowplow.getTracker(namespace);
+                if (tracker != null) {
+                    tracker.track(event);
+                } else {
+                    Logger.e(TAG, String.format("Tracker with namespace %s not found.", namespace));
+                }
+            }
+        }
+    }
+
+    private List<SelfDescribingJson> parseContext(@NonNull String context) throws JSONException {
+        List<SelfDescribingJson> entities = new ArrayList<>();
+        JSONArray contextJson = new JSONArray(context);
+
+        for (int i = 0; i < contextJson.length(); i++) {
+            JSONObject itemJson = contextJson.getJSONObject(i);
+            Map<String, Object> item = JsonUtils.jsonToMap(itemJson);
+
+            String schema = (String) item.get("schema");
+            Object data = item.get("data");
+
+            if (schema != null && data != null) {
+                entities.add(new SelfDescribingJson(schema, data));
+            }
+        }
+
+        return entities;
+    }
+
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/JsonUtils.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/JsonUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
 package com.snowplowanalytics.snowplow.internal.utils;
 
 import org.json.JSONArray;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/JsonUtils.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/JsonUtils.java
@@ -1,0 +1,60 @@
+package com.snowplowanalytics.snowplow.internal.utils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class JsonUtils {
+
+    public static Map<String, Object> jsonToMap(JSONObject json) throws JSONException {
+        Map<String, Object> items = new HashMap<>();
+
+        if(json != JSONObject.NULL) {
+            items = toMap(json);
+        }
+        return items;
+    }
+
+    private static Map<String, Object> toMap(JSONObject object) throws JSONException {
+        Map<String, Object> map = new HashMap<>();
+
+        Iterator<String> keysItr = object.keys();
+        while(keysItr.hasNext()) {
+            String key = keysItr.next();
+            Object value = object.get(key);
+
+            if(value instanceof JSONArray) {
+                value = toList((JSONArray) value);
+            }
+
+            else if(value instanceof JSONObject) {
+                value = toMap((JSONObject) value);
+            }
+            map.put(key, value);
+        }
+        return map;
+    }
+
+    private static List<Object> toList(JSONArray array) throws JSONException {
+        List<Object> list = new ArrayList<>();
+        for(int i = 0; i < array.length(); i++) {
+            Object value = array.get(i);
+            if(value instanceof JSONArray) {
+                value = toList((JSONArray) value);
+            }
+
+            else if(value instanceof JSONObject) {
+                value = toMap((JSONObject) value);
+            }
+            list.add(value);
+        }
+        return list;
+    }
+
+}


### PR DESCRIPTION
This PR addresses issue #531 and adds an option to subscribe to events tracked inside web view using the [WebView tracker](https://github.com/snowplow-incubator/snowplow-webview-tracker) ([WebView tracker PR here](https://github.com/snowplow-incubator/snowplow-webview-tracker/pull/3)).

The change is part of the hybrid app tracking solution – this PR enables the iOS tracker to listen for the forwarded events from the WebView tracker.

```mermaid
flowchart TB

subgraph hybridApp[Hybrid Mobile App]

    subgraph webView[Web View]
        webViewCode[App logic]
        webViewTracker[Snowplow WebView tracker]

        webViewCode -- "Tracks events" --> webViewTracker
    end

    subgraph nativeCode[Native Code]
        nativeAppCode[App logic]
        nativeTracker[Snowplow iOS/Android tracker]

        nativeAppCode -- "Tracks events" --> nativeTracker
    end

    webViewTracker -- "Forwards events" --> nativeTracker
end

subgraph cloud[Cloud]
    collector[Snowplow Collector]
end

nativeTracker -- "Sends tracked events" --> collector
```

## Implementation

In order for the tracker to listen to events from the Web view, it was necessary to implement a JavaScript interface for the Android Web view – `TrackerWebViewInterface`. The interface provides the tracking API and tracks received events using the default or selected trackers (the tracked messages can contain tracker namespaces to use).

The user needs to subscribe the tracker for events from a Web view. This can be done as follows (`webView` is an instance of `WebView`):

```swift
Snowplow.subscribeToWebViewEvents(webView);
```

## Documentation

The documentation is common for the whole hybrid tracking setup and written as an accelerator/tutorial [here](https://github.com/snowplow-incubator/snowplow-hybrid-apps-accelerator).

## Example app

I added a small Web view to the example app with a URL bar to navigate to a given page in the bottom right part of the UI. The Web view is subscribed to by the tracker so events from it are forwarded.

![Screenshot_1658748834](https://user-images.githubusercontent.com/42166/180768816-a69a4dd1-5bfb-4958-b813-59d81f47f7d2.png)

