### PR TITLE
Log an error when recreating tracker after being removed (close #548)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/Snowplow.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/Snowplow.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Future;
 
 /**
  * Entry point to instance a new Snowplow tracker.
@@ -193,7 +192,7 @@ public class Snowplow {
             serviceProvider = new ServiceProvider(context, namespace, network, Arrays.asList(configurations));
             registerInstance(serviceProvider);
         }
-        return serviceProvider.getTrackerController();
+        return serviceProvider.getOrMakeTrackerController();
     }
 
     /**
@@ -205,7 +204,7 @@ public class Snowplow {
     @Nullable
     public static TrackerController getDefaultTracker() {
         ServiceProvider serviceProvider = defaultServiceProvider;
-        return serviceProvider == null ? null : serviceProvider.getTrackerController();
+        return serviceProvider == null ? null : serviceProvider.getOrMakeTrackerController();
     }
 
     /**
@@ -220,7 +219,7 @@ public class Snowplow {
         if (serviceProvider == null) {
             return null;
         }
-        return serviceProvider.getTrackerController();
+        return serviceProvider.getOrMakeTrackerController();
     }
 
     /**

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/EmitterControllerImpl.java
@@ -23,7 +23,7 @@ public class EmitterControllerImpl extends Controller implements EmitterControll
     }
 
     private Emitter getEmitter() {
-        return serviceProvider.getTracker().getEmitter();
+        return serviceProvider.getOrMakeTracker().getEmitter();
     }
 
     // Getters and Setters

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/NetworkControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/emitter/NetworkControllerImpl.java
@@ -10,7 +10,6 @@ import com.snowplowanalytics.snowplow.internal.tracker.ServiceProviderInterface;
 import com.snowplowanalytics.snowplow.network.HttpMethod;
 import com.snowplowanalytics.snowplow.network.NetworkConnection;
 import com.snowplowanalytics.snowplow.network.OkHttpNetworkConnection;
-import com.snowplowanalytics.snowplow.network.Protocol;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class NetworkControllerImpl extends Controller implements NetworkController {
@@ -76,7 +75,7 @@ public class NetworkControllerImpl extends Controller implements NetworkControll
     // Private methods
 
     private Emitter getEmitter() {
-        return serviceProvider.getEmitter();
+        return serviceProvider.getOrMakeEmitter();
     }
 
     private NetworkConfigurationUpdate getDirtyConfig() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/gdpr/GdprControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/gdpr/GdprControllerImpl.java
@@ -98,7 +98,7 @@ public class GdprControllerImpl extends Controller implements GdprController {
 
     @NonNull
     private Tracker getTracker() {
-        return serviceProvider.getTracker();
+        return serviceProvider.getOrMakeTracker();
     }
 
     @NonNull

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/globalcontexts/GlobalContextsControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/globalcontexts/GlobalContextsControllerImpl.java
@@ -10,8 +10,6 @@ import com.snowplowanalytics.snowplow.internal.Controller;
 import com.snowplowanalytics.snowplow.internal.tracker.ServiceProviderInterface;
 import com.snowplowanalytics.snowplow.internal.tracker.Tracker;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -41,6 +39,6 @@ public class GlobalContextsControllerImpl extends Controller implements GlobalCo
     // Private methods
 
     private Tracker getTracker() {
-        return serviceProvider.getTracker();
+        return serviceProvider.getOrMakeTracker();
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionControllerImpl.java
@@ -196,12 +196,12 @@ public class SessionControllerImpl extends Controller implements SessionControll
 
     @NonNull
     private Tracker getTracker() {
-        return serviceProvider.getTracker();
+        return serviceProvider.getOrMakeTracker();
     }
 
     @Nullable
     private Session getSession() {
-        return serviceProvider.getTracker().getSession();
+        return serviceProvider.getOrMakeTracker().getSession();
     }
 
     @NonNull

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProviderInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/ServiceProviderInterface.java
@@ -1,6 +1,7 @@
 package com.snowplowanalytics.snowplow.internal.tracker;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.snowplowanalytics.snowplow.internal.emitter.Emitter;
 import com.snowplowanalytics.snowplow.internal.emitter.EmitterConfigurationUpdate;
@@ -21,36 +22,39 @@ public interface ServiceProviderInterface {
     // Internal services
 
     @NonNull
-    Tracker getTracker();
+    Boolean isTrackerInitialized();
 
     @NonNull
-    Emitter getEmitter();
+    Tracker getOrMakeTracker();
 
     @NonNull
-    Subject getSubject();
+    Emitter getOrMakeEmitter();
+
+    @NonNull
+    Subject getOrMakeSubject();
 
     // Controllers
 
     @NonNull
-    TrackerControllerImpl getTrackerController();
+    TrackerControllerImpl getOrMakeTrackerController();
 
     @NonNull
-    EmitterControllerImpl getEmitterController();
+    EmitterControllerImpl getOrMakeEmitterController();
 
     @NonNull
-    NetworkControllerImpl getNetworkController();
+    NetworkControllerImpl getOrMakeNetworkController();
 
     @NonNull
-    GdprControllerImpl getGdprController();
+    GdprControllerImpl getOrMakeGdprController();
 
     @NonNull
-    GlobalContextsControllerImpl getGlobalContextsController();
+    GlobalContextsControllerImpl getOrMakeGlobalContextsController();
 
     @NonNull
-    SubjectControllerImpl getSubjectController();
+    SubjectControllerImpl getOrMakeSubjectController();
 
     @NonNull
-    SessionControllerImpl getSessionController();
+    SessionControllerImpl getOrMakeSessionController();
 
     // Configuration Updates
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/SubjectControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/SubjectControllerImpl.java
@@ -152,7 +152,7 @@ public class SubjectControllerImpl extends Controller implements SubjectControll
     // Private methods
 
     private Subject getSubject() {
-        return serviceProvider.getSubject();
+        return serviceProvider.getOrMakeSubject();
     }
 
     private SubjectConfigurationUpdate getDirtyConfig() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
@@ -24,6 +24,8 @@ import java.util.UUID;
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public class TrackerControllerImpl extends Controller implements TrackerController {
 
+    private final static String TAG = TrackerControllerImpl.class.getSimpleName();
+
     // Constructors
 
     public TrackerControllerImpl(@NonNull ServiceProvider serviceProvider) {
@@ -35,36 +37,36 @@ public class TrackerControllerImpl extends Controller implements TrackerControll
     @Nullable
     @Override
     public NetworkController getNetwork() {
-        return serviceProvider.getNetworkController();
+        return serviceProvider.getOrMakeNetworkController();
     }
 
     @Override
     @NonNull
     public EmitterController getEmitter() {
-        return serviceProvider.getEmitterController();
+        return serviceProvider.getOrMakeEmitterController();
     }
 
     @Override
     @NonNull
     public SubjectController getSubject() {
-        return serviceProvider.getSubjectController();
+        return serviceProvider.getOrMakeSubjectController();
     }
 
     @Override
     @NonNull
     public GdprController getGdpr() {
-        return serviceProvider.getGdprController();
+        return serviceProvider.getOrMakeGdprController();
     }
 
     @NonNull
     @Override
     public GlobalContextsController getGlobalContexts() {
-        return serviceProvider.getGlobalContextsController();
+        return serviceProvider.getOrMakeGlobalContextsController();
     }
 
     @NonNull
     public SessionControllerImpl getSessionController() {
-        return serviceProvider.getSessionController();
+        return serviceProvider.getOrMakeSessionController();
     }
 
     @Nullable
@@ -88,7 +90,7 @@ public class TrackerControllerImpl extends Controller implements TrackerControll
     }
 
     @Override
-    public UUID track(@NonNull Event event) {
+    public @Nullable UUID track(@NonNull Event event) {
         return getTracker().track(event);
     }
 
@@ -335,7 +337,10 @@ public class TrackerControllerImpl extends Controller implements TrackerControll
 
     @NonNull
     private Tracker getTracker() {
-        return serviceProvider.getTracker();
+        if (!serviceProvider.isTrackerInitialized()) {
+            getLoggerDelegate().error(TAG, "Recreating tracker instance after it was removed. This will not be supported in future versions.");
+        }
+        return serviceProvider.getOrMakeTracker();
     }
 
     @NonNull


### PR DESCRIPTION
Issue #548 

The problem that we are dealing with here is that users got confusing behaviour after having code that did something similar to this:

```java
TrackerController tracker = Snowplow.createTracker(...);
Snowplow.removeTracker(tracker);
System.out.println("Tracker removed: " + tracker.getNamespace());
```

In this case the tracker was removed on the second line but it was reinitialized on the third line, which is not obvious based on the snippet. Reinitializing the tracker also means that various autotracking features may be reactivated and unexpected events tracked.

I would like to prevent this behaviour and just return NULL from the `getNamespace()` and other functions from the `TrackerController` but I realized that this would be a breaking change. We would need to change the signature of the `TrackerController` functions.

So in order to prevent making the breaking change, this PR:

1. Logs an error when a tracker that was previously removed is accessed. This should make it easier for users to debug the weird behaviour.
2. Renames some of the internal functions to make clear that they are not just getters but can also change the objects (e.g., `getTracker()` -> `getOrMakeTracker()`).