### PR TITLE
Return tracked event ID from the track method (close #544)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/TrackerController.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/TrackerController.java
@@ -6,6 +6,8 @@ import androidx.annotation.Nullable;
 import com.snowplowanalytics.snowplow.internal.tracker.TrackerConfigurationInterface;
 import com.snowplowanalytics.snowplow.event.Event;
 
+import java.util.UUID;
+
 public interface TrackerController extends TrackerConfigurationInterface {
 
     /** Version of the tracker. */
@@ -75,8 +77,9 @@ public interface TrackerController extends TrackerConfigurationInterface {
      * Track the event.
      * The tracker will take care to process and send the event assigning `event_id` and `device_timestamp`.
      * @param event The event to track.
+     * @return The event ID or null in case tracking is paused
      */
-    void track(@NonNull Event event);
+    UUID track(@NonNull Event event);
 
     /**
      * Pause the tracker.

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -611,10 +612,11 @@ public class Tracker {
      * the Tracker can encounter.
      *
      * @param event the event to track
+     * @return The event ID or null in case tracking is paused
      */
-    public void track(final @NonNull Event event) {
+    public UUID track(final @NonNull Event event) {
         if (!dataCollection.get()) {
-            return;
+            return null;
         }
         event.beginProcessing(this);
         TrackerStateSnapshot stateSnapshot;
@@ -632,6 +634,7 @@ public class Tracker {
             this.emitter.add(payload);
             event.endProcessing(this);
         });
+        return trackerEvent.eventId;
     }
 
     private void transformEvent(@NonNull TrackerEvent event) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
@@ -19,6 +19,8 @@ import com.snowplowanalytics.snowplow.tracker.LoggerDelegate;
 import com.snowplowanalytics.snowplow.event.Event;
 import com.snowplowanalytics.snowplow.tracker.LogLevel;
 
+import java.util.UUID;
+
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class TrackerControllerImpl extends Controller implements TrackerController {
 
@@ -86,8 +88,8 @@ public class TrackerControllerImpl extends Controller implements TrackerControll
     }
 
     @Override
-    public void track(@NonNull Event event) {
-        getTracker().track(event);
+    public UUID track(@NonNull Event event) {
+        return getTracker().track(event);
     }
 
     @NonNull


### PR DESCRIPTION
Addresses issue #544 and makes the track method return the event ID as a `UUID`. The change is quite small as the ID was already present in the method, it was only necessary to return it.