### PR TITLE
Add DeepLink entity referrer and url to atomic properties in ScreenView events (close #553)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -22,7 +22,6 @@ import androidx.annotation.Nullable;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
-import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
 import com.snowplowanalytics.snowplow.TestUtils;
 import com.snowplowanalytics.snowplow.emitter.EventStore;
 import com.snowplowanalytics.snowplow.event.SelfDescribing;

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/entity/DeepLink.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/entity/DeepLink.java
@@ -44,5 +44,15 @@ public class DeepLink extends SelfDescribingJson {
         setData(parameters);
         return this;
     }
+
+    @Nullable
+    public String getUrl() {
+        return (String) parameters.get(PARAM_DEEPLINK_URL);
+    }
+
+    @Nullable
+    public String getReferrer() {
+        return (String) parameters.get(PARAM_DEEPLINK_REFERRER);
+    }
 }
 


### PR DESCRIPTION
Issue #553 

This PR extends the workaround in the tracker which sets the page referrer and page URL atomic properties in events – previously it only set them for deep link events based on their properties. Now, it also sets them for screen view events based on the deep link context entities.

I had to move the workaround to a different place. Previously it was called in `addSelfDescribingPropertiesToPayload()` in Tracker but at that point the events do not contain context entities assigned using state machines. Since the deep link entity is added in a state machine, I moved the call to after state machine context entities are added to events.

## Documentation: Tracking Events > Deep Link

The tracked `DeepLinkReceived` event and each subsequent `ScreenView` event also have the URL and referrer information added in the `page_url` and `page_referrer` atomic properties in the events. This makes them compatible with data models built for events tracked on the Web.