### PR TITLE
Fix serialization of session timeouts in remote configuration cache (close #547)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/util/TimeMeasure.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/util/TimeMeasure.java
@@ -2,13 +2,14 @@ package com.snowplowanalytics.snowplow.util;
 
 import androidx.annotation.NonNull;
 
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
  * It represents time durations and provides utility methods to convert across time units.
  */
-public class TimeMeasure {
+public class TimeMeasure implements Serializable {
 
     /** Time duration at the selected TimeUnit. */
     public final long value;


### PR DESCRIPTION
Issue #547 

This is a tiny PR that just makes the `TimeMeasure` class serializable as it is used in `SessionConfiguration` which needs to be serialized when storing in cache. Otherwise, storing it in cache throws an `IOException`.