### PR TITLE
Ensure english numerals are used in datetimes (close #537)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
@@ -5,6 +5,7 @@ import android.test.AndroidTestCase;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class UtilTest extends AndroidTestCase {
@@ -16,6 +17,15 @@ public class UtilTest extends AndroidTestCase {
     public void testGetDateTimeFromTimestamp() {
         long timestamp = 1653923456266L;
         assertEquals("2022-05-30T15:10:56.266Z", Util.getDateTimeFromTimestamp(timestamp));
+
+        Locale defaultLocale = Locale.getDefault();
+
+        // set locale to one where different numerals are used (Egypt - arabic)
+        Locale.setDefault(new Locale("ar", "EG"));
+        assertEquals("2022-05-30T15:10:56.266Z", Util.getDateTimeFromTimestamp(timestamp));
+
+        // restore original locale
+        Locale.setDefault(defaultLocale);
     }
 
     public void testBase64Encode() {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
@@ -17,12 +17,15 @@ public class UtilTest extends AndroidTestCase {
     public void testGetDateTimeFromTimestamp() {
         long timestamp = 1653923456266L;
         assertEquals("2022-05-30T15:10:56.266Z", Util.getDateTimeFromTimestamp(timestamp));
+    }
 
+    public void testDateTimeProducesExpectedNumerals() {
+        long timestamp = 1660643130123L;
         Locale defaultLocale = Locale.getDefault();
 
         // set locale to one where different numerals are used (Egypt - arabic)
         Locale.setDefault(new Locale("ar", "EG"));
-        assertEquals("2022-05-30T15:10:56.266Z", Util.getDateTimeFromTimestamp(timestamp));
+        assertEquals("2022-08-16T10:45:30.123Z", Util.getDateTimeFromTimestamp(timestamp));
 
         // restore original locale
         Locale.setDefault(defaultLocale);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.java
@@ -25,7 +25,7 @@ public class UtilTest extends AndroidTestCase {
 
         // set locale to one where different numerals are used (Egypt - arabic)
         Locale.setDefault(new Locale("ar", "EG"));
-        assertEquals("2022-08-16T10:45:30.123Z", Util.getDateTimeFromTimestamp(timestamp));
+        assertEquals("2022-08-16T09:45:30.123Z", Util.getDateTimeFromTimestamp(timestamp));
 
         // restore original locale
         Locale.setDefault(defaultLocale);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
@@ -40,9 +40,11 @@ import java.io.ObjectOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -66,9 +68,11 @@ public class Util {
     }
 
     public static String getDateTimeFromTimestamp(long timestamp) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", new Locale("en"));
+
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date date = new Date(timestamp);
+        System.out.println(date + "❗️️❗");
         return dateFormat.format(date);
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/utils/Util.java
@@ -69,10 +69,8 @@ public class Util {
 
     public static String getDateTimeFromTimestamp(long timestamp) {
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", new Locale("en"));
-
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date date = new Date(timestamp);
-        System.out.println(date + "❗️️❗");
         return dateFormat.format(date);
     }
 


### PR DESCRIPTION
For issue #537.

Fixes a bug in client sessions, where non-english numerals were being used for datetimes based on the user's locale.