### PR TITLE
Do not resume remote configuration from cache in case it has different endpoint (close #533)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/RemoteConfiguration.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/RemoteConfiguration.java
@@ -15,13 +15,13 @@ import java.util.Objects;
 public class RemoteConfiguration implements Configuration {
 
     /**
-     * URL (without schema/protocol) used to send events to the collector.
+     * URL of the remote configuration.
      */
     @NonNull
     public final String endpoint;
 
     /**
-     * Method used to send events to the collector.
+     * The method used to send the requests (GET or POST).
      */
     @NonNull
     public final HttpMethod method;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationCache.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationCache.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.snowplowanalytics.snowplow.configuration.RemoteConfiguration;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -19,6 +21,12 @@ public class ConfigurationCache {
     private String cacheFilePath;
     @Nullable
     private FetchedConfigurationBundle configuration;
+    @NonNull
+    private RemoteConfiguration remoteConfiguration;
+
+    public ConfigurationCache(@NonNull RemoteConfiguration remoteConfiguration) {
+        this.remoteConfiguration = remoteConfiguration;
+    }
 
     @Nullable
     public synchronized FetchedConfigurationBundle readCache(@NonNull Context context) {
@@ -51,7 +59,8 @@ public class ConfigurationCache {
         if (!cacheDir.exists()) {
             cacheDir.mkdirs();
         }
-        cacheFilePath = cacheDir.getAbsolutePath() + File.separator + "remoteConfig.data";
+        String fileName = "remoteConfig-" + remoteConfiguration.endpoint.hashCode() + ".data";
+        cacheFilePath = cacheDir.getAbsolutePath() + File.separator + fileName;
         return cacheFilePath;
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationProvider.java
@@ -33,7 +33,7 @@ public class ConfigurationProvider {
 
     public ConfigurationProvider(@NonNull RemoteConfiguration remoteConfiguration, @Nullable List<ConfigurationBundle> defaultBundles) {
         this.remoteConfiguration = remoteConfiguration;
-        this.cache = new ConfigurationCache();
+        this.cache = new ConfigurationCache(remoteConfiguration);
         if (defaultBundles != null) {
             FetchedConfigurationBundle bundle = new FetchedConfigurationBundle("1.0");
             bundle.configurationVersion = Integer.MIN_VALUE;


### PR DESCRIPTION
Addresses issue #533 which goal was to support switching between remote configurations with different endpoints. This was not previously possible because the tracker cached previous configurations and didn't consider the endpoint when using the cache. Thus, if one switched to a new remote configuration with a new endpoint, a cache for the previous one could still be used by the tracker.

The approach that I chose is to add a hash of the remote config endpoint URL into the cache file name. So instead of `.../snowplow-cache/remoteConfig.data`, the cache files are now called `.../snowplow-cache/remoteConfig-12498219.data` where the number (12498219) is the hashcode of the URL. I make use of the String hashCode function which is not the most reliable but I think it's sufficient for this purpose.