### PR TITLE
Add anonymous tracking features (close #540)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContextTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContextTest.java
@@ -15,6 +15,7 @@ package com.snowplowanalytics.snowplow.internal.tracker;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
@@ -39,7 +40,7 @@ public class PlatformContextTest {
     @Test
     public void addsNotMockedMobileContext() {
         PlatformContext platformContext = new PlatformContext(getContext());
-        SelfDescribingJson sdj = platformContext.getMobileContext();
+        SelfDescribingJson sdj = platformContext.getMobileContext(false);
         assertNotNull(sdj);
 
         Map<String, Object> sdjMap = sdj.getMap();
@@ -58,7 +59,7 @@ public class PlatformContextTest {
     public void addsAllMockedInfo() {
         MockDeviceInfoMonitor deviceInfoMonitor = new MockDeviceInfoMonitor();
         PlatformContext platformContext = new PlatformContext(0, 0, deviceInfoMonitor, getContext());
-        SelfDescribingJson sdj = platformContext.getMobileContext();
+        SelfDescribingJson sdj = platformContext.getMobileContext(false);
         Map<String, Object> sdjMap = sdj.getMap();
         Map sdjData = (Map) sdjMap.get("data");
         assertEquals("Android", sdjData.get(Parameters.OS_TYPE));
@@ -83,7 +84,7 @@ public class PlatformContextTest {
         PlatformContext platformContext = new PlatformContext(0, 0, deviceInfoMonitor, getContext());
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getSystemAvailableMemory"));
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getBatteryStateAndLevel"));
-        platformContext.getMobileContext();
+        platformContext.getMobileContext(false);
         assertEquals(2, deviceInfoMonitor.getMethodAccessCount("getSystemAvailableMemory"));
         assertEquals(2, deviceInfoMonitor.getMethodAccessCount("getBatteryStateAndLevel"));
     }
@@ -94,7 +95,7 @@ public class PlatformContextTest {
         PlatformContext platformContext = new PlatformContext(1000, 0, deviceInfoMonitor, getContext());
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getSystemAvailableMemory"));
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getBatteryStateAndLevel"));
-        platformContext.getMobileContext();
+        platformContext.getMobileContext(false);
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getSystemAvailableMemory"));
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getBatteryStateAndLevel"));
     }
@@ -105,7 +106,7 @@ public class PlatformContextTest {
         PlatformContext platformContext = new PlatformContext(0, 0, deviceInfoMonitor, getContext());
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getNetworkType"));
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getNetworkTechnology"));
-        platformContext.getMobileContext();
+        platformContext.getMobileContext(false);
         assertEquals(2, deviceInfoMonitor.getMethodAccessCount("getNetworkType"));
         assertEquals(2, deviceInfoMonitor.getMethodAccessCount("getNetworkTechnology"));
     }
@@ -116,7 +117,7 @@ public class PlatformContextTest {
         PlatformContext platformContext = new PlatformContext(0, 1000, deviceInfoMonitor, getContext());
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getNetworkType"));
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getNetworkTechnology"));
-        platformContext.getMobileContext();
+        platformContext.getMobileContext(false);
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getNetworkType"));
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getNetworkTechnology"));
     }
@@ -127,7 +128,7 @@ public class PlatformContextTest {
         PlatformContext platformContext = new PlatformContext(0, 0, deviceInfoMonitor, getContext());
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getOsType"));
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getTotalStorage"));
-        platformContext.getMobileContext();
+        platformContext.getMobileContext(false);
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getOsType"));
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getTotalStorage"));
     }
@@ -137,7 +138,7 @@ public class PlatformContextTest {
         MockDeviceInfoMonitor deviceInfoMonitor = new MockDeviceInfoMonitor();
         PlatformContext platformContext = new PlatformContext(0, 1, deviceInfoMonitor, getContext());
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
-        platformContext.getMobileContext();
+        platformContext.getMobileContext(false);
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
     }
 
@@ -148,10 +149,22 @@ public class PlatformContextTest {
         PlatformContext platformContext = new PlatformContext(0, 1, deviceInfoMonitor, getContext());
         assertEquals(1, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
         deviceInfoMonitor.customIdfa = null;
-        platformContext.getMobileContext();
+        platformContext.getMobileContext(false);
         assertEquals(2, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
-        platformContext.getMobileContext();
+        platformContext.getMobileContext(false);
         assertEquals(3, deviceInfoMonitor.getMethodAccessCount("getAndroidIdfa"));
+    }
+
+    @Test
+    public void anonymisesUserIdentifiers() {
+        MockDeviceInfoMonitor deviceInfoMonitor = new MockDeviceInfoMonitor();
+        PlatformContext platformContext = new PlatformContext(0, 0, deviceInfoMonitor, getContext());
+        SelfDescribingJson sdj = platformContext.getMobileContext(true);
+        Map<String, Object> sdjMap = sdj.getMap();
+        Map sdjData = (Map) sdjMap.get("data");
+
+        assertEquals("Android", sdjData.get(Parameters.OS_TYPE));
+        assertNull(sdjData.get(Parameters.ANDROID_IDFA));
     }
 
     // --- PRIVATE

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -15,18 +15,16 @@ package com.snowplowanalytics.snowplow.internal.tracker;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.test.AndroidTestCase;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.snowplowanalytics.snowplow.TestUtils;
 import com.snowplowanalytics.snowplow.emitter.EventStore;
 import com.snowplowanalytics.snowplow.event.SelfDescribing;
-import com.snowplowanalytics.snowplow.internal.constants.TrackerConstants;
-import com.snowplowanalytics.snowplow.internal.utils.Util;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
 import com.snowplowanalytics.snowplow.internal.emitter.Emitter;
@@ -36,14 +34,15 @@ import com.snowplowanalytics.snowplow.emitter.BufferOption;
 import com.snowplowanalytics.snowplow.event.ScreenView;
 import com.snowplowanalytics.snowplow.event.Timing;
 import com.snowplowanalytics.snowplow.tracker.LogLevel;
-import com.snowplowanalytics.snowplow.tracker.MockEventStore;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import java.util.UUID;
@@ -53,15 +52,21 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class TrackerTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class TrackerTest {
 
     private static Tracker tracker;
 
-    @Override
-    protected synchronized void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public synchronized void setUp() throws Exception {
         try {
             if (tracker == null) return;
             Emitter emitter = tracker.getEmitter();
@@ -117,8 +122,13 @@ public class TrackerTest extends AndroidTestCase {
         return tracker;
     }
 
+    private Context getContext() {
+        return InstrumentationRegistry.getInstrumentation().getTargetContext();
+    }
+
     // Tests
 
+    @Test
     public void testSetValues() {
         Tracker tracker = getTracker(true);
         assertEquals("myNamespace", tracker.getNamespace());
@@ -135,6 +145,7 @@ public class TrackerTest extends AndroidTestCase {
         assertTrue(tracker.getApplicationContext());
     }
 
+    @Test
     public void testEmitterUpdate() {
         Tracker tracker = getTracker();
         assertNotNull(tracker.getEmitter());
@@ -143,6 +154,7 @@ public class TrackerTest extends AndroidTestCase {
         assertNotNull(tracker.getEmitter());
     }
 
+    @Test
     public void testSubjectUpdate() {
         Tracker tracker = getTracker();
         assertNotNull(tracker.getSubject());
@@ -151,6 +163,7 @@ public class TrackerTest extends AndroidTestCase {
         assertNull(tracker.getSubject());
     }
 
+    @Test
     public void testPlatformUpdate() {
         Tracker tracker = getTracker();
         assertEquals(DevicePlatform.InternetOfThings, tracker.getPlatform());
@@ -159,6 +172,7 @@ public class TrackerTest extends AndroidTestCase {
         assertEquals(DevicePlatform.Mobile, tracker.getPlatform());
     }
 
+    @Test
     public void testDataCollectionSwitch() {
         Tracker tracker = getTracker();
         assertTrue(tracker.getDataCollection());
@@ -174,6 +188,7 @@ public class TrackerTest extends AndroidTestCase {
         assertTrue(tracker.getDataCollection());
     }
 
+    @Test
     public void testTrackEventMultipleTimes() {
         Timing event = new Timing("category", "variable", 100);
         UUID id1 = new TrackerEvent(event).eventId;
@@ -181,6 +196,7 @@ public class TrackerTest extends AndroidTestCase {
         assertNotEquals(id1, id2);
     }
 
+    @Test
     public void testTrackSelfDescribingEvent() throws JSONException, IOException, InterruptedException {
         Executor.setThreadCount(30);
         Executor.shutdown();
@@ -246,6 +262,7 @@ public class TrackerTest extends AndroidTestCase {
         mockWebServer.shutdown();
     }
 
+    @Test
     public void testTrackWithNoContext() throws Exception {
         Executor.setThreadCount(30);
         Executor.shutdown();
@@ -308,6 +325,7 @@ public class TrackerTest extends AndroidTestCase {
         mockWebServer.shutdown();
     }
 
+    @Test
     public void testTrackWithoutDataCollection() throws Exception {
         Executor.setThreadCount(30);
         Executor.shutdown();
@@ -342,6 +360,7 @@ public class TrackerTest extends AndroidTestCase {
         mockWebServer.shutdown();
     }
 
+    @Test
     public void testTrackWithSession() throws Exception {
         Executor.setThreadCount(30);
         Executor.shutdown();
@@ -377,6 +396,7 @@ public class TrackerTest extends AndroidTestCase {
         mockWebServer.shutdown();
     }
 
+    @Test
     public void testTrackScreenView() {
         String namespace = "myNamespace";
         TestUtils.createSessionSharedPreferences(getContext(), namespace);
@@ -423,6 +443,7 @@ public class TrackerTest extends AndroidTestCase {
         tracker.track(screenView);
     }
 
+    @Test
     public void testTrackUncaughtException() {
         String namespace = "myNamespace";
         TestUtils.createSessionSharedPreferences(getContext(), namespace);
@@ -453,6 +474,7 @@ public class TrackerTest extends AndroidTestCase {
         );
     }
 
+    @Test
     public void testExceptionHandler() {
         String namespace = "myNamespace";
         TestUtils.createSessionSharedPreferences(getContext(), namespace);

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.java
@@ -13,7 +13,7 @@ import com.snowplowanalytics.snowplow.network.RequestResult;
 import java.util.ArrayList;
 import java.util.List;
 
-class MockNetworkConnection implements NetworkConnection {
+public class MockNetworkConnection implements NetworkConnection {
     public int statusCode;
     public HttpMethod httpMethod;
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.java
@@ -61,6 +61,11 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
     @Nullable
     public Map<Integer, Boolean> customRetryForStatusCodes;
 
+    /**
+     * @see #serverAnonymisation(boolean)
+     */
+    public boolean serverAnonymisation;
+
     // Constructor
 
     /**
@@ -71,6 +76,7 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
      *         threadPoolSize = 15;
      *         byteLimitGet = 40000;
      *         byteLimitPost = 40000;
+     *         serverAnonymisation = false;
      */
     public EmitterConfiguration() {
         bufferOption = BufferOption.Single;
@@ -78,6 +84,7 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
         threadPoolSize = 15;
         byteLimitGet = 40000;
         byteLimitPost = 40000;
+        serverAnonymisation = false;
     }
 
     // Getters and Setters
@@ -160,6 +167,16 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
         this.customRetryForStatusCodes = customRetryForStatusCodes;
     }
 
+    @Override
+    public boolean isServerAnonymisation() {
+        return serverAnonymisation;
+    }
+
+    @Override
+    public void setServerAnonymisation(boolean serverAnonymisation) {
+        this.serverAnonymisation = serverAnonymisation;
+    }
+
     // Builders
 
     /**
@@ -237,6 +254,15 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
         return this;
     }
 
+    /**
+     * Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+     */
+    @NonNull
+    public EmitterConfiguration serverAnonymisation(boolean serverAnonymisation) {
+        this.serverAnonymisation = serverAnonymisation;
+        return this;
+    }
+
     // Copyable
 
     @Override
@@ -251,6 +277,7 @@ public class EmitterConfiguration implements Configuration, EmitterConfiguration
         copy.eventStore = eventStore;
         copy.requestCallback = requestCallback;
         copy.customRetryForStatusCodes = customRetryForStatusCodes;
+        copy.serverAnonymisation = serverAnonymisation;
         return copy;
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.java
@@ -93,6 +93,10 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
      */
     public boolean diagnosticAutotracking;
     /**
+     * @see #userAnonymisation(boolean)
+     */
+    public boolean userAnonymisation;
+    /**
      * @see #trackerVersionSuffix(String)
      */
     @Nullable
@@ -265,6 +269,16 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
     }
 
     @Override
+    public boolean isUserAnonymisation() {
+        return userAnonymisation;
+    }
+
+    @Override
+    public void setUserAnonymisation(boolean userAnonymisation) {
+        this.userAnonymisation = userAnonymisation;
+    }
+
+    @Override
     @Nullable
     public String getTrackerVersionSuffix() {
         return trackerVersionSuffix;
@@ -295,6 +309,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
      *         installAutotracking = true;
      *         exceptionAutotracking = true;
      *         diagnosticAutotracking = false;
+     *         userAnonymisation = false;
      * @param appId Identifier of the app.
      */
     public TrackerConfiguration(@NonNull String appId) {
@@ -317,6 +332,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
         installAutotracking = true;
         exceptionAutotracking = true;
         diagnosticAutotracking = false;
+        userAnonymisation = false;
     }
 
     // Builder methods
@@ -470,6 +486,15 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
     }
 
     /**
+     * Whether to anonymise client-side user identifiers in session and platform context entities
+     */
+    @NonNull
+    public TrackerConfiguration userAnonymisation(boolean userAnonymisation) {
+        this.userAnonymisation = userAnonymisation;
+        return this;
+    }
+
+    /**
      * Decorate the v_tracker field in the tracker protocol.
      * @note Do not use. Internal use only.
      */
@@ -502,6 +527,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
         copy.installAutotracking = installAutotracking;
         copy.exceptionAutotracking = exceptionAutotracking;
         copy.diagnosticAutotracking = diagnosticAutotracking;
+        copy.userAnonymisation = userAnonymisation;
         copy.trackerVersionSuffix = trackerVersionSuffix;
         return copy;
     }
@@ -530,5 +556,6 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
         installAutotracking = jsonObject.optBoolean("installAutotracking", installAutotracking);
         exceptionAutotracking = jsonObject.optBoolean("exceptionAutotracking", exceptionAutotracking);
         diagnosticAutotracking = jsonObject.optBoolean("diagnosticAutotracking", diagnosticAutotracking);
+        userAnonymisation = jsonObject.optBoolean("userAnonymisation", userAnonymisation);
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/Emitter.java
@@ -78,6 +78,7 @@ public class Emitter {
     private String customPostPath;
     private OkHttpClient client;
     private CookieJar cookieJar;
+    private boolean serverAnonymisation;
 
     private boolean isCustomNetworkConnection;
     private final AtomicReference<NetworkConnection> networkConnection = new AtomicReference<NetworkConnection>();
@@ -103,6 +104,7 @@ public class Emitter {
         long byteLimitPost = 40000; // Optional
         private int emitTimeout = 5; // Optional
         int threadPoolSize = 2; // Optional
+        boolean serverAnonymisation = false; // Optional
         @NonNull TimeUnit timeUnit = TimeUnit.SECONDS;
         @Nullable OkHttpClient client = null; //Optional
         @Nullable CookieJar cookieJar = null; // Optional
@@ -319,6 +321,17 @@ public class Emitter {
             this.customRetryForStatusCodes = customRetryForStatusCodes;
             return this;
         }
+
+        /**
+         * Ignored if using a custom network connection.
+         * @param serverAnonymisation whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+         * @return itself
+         */
+        @NonNull
+        public EmitterBuilder serverAnonymisation(boolean serverAnonymisation) {
+            this.serverAnonymisation = serverAnonymisation;
+            return this;
+        }
     }
 
     /**
@@ -342,6 +355,7 @@ public class Emitter {
         this.timeUnit = builder.timeUnit;
         this.client = builder.client;
         this.eventStore = builder.eventStore;
+        this.serverAnonymisation = builder.serverAnonymisation;
 
         this.uri = collectorUri;
         this.httpMethod = builder.httpMethod;
@@ -361,6 +375,7 @@ public class Emitter {
                     .customPostPath(builder.customPostPath)
                     .client(builder.client)
                     .cookieJar(builder.cookieJar)
+                    .serverAnonymisation(builder.serverAnonymisation)
                     .build());
         } else {
             isCustomNetworkConnection = true;
@@ -734,6 +749,7 @@ public class Emitter {
                     .customPostPath(customPostPath)
                     .client(client)
                     .cookieJar(cookieJar)
+                    .serverAnonymisation(serverAnonymisation)
                     .build());
         }
     }
@@ -753,6 +769,7 @@ public class Emitter {
                     .customPostPath(customPostPath)
                     .client(client)
                     .cookieJar(cookieJar)
+                    .serverAnonymisation(serverAnonymisation)
                     .build());
         }
     }
@@ -772,6 +789,7 @@ public class Emitter {
                     .customPostPath(customPostPath)
                     .client(client)
                     .cookieJar(cookieJar)
+                    .serverAnonymisation(serverAnonymisation)
                     .build());
         }
     }
@@ -791,6 +809,7 @@ public class Emitter {
                     .customPostPath(customPostPath)
                     .client(client)
                     .cookieJar(cookieJar)
+                    .serverAnonymisation(serverAnonymisation)
                     .build());
         }
     }
@@ -810,6 +829,28 @@ public class Emitter {
                     .customPostPath(customPostPath)
                     .client(client)
                     .cookieJar(cookieJar)
+                    .serverAnonymisation(serverAnonymisation)
+                    .build());
+        }
+    }
+
+    /**
+     * Updates the server anonymisation setting for the Emitter.
+     * Ignored if using a custom network connection.
+     *
+     * @param serverAnonymisation whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+     */
+    public void setServerAnonymisation(boolean serverAnonymisation) {
+        if (!isCustomNetworkConnection) {
+            this.serverAnonymisation = serverAnonymisation;
+            setNetworkConnection(new OkHttpNetworkConnection.OkHttpNetworkConnectionBuilder(uri, context)
+                    .method(httpMethod)
+                    .tls(tlsVersions)
+                    .emitTimeout(emitTimeout)
+                    .customPostPath(customPostPath)
+                    .client(client)
+                    .cookieJar(cookieJar)
+                    .serverAnonymisation(serverAnonymisation)
                     .build());
         }
     }
@@ -932,6 +973,13 @@ public class Emitter {
      */
     public int getEmitTimeout() {
         return this.emitTimeout;
+    }
+
+    /**
+     * @return whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+     */
+    public boolean getServerAnonymisation() {
+        return this.serverAnonymisation;
     }
 
     /**

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterConfigurationInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterConfigurationInterface.java
@@ -89,4 +89,14 @@ public interface EmitterConfigurationInterface {
      * The dictionary is a mapping of integers (status codes) to booleans (true for retry and false for not retry).
      */
     void setCustomRetryForStatusCodes(@Nullable Map<Integer, Boolean> customRetryForStatusCodes);
+
+    /**
+     * Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+     */
+    boolean isServerAnonymisation();
+
+    /**
+     * Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
+     */
+    void setServerAnonymisation(boolean serverAnonymisation);
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterConfigurationUpdate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterConfigurationUpdate.java
@@ -75,4 +75,12 @@ public class EmitterConfigurationUpdate extends EmitterConfiguration {
     public Map<Integer, Boolean> getCustomRetryForStatusCodes() {
         return (sourceConfig == null || customRetryForStatusCodesUpdated) ? super.customRetryForStatusCodes : sourceConfig.customRetryForStatusCodes;
     }
+
+    // serverAnonymisation flag
+
+    public boolean serverAnonymisationUpdated;
+
+    public boolean isServerAnonymisation() {
+        return (sourceConfig == null || serverAnonymisationUpdated) ? super.serverAnonymisation : sourceConfig.serverAnonymisation;
+    }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterControllerImpl.java
@@ -111,6 +111,18 @@ public class EmitterControllerImpl extends Controller implements EmitterControll
     }
 
     @Override
+    public boolean isServerAnonymisation() {
+        return getEmitter().getServerAnonymisation();
+    }
+
+    @Override
+    public void setServerAnonymisation(boolean serverAnonymisation) {
+        getDirtyConfig().serverAnonymisation = serverAnonymisation;
+        getDirtyConfig().serverAnonymisationUpdated = true;
+        getEmitter().setServerAnonymisation(serverAnonymisation);
+    }
+
+    @Override
     public long getDbCount() {
         EventStore eventStore = getEmitter().getEventStore();
         if (eventStore == null) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -181,7 +182,7 @@ public class Session {
      * @return a SelfDescribingJson containing the session context
      */
     @NonNull
-    public synchronized SelfDescribingJson getSessionContext(@NonNull String eventId, long eventTimestamp) {
+    public synchronized SelfDescribingJson getSessionContext(@NonNull String eventId, long eventTimestamp, boolean userAnonymisation) {
         Logger.v(TAG, "Getting session context...");
         if (isSessionCheckerEnabled) {
             if (shouldUpdateSession()) {
@@ -199,9 +200,11 @@ public class Session {
         eventIndex += 1;
 
         Map<String, Object> sessionValues = state.getSessionValues();
-        Map<String, Object> sessionCopy = new HashMap<>();
-        sessionCopy.putAll(sessionValues);
+        Map<String, Object> sessionCopy = new HashMap<>(sessionValues);
         sessionCopy.put(Parameters.SESSION_EVENT_INDEX, eventIndex);
+        if (userAnonymisation) {
+            sessionCopy.put(Parameters.SESSION_USER_ID, new UUID(0, 0).toString());
+        }
 
         return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionCopy);
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContext.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContext.java
@@ -66,7 +66,7 @@ public class PlatformContext {
     }
 
     @Nullable
-    public SelfDescribingJson getMobileContext() {
+    public SelfDescribingJson getMobileContext(boolean userAnonymisation) {
         updateEphemeralDictsIfNecessary();
 
         if (Util.mapHasKeys(pairs,
@@ -74,7 +74,13 @@ public class PlatformContext {
                 Parameters.OS_VERSION,
                 Parameters.DEVICE_MANUFACTURER,
                 Parameters.DEVICE_MODEL)) {
-            return new SelfDescribingJson(TrackerConstants.MOBILE_SCHEMA, pairs);
+            if (userAnonymisation && pairs.containsKey(Parameters.ANDROID_IDFA)) {
+                Map<String, Object> copy = new HashMap<>(pairs);
+                copy.remove(Parameters.ANDROID_IDFA);
+                return new SelfDescribingJson(TrackerConstants.MOBILE_SCHEMA, copy);
+            } else {
+                return new SelfDescribingJson(TrackerConstants.MOBILE_SCHEMA, pairs);
+            }
         } else {
             return null;
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContext.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContext.java
@@ -69,21 +69,23 @@ public class PlatformContext {
     public SelfDescribingJson getMobileContext(boolean userAnonymisation) {
         updateEphemeralDictsIfNecessary();
 
-        if (Util.mapHasKeys(pairs,
+        // If does not contain the required properties, return null
+        if (!Util.mapHasKeys(pairs,
                 Parameters.OS_TYPE,
                 Parameters.OS_VERSION,
                 Parameters.DEVICE_MANUFACTURER,
                 Parameters.DEVICE_MODEL)) {
-            if (userAnonymisation && pairs.containsKey(Parameters.ANDROID_IDFA)) {
-                Map<String, Object> copy = new HashMap<>(pairs);
-                copy.remove(Parameters.ANDROID_IDFA);
-                return new SelfDescribingJson(TrackerConstants.MOBILE_SCHEMA, copy);
-            } else {
-                return new SelfDescribingJson(TrackerConstants.MOBILE_SCHEMA, pairs);
-            }
-        } else {
             return null;
         }
+
+        // If user anonymisation is on, remove the IDFA value
+        if (userAnonymisation && pairs.containsKey(Parameters.ANDROID_IDFA)) {
+            Map<String, Object> copy = new HashMap<>(pairs);
+            copy.remove(Parameters.ANDROID_IDFA);
+            return new SelfDescribingJson(TrackerConstants.MOBILE_SCHEMA, copy);
+        }
+
+        return new SelfDescribingJson(TrackerConstants.MOBILE_SCHEMA, pairs);
     }
 
     // --- PRIVATE

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProvider.java
@@ -371,7 +371,8 @@ public class ServiceProvider implements ServiceProviderInterface {
                 .byteLimitGet(emitterConfig.getByteLimitGet())
                 .threadPoolSize(emitterConfig.getThreadPoolSize())
                 .callback(emitterConfig.getRequestCallback())
-                .customRetryForStatusCodes(emitterConfig.getCustomRetryForStatusCodes());
+                .customRetryForStatusCodes(emitterConfig.getCustomRetryForStatusCodes())
+                .serverAnonymisation(emitterConfig.isServerAnonymisation());
         HttpMethod method = networkConfig.getMethod();
         if (method != null) {
             builder.method(method);
@@ -415,7 +416,8 @@ public class ServiceProvider implements ServiceProviderInterface {
                 .applicationCrash(trackerConfig.isExceptionAutotracking())
                 .trackerDiagnostic(trackerConfig.isDiagnosticAutotracking())
                 .backgroundTimeout(sessionConfig.getBackgroundTimeout().convert(TimeUnit.SECONDS))
-                .foregroundTimeout(sessionConfig.getForegroundTimeout().convert(TimeUnit.SECONDS));
+                .foregroundTimeout(sessionConfig.getForegroundTimeout().convert(TimeUnit.SECONDS))
+                .userAnonymisation(trackerConfig.isUserAnonymisation());
         GdprConfigurationUpdate gdprConfig = getGdprConfigurationUpdate();
         if (gdprConfig.sourceConfig != null) {
             builder.gdprContext(

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -89,6 +89,7 @@ public class Tracker {
         boolean activityTracking = false; // Optional
         boolean installTracking = false; // Optional
         boolean applicationContext = false; // Optional
+        boolean userAnonymisation = false; // Optional
         @Nullable Gdpr gdpr = null; // Optional
         @Nullable String trackerVersionSuffix = null; // Optional
 
@@ -338,6 +339,16 @@ public class Tracker {
         }
 
         /**
+         * @param userAnonymisation whether to anonymise client-side user identifiers in session and platform context entities
+         * @return itself
+         */
+        @NonNull
+        public TrackerBuilder userAnonymisation(@NonNull Boolean userAnonymisation) {
+            this.userAnonymisation = userAnonymisation;
+            return this;
+        }
+
+        /**
          * Internal use only.
          * Decorate the `tv` (tracker version) field in the tracker protocol.
          */
@@ -375,6 +386,7 @@ public class Tracker {
     boolean installTracking;
     boolean activityTracking;
     boolean applicationContext;
+    boolean userAnonymisation;
     String trackerVersionSuffix;
 
     private boolean deepLinkContext;
@@ -498,6 +510,7 @@ public class Tracker {
         this.timeUnit = builder.timeUnit;
         this.foregroundTimeout = builder.foregroundTimeout;
         this.backgroundTimeout = builder.backgroundTimeout;
+        this.userAnonymisation = builder.userAnonymisation;
 
         this.platformContext = new PlatformContext(this.context);
 
@@ -720,7 +733,7 @@ public class Tracker {
                 Logger.track(TAG, "Session not ready or method getHasLoadedFromFile returned false with eventId: %s", eventId);
                 return;
             }
-            SelfDescribingJson sessionContextJson = sessionManager.getSessionContext(eventId, eventTimestamp);
+            SelfDescribingJson sessionContextJson = sessionManager.getSessionContext(eventId, eventTimestamp, userAnonymisation);
             event.contexts.add(sessionContextJson);
         }
     }
@@ -731,7 +744,7 @@ public class Tracker {
         }
 
         if (mobileContext) {
-            contexts.add(platformContext.getMobileContext());
+            contexts.add(platformContext.getMobileContext(userAnonymisation));
         }
 
         if (event.isService) {
@@ -801,7 +814,7 @@ public class Tracker {
 
         // Add Mobile Context
         if (this.mobileContext) {
-            contexts.add(platformContext.getMobileContext());
+            contexts.add(platformContext.getMobileContext(userAnonymisation));
         }
 
         // Add application context

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationInterface.java
@@ -182,6 +182,16 @@ public interface TrackerConfigurationInterface {
     void setDiagnosticAutotracking(boolean diagnosticAutotracking);
 
     /**
+     * Whether to anonymise client-side user identifiers in session and platform context entities
+     */
+    boolean isUserAnonymisation();
+
+    /**
+     * Whether to anonymise client-side user identifiers in session and platform context entities
+     */
+    void setUserAnonymisation(boolean userAnonymisation);
+
+    /**
      * Decorate the v_tracker field in the tracker protocol.
      *
      * @note Do not use. Internal use only.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationUpdate.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationUpdate.java
@@ -157,6 +157,14 @@ public class TrackerConfigurationUpdate extends TrackerConfiguration {
         return (sourceConfig == null || diagnosticAutotrackingUpdated) ? super.diagnosticAutotracking : sourceConfig.diagnosticAutotracking;
     }
 
+    // userAnonymisation flag
+
+    public boolean userAnonymisationUpdated;
+
+    public boolean isUserAnonymisation() {
+        return (sourceConfig == null || userAnonymisationUpdated) ? super.userAnonymisation : sourceConfig.userAnonymisation;
+    }
+
     // trackerVersionSuffix flag
 
     public boolean trackerVersionSuffixUpdated;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
@@ -306,6 +306,18 @@ public class TrackerControllerImpl extends Controller implements TrackerControll
         getTracker().trackerDiagnostic = diagnosticAutotracking;
     }
 
+    @Override
+    public boolean isUserAnonymisation() {
+        return getTracker().userAnonymisation;
+    }
+
+    @Override
+    public void setUserAnonymisation(boolean userAnonymisation) {
+        getDirtyConfig().userAnonymisation = userAnonymisation;
+        getDirtyConfig().userAnonymisationUpdated = true;
+        getTracker().userAnonymisation = userAnonymisation;
+    }
+
     @Nullable
     @Override
     public String getTrackerVersionSuffix() {


### PR DESCRIPTION
This PR addresses issue #540 and adds anonymous tracking features to the tracker.

Two properties were added in configuration:

* `TrackerConfiguration.userAnonymisation`
  * Disables user identifiers in session context (sets `userId` to `00000000-0000-0000-0000-000000000000`) and platform context (removes `androidIdfa`).
  * It is implemented by masking the identifiers at the time when the entities are added to events. So the `userId` is actually stored in session state but removed when adding to events (JS tracker does a similar thing).
* `EmitterConfiguraiton.serverAnonymisation`
  * Sets the `SP-Anonymous: *` header in requests to Collector (at the time when the requests are sent, not when the events are tracked). This results in anonymising the `network_userid` and `user_ipaddress` properties.
  * Decided to put it in the Emitter config and not Tracker config as it is handled by the Emitter. But if it makes more sense to put it in Tracker config, we can move it there.

# Documentation

(Available from v4)

Anonymous tracking enables anonymising various user and session identifiers. It affects the following user and session identifiers:

1. Client-side user identifiers: the `userId` in Session context entity and the IDFA identifiers (`openIdfa`, `appleIdfa`, and `androidIdfa`) in the Platform context entity.
2. Client-side session identifiers: `sessionId` in Session context.
3. Server-side user identifiers: `network_userid` and `user_ipaddress` event properties.

There are several levels to the anonymisation depending on which of the three categories are affected:

## 1. Full client-side anonymisation

In this case, both the client-side user identifiers as well as the client-side session identifiers are anonymised. To enable it, disable session context and enable user anonymisation:

```java
TrackerConfiguration config = new TrackerConfiguration()
    .sessionContext(false)
    .userAnonymisation(true);
```

## 2. Client-side anonymisation with session tracking

This setting disables client-side user identifiers are but tracks session information. In practice, this means that events track the Session context entity but the `userId` property is a null UUID (`00000000-0000-0000-0000-000000000000`). In case Platform context is enabled, the IDFA identifiers will not be present.

```java
TrackerConfiguration config = new TrackerConfiguration()
    .sessionContext(true)
    .userAnonymisation(true);
```

## 3. Server-side anonymisation

Server-side anonymisation affects user identifiers set server-side. In particular, these are the `network_userid` property set in server-side cookie and the user IP address. You can anonymise the properties using the `serverAnonymisation` flag in `EmitterConfiguration`:

```java
EmitterConfiguraiton config = new EmitterConfiguraiton()
    .serverAnonymisation(true);
```