### PR TITLE
Fix default session timeout values to 30 minutes everywhere (close #542)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -74,8 +74,8 @@ public class Tracker {
         DevicePlatform devicePlatform = DevicePlatform.Mobile; // Optional
         LogLevel logLevel = LogLevel.OFF; // Optional
         boolean sessionContext = false; // Optional
-        long foregroundTimeout = 600; // Optional - 10 minutes
-        long backgroundTimeout = 300; // Optional - 5 minutes
+        long foregroundTimeout = 1800; // Optional - 30 minutes
+        long backgroundTimeout = 1800; // Optional - 30 minutes
         @NonNull Runnable[] sessionCallbacks = new Runnable[]{}; // Optional
         int threadCount = 10; // Optional
         TimeUnit timeUnit = TimeUnit.SECONDS; // Optional


### PR DESCRIPTION
This is a tiny PR that just updates the default foreground and background timeouts in `Tracker` to 30 minutes to match the `SessionConfiguration` defaults and avoid confusion. Issue #542