### PR TITLE
Extend the onSuccess callback when setting up remote configuration to pass configuration state (close #694)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/Snowplow.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/Snowplow.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.Consumer;
+import androidx.core.util.Pair;
 
 import com.snowplowanalytics.snowplow.configuration.Configuration;
 import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration;
@@ -13,6 +14,7 @@ import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.controller.TrackerController;
 import com.snowplowanalytics.snowplow.internal.remoteconfiguration.ConfigurationBundle;
 import com.snowplowanalytics.snowplow.internal.remoteconfiguration.ConfigurationProvider;
+import com.snowplowanalytics.snowplow.internal.remoteconfiguration.ConfigurationState;
 import com.snowplowanalytics.snowplow.internal.remoteconfiguration.FetchedConfigurationBundle;
 import com.snowplowanalytics.snowplow.internal.tracker.ServiceProvider;
 import com.snowplowanalytics.snowplow.network.HttpMethod;
@@ -64,19 +66,20 @@ public class Snowplow {
      * @param context The Android app context.
      * @param remoteConfiguration The remote configuration used to indicate where to download the configuration from.
      * @param defaultBundles The default configuration passed by default in case there isn't a cached version and it's able to download a new one.
-     * @param onSuccess The callback called when a configuration (cached or downloaded) is set It passes the list of the namespaces associated
-     *                  to the created trackers.
+     * @param onSuccess The callback called when a configuration (cached or downloaded) is set.
+     *                  It passes a pair object with the list of the namespaces associated
+     *                  to the created trackers and the state of the configuration – whether it was
+     *                  retrieved from cache or fetched over the network.
      */
-    public static void setup(@NonNull Context context, @NonNull RemoteConfiguration remoteConfiguration, @Nullable List<ConfigurationBundle> defaultBundles, @Nullable Consumer<List<String>> onSuccess) {
+    public static void setup(@NonNull Context context, @NonNull RemoteConfiguration remoteConfiguration, @Nullable List<ConfigurationBundle> defaultBundles, @Nullable Consumer<Pair<List<String>, ConfigurationState>> onSuccess) {
         configurationProvider = new ConfigurationProvider(remoteConfiguration, defaultBundles);
-        configurationProvider.retrieveConfiguration(context, false, new Consumer<FetchedConfigurationBundle>() {
-            @Override
-            public void accept(FetchedConfigurationBundle fetchedConfigurationBundle) {
-                List<ConfigurationBundle> bundles = fetchedConfigurationBundle.configurationBundle;
-                List<String> namespaces = createTracker(context, bundles);
-                if (onSuccess != null) {
-                    onSuccess.accept(namespaces);
-                }
+        configurationProvider.retrieveConfiguration(context, false, fetchedConfigurationPair -> {
+            FetchedConfigurationBundle fetchedConfigurationBundle = fetchedConfigurationPair.first;
+            ConfigurationState configurationState = fetchedConfigurationPair.second;
+            List<ConfigurationBundle> bundles = fetchedConfigurationBundle.configurationBundle;
+            List<String> namespaces = createTracker(context, bundles);
+            if (onSuccess != null) {
+                onSuccess.accept(new Pair<>(namespaces, configurationState));
             }
         });
     }
@@ -98,19 +101,20 @@ public class Snowplow {
      * which will delete all the EventStores instanced with namespaces not listed in the passed list.
      *
      * @param context The Android app context.
-     * @param onSuccess The callback called when a configuration (cached or downloaded) is set It passes the list of the namespaces associated
-     *                  to the created trackers.
+     * @param onSuccess The callback called when a configuration (cached or downloaded) is set.
+     *                  It passes a pair object with the list of the namespaces associated
+     *                  to the created trackers and the state of the configuration – whether it was
+     *                  retrieved from cache or fetched over the network.
      */
-    public static void refresh(@NonNull Context context, @Nullable Consumer<List<String>> onSuccess) {
+    public static void refresh(@NonNull Context context, @Nullable Consumer<Pair<List<String>, ConfigurationState>> onSuccess) {
         if (configurationProvider == null) return;
-        configurationProvider.retrieveConfiguration(context, true, new Consumer<FetchedConfigurationBundle>() {
-            @Override
-            public void accept(FetchedConfigurationBundle fetchedConfigurationBundle) {
-                List<ConfigurationBundle> bundles = fetchedConfigurationBundle.configurationBundle;
-                List<String> namespaces = createTracker(context, bundles);
-                if (onSuccess != null) {
-                    onSuccess.accept(namespaces);
-                }
+        configurationProvider.retrieveConfiguration(context, true, fetchedConfigurationPair -> {
+            FetchedConfigurationBundle fetchedConfigurationBundle = fetchedConfigurationPair.first;
+            ConfigurationState configurationState = fetchedConfigurationPair.second;
+            List<ConfigurationBundle> bundles = fetchedConfigurationBundle.configurationBundle;
+            List<String> namespaces = createTracker(context, bundles);
+            if (onSuccess != null) {
+                onSuccess.accept(new Pair<>(namespaces, configurationState));
             }
         });
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationState.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationState.java
@@ -1,0 +1,19 @@
+package com.snowplowanalytics.snowplow.internal.remoteconfiguration;
+
+/**
+ * State of retrieved remote configuration that states where the configuration was retrieved from.
+ */
+public enum ConfigurationState {
+    /**
+     * The default configuration was used.
+     */
+    DEFAULT,
+    /**
+     * The configuration was retrieved from local cache.
+     */
+    CACHED,
+    /**
+     * The configuration was retrieved from the remote configuration endpoint.
+     */
+    FETCHED
+}


### PR DESCRIPTION
This PR addresses issue #536 and adds information about the remote configuration state to the `onSuccess` callback.

The configuration state describes where was the configuration retrieved from. It can have one of three values:

1. `CACHED` - retrieved from local cache file
2. `DEFAULT` - there was no cache, so the default settings provided by user were used
3. `FETCHED` - retrieved from the remote endpoint

This should make it more clear how to handle repeating calls to the `onSuccess` callback.

## Limitations

There are still some cases when we don't give any information to the user which makes it more difficult to get visibility of the remote config. However, these states don't really fit into the `onSuccess` callback so I decided to skip them here. But we could provide additional callbacks in the future.

These states are not covered by a calback:

* initial configuration was retrieved from cache and when the remote one was downloaded, the tracker decided not to use it.
* any failure to download the configuration or process the downloaded configuration