### PR TITLE
Anonymise previous session ID and user identifiers in subject when user anonymisation is enabled (close #549)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -26,6 +26,7 @@ import com.google.android.gms.common.internal.safeparcel.SafeParcelable;
 import com.snowplowanalytics.snowplow.TestUtils;
 import com.snowplowanalytics.snowplow.emitter.EventStore;
 import com.snowplowanalytics.snowplow.event.SelfDescribing;
+import com.snowplowanalytics.snowplow.event.Structured;
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson;
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
 import com.snowplowanalytics.snowplow.internal.emitter.Emitter;
@@ -510,6 +511,39 @@ public class TrackerTest {
         );
 
         handler1.uncaughtException(Thread.currentThread(), new Throwable("Illegal State Exception has been thrown!"));
+    }
+
+    @Test
+    public void testChangeUserAnonymisation() {
+        Emitter emitter = new Emitter(getContext(), "fake-uri", new Emitter.EmitterBuilder()
+                .option(BufferOption.Single)
+        );
+        emitter.pauseEmit();
+
+        tracker = new Tracker(new Tracker.TrackerBuilder(emitter, "ns", "myAppId", getContext())
+                .base64(false)
+                .level(LogLevel.VERBOSE)
+                .sessionContext(true)
+                .installTracking(false)
+                .applicationCrash(false)
+                .screenviewEvents(false)
+                .foregroundTimeout(5)
+                .backgroundTimeout(5)
+                .timeUnit(TimeUnit.SECONDS)
+        );
+
+        tracker.track(new Structured("c", "a"));
+        String sessionIdStart = tracker.getSession().getState().getSessionId();
+
+        tracker.setUserAnonymisation(true);
+        tracker.track(new Structured("c", "a"));
+        String sessionIdAnonymous = tracker.getSession().getState().getSessionId();
+        assertNotEquals(sessionIdStart, sessionIdAnonymous);
+
+        tracker.setUserAnonymisation(false);
+        tracker.track(new Structured("c", "a"));
+        String sessionIdNotAnonymous = tracker.getSession().getState().getSessionId();
+        assertNotEquals(sessionIdAnonymous, sessionIdNotAnonymous);
     }
 
     public static class TestExceptionHandler implements Thread.UncaughtExceptionHandler {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.java
@@ -514,7 +514,7 @@ public class TrackerTest {
     }
 
     @Test
-    public void testChangeUserAnonymisation() {
+    public void testStartsNewSessionWhenChangingAnonymousTracking() {
         Emitter emitter = new Emitter(getContext(), "fake-uri", new Emitter.EmitterBuilder()
                 .option(BufferOption.Single)
         );

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.java
@@ -410,11 +410,14 @@ public class SessionTest {
     }
 
     @Test
-    public void testAnonymisesUserIdentifiers() {
+    public void testAnonymisesUserAndPreviousSessionIdentifiers() {
         Session session = new Session(600, 300, TimeUnit.SECONDS, null, getContext());
-        Map<String, Object> context = getSessionContext(session, "eid", 1000, true);
+        getSessionContext(session, "eid1", 1000, false);
+        session.startNewSession(); // so that a reference to previous session is created
+        Map<String, Object> context = getSessionContext(session, "eid2", 1001, true);
 
         assertEquals("00000000-0000-0000-0000-000000000000", context.get(Parameters.SESSION_USER_ID));
+        assertNull(context.get(Parameters.SESSION_PREVIOUS_ID));
     }
 
     // Private methods

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -41,7 +41,7 @@ public class SubjectTest {
 
     @Test
     public void testGetSubjectStandardPairs() throws Exception {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         Map<String, String> standardPairs = subject.getSubject(false);
 
         assertTrue(standardPairs.containsKey("tz"));
@@ -51,70 +51,70 @@ public class SubjectTest {
 
     @Test
     public void testSetUserId() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setUserId("newUserId");
         assertEquals("newUserId", subject.getSubject(false).get("uid"));
     }
 
     @Test
     public void testSetScreenRes() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setScreenResolution(3000,1000);
         assertEquals("3000x1000", subject.getSubject(false).get("res"));
     }
 
     @Test
     public void testSetViewPort() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setViewPort(3000,1000);
         assertEquals("3000x1000", subject.getSubject(false).get("vp"));
     }
 
     @Test
     public void testSetColorDepth() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setColorDepth(1000);
         assertEquals("1000", subject.getSubject(false).get("cd"));
     }
 
     @Test
     public void testSetTimezone() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setTimezone("fake/timezone");
         assertEquals("fake/timezone", subject.getSubject(false).get("tz"));
     }
 
     @Test
     public void testSetLanguage() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setLanguage("French");
         assertEquals("French", subject.getSubject(false).get("lang"));
     }
 
     @Test
     public void testSetIpAddress() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setIpAddress("127.0.0.1");
         assertEquals("127.0.0.1", subject.getSubject(false).get("ip"));
     }
 
     @Test
     public void testSetUseragent() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setUseragent("Agent");
         assertEquals("Agent", subject.getSubject(false).get("ua"));
     }
 
     @Test
     public void testSetNetworkUID() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setNetworkUserId("nuid-test");
         assertEquals("nuid-test", subject.getSubject(false).get("tnuid"));
     }
 
     @Test
     public void testSetDomainUID() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setDomainUserId("duid-test");
         assertEquals("duid-test", subject.getSubject(false).get("duid"));
     }
@@ -132,7 +132,7 @@ public class SubjectTest {
 
     @Test
     public void testAnonymisesUserIdentifiers() {
-        Subject subject = getSubject();
+        Subject subject = createSubject();
         subject.setUserId("uid-test");
         subject.setDomainUserId("duid-test");
         subject.setNetworkUserId("nuid-test");
@@ -145,7 +145,7 @@ public class SubjectTest {
 
     // Helper Methods
 
-    private Subject getSubject() {
+    private Subject createSubject() {
         Logger.updateLogLevel(LogLevel.DEBUG);
         return new Subject(getContext(), null);
     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.java
@@ -13,97 +13,113 @@
 
 package com.snowplowanalytics.snowplow.tracker;
 
-import android.test.AndroidTestCase;
+import android.content.Context;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.snowplowanalytics.snowplow.Snowplow;
 import com.snowplowanalytics.snowplow.controller.TrackerController;
-import com.snowplowanalytics.snowplow.internal.constants.Parameters;
 import com.snowplowanalytics.snowplow.internal.tracker.Subject;
 import com.snowplowanalytics.snowplow.internal.tracker.Logger;
 import com.snowplowanalytics.snowplow.network.HttpMethod;
 
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.util.Map;
 
-public class SubjectTest extends AndroidTestCase {
-
-    // Helper Methods
-
-    private Subject getSubject() {
-        Logger.updateLogLevel(LogLevel.DEBUG);
-        return new Subject(getContext(), null);
-    }
+@RunWith(AndroidJUnit4.class)
+public class SubjectTest {
 
     // Tests
 
+    @Test
     public void testGetSubjectStandardPairs() throws Exception {
         Subject subject = getSubject();
-        Map<String, String> standardPairs = subject.getSubject();
+        Map<String, String> standardPairs = subject.getSubject(false);
 
         assertTrue(standardPairs.containsKey("tz"));
         assertTrue(standardPairs.containsKey("lang"));
         assertTrue(standardPairs.containsKey("res"));
     }
 
+    @Test
     public void testSetUserId() {
         Subject subject = getSubject();
         subject.setUserId("newUserId");
-        assertEquals("newUserId", subject.getSubject().get("uid"));
+        assertEquals("newUserId", subject.getSubject(false).get("uid"));
     }
 
+    @Test
     public void testSetScreenRes() {
         Subject subject = getSubject();
         subject.setScreenResolution(3000,1000);
-        assertEquals("3000x1000", subject.getSubject().get("res"));
+        assertEquals("3000x1000", subject.getSubject(false).get("res"));
     }
 
+    @Test
     public void testSetViewPort() {
         Subject subject = getSubject();
         subject.setViewPort(3000,1000);
-        assertEquals("3000x1000", subject.getSubject().get("vp"));
+        assertEquals("3000x1000", subject.getSubject(false).get("vp"));
     }
 
+    @Test
     public void testSetColorDepth() {
         Subject subject = getSubject();
         subject.setColorDepth(1000);
-        assertEquals("1000", subject.getSubject().get("cd"));
+        assertEquals("1000", subject.getSubject(false).get("cd"));
     }
 
+    @Test
     public void testSetTimezone() {
         Subject subject = getSubject();
         subject.setTimezone("fake/timezone");
-        assertEquals("fake/timezone", subject.getSubject().get("tz"));
+        assertEquals("fake/timezone", subject.getSubject(false).get("tz"));
     }
 
+    @Test
     public void testSetLanguage() {
         Subject subject = getSubject();
         subject.setLanguage("French");
-        assertEquals("French", subject.getSubject().get("lang"));
+        assertEquals("French", subject.getSubject(false).get("lang"));
     }
 
+    @Test
     public void testSetIpAddress() {
         Subject subject = getSubject();
         subject.setIpAddress("127.0.0.1");
-        assertEquals("127.0.0.1", subject.getSubject().get("ip"));
+        assertEquals("127.0.0.1", subject.getSubject(false).get("ip"));
     }
 
+    @Test
     public void testSetUseragent() {
         Subject subject = getSubject();
         subject.setUseragent("Agent");
-        assertEquals("Agent", subject.getSubject().get("ua"));
+        assertEquals("Agent", subject.getSubject(false).get("ua"));
     }
 
+    @Test
     public void testSetNetworkUID() {
         Subject subject = getSubject();
         subject.setNetworkUserId("nuid-test");
-        assertEquals("nuid-test", subject.getSubject().get("tnuid"));
+        assertEquals("nuid-test", subject.getSubject(false).get("tnuid"));
     }
 
+    @Test
     public void testSetDomainUID() {
         Subject subject = getSubject();
         subject.setDomainUserId("duid-test");
-        assertEquals("duid-test", subject.getSubject().get("duid"));
+        assertEquals("duid-test", subject.getSubject(false).get("duid"));
     }
 
+    @Test
     public void testSubjectUserIdCanBeUpdated() {
         TrackerController tracker = Snowplow.createTracker(getContext(), "default", "https://fake-url", HttpMethod.POST);
         assertNotNull(tracker.getSubject());
@@ -114,5 +130,27 @@ public class SubjectTest extends AndroidTestCase {
         assertNull(tracker.getSubject().getUserId());
     }
 
+    @Test
+    public void testAnonymisesUserIdentifiers() {
+        Subject subject = getSubject();
+        subject.setUserId("uid-test");
+        subject.setDomainUserId("duid-test");
+        subject.setNetworkUserId("nuid-test");
+        subject.setIpAddress("127.0.0.1");
+        assertNull(subject.getSubject(true).get("uid"));
+        assertNull(subject.getSubject(true).get("duid"));
+        assertNull(subject.getSubject(true).get("tnuid"));
+        assertNull(subject.getSubject(true).get("ip"));
+    }
 
+    // Helper Methods
+
+    private Subject getSubject() {
+        Logger.updateLogLevel(LogLevel.DEBUG);
+        return new Subject(getContext(), null);
+    }
+
+    private Context getContext() {
+        return InstrumentationRegistry.getInstrumentation().getTargetContext();
+    }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.java
@@ -486,7 +486,7 @@ public class TrackerConfiguration implements TrackerConfigurationInterface, Conf
     }
 
     /**
-     * Whether to anonymise client-side user identifiers in session and platform context entities
+     * Whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
      */
     @NonNull
     public TrackerConfiguration userAnonymisation(boolean userAnonymisation) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -204,6 +204,7 @@ public class Session {
         sessionCopy.put(Parameters.SESSION_EVENT_INDEX, eventIndex);
         if (userAnonymisation) {
             sessionCopy.put(Parameters.SESSION_USER_ID, new UUID(0, 0).toString());
+            sessionCopy.put(Parameters.SESSION_PREVIOUS_ID, null);
         }
 
         return new SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionCopy);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Subject.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Subject.java
@@ -230,10 +230,19 @@ public class Subject {
     }
 
     /**
+     * @param userAnonymisation Whether to anonymize user identifiers
      * @return the standard subject pairs
      */
     @NonNull
-    public Map<String, String> getSubject() {
+    public Map<String, String> getSubject(boolean userAnonymisation) {
+        if (userAnonymisation) {
+            Map<String, String> pairsCopy = new HashMap<>(standardPairs);
+            pairsCopy.remove(Parameters.UID);
+            pairsCopy.remove(Parameters.DOMAIN_UID);
+            pairsCopy.remove(Parameters.NETWORK_UID);
+            pairsCopy.remove(Parameters.IP_ADDRESS);
+            return pairsCopy;
+        }
         return this.standardPairs;
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -340,7 +340,7 @@ public class Tracker {
         }
 
         /**
-         * @param userAnonymisation whether to anonymise client-side user identifiers in session and platform context entities
+         * @param userAnonymisation whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
          * @return itself
          */
         @NonNull
@@ -676,7 +676,7 @@ public class Tracker {
         payload.add(Parameters.NAMESPACE, this.namespace);
         payload.add(Parameters.TRACKER_VERSION, this.trackerVersion);
         if (this.subject != null) {
-            payload.addMap(new HashMap<>(this.subject.getSubject()));
+            payload.addMap(new HashMap<>(this.subject.getSubject(userAnonymisation)));
         }
         payload.add(Parameters.PLATFORM, this.devicePlatform.getValue());
     }
@@ -812,7 +812,7 @@ public class Tracker {
 
         // If there is a subject present for the Tracker add it
         if (this.subject != null) {
-            payload.addMap(new HashMap<>(this.subject.getSubject()));
+            payload.addMap(new HashMap<>(this.subject.getSubject(userAnonymisation)));
         }
 
         // Add Mobile Context

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -345,6 +345,7 @@ public class Tracker {
          */
         @NonNull
         public TrackerBuilder userAnonymisation(@NonNull Boolean userAnonymisation) {
+            boolean changedUserAnonymisation = this.userAnonymisation != userAnonymisation;
             this.userAnonymisation = userAnonymisation;
             return this;
         }
@@ -387,7 +388,7 @@ public class Tracker {
     boolean installTracking;
     boolean activityTracking;
     boolean applicationContext;
-    boolean userAnonymisation;
+    private boolean userAnonymisation;
     String trackerVersionSuffix;
 
     private boolean deepLinkContext;
@@ -985,6 +986,16 @@ public class Tracker {
         }
     }
 
+    /** Internal use only */
+    public void setUserAnonymisation(boolean userAnonymisation) {
+        if (this.userAnonymisation != userAnonymisation) {
+            this.userAnonymisation = userAnonymisation;
+            if (trackerSession != null) {
+                trackerSession.startNewSession();
+            }
+        }
+    }
+
     // --- Getters
 
     /** Internal use only */
@@ -997,8 +1008,14 @@ public class Tracker {
         return deepLinkContext;
     }
 
+    /** Internal use only */
     public boolean getSessionContext() {
         return sessionContext;
+    }
+
+    /** Internal use only */
+    public boolean isUserAnonymisation() {
+        return userAnonymisation;
     }
 
     /**

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationInterface.java
@@ -182,12 +182,12 @@ public interface TrackerConfigurationInterface {
     void setDiagnosticAutotracking(boolean diagnosticAutotracking);
 
     /**
-     * Whether to anonymise client-side user identifiers in session and platform context entities
+     * Whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
      */
     boolean isUserAnonymisation();
 
     /**
-     * Whether to anonymise client-side user identifiers in session and platform context entities
+     * Whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
      */
     void setUserAnonymisation(boolean userAnonymisation);
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationInterface.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerConfigurationInterface.java
@@ -188,6 +188,7 @@ public interface TrackerConfigurationInterface {
 
     /**
      * Whether to anonymise client-side user identifiers in session (userId, previousSessionId), subject (userId, networkUserId, domainUserId, ipAddress) and platform context entities (IDFA)
+     * Setting this property on a running tracker instance starts a new session (if sessions are tracked).
      */
     void setUserAnonymisation(boolean userAnonymisation);
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerControllerImpl.java
@@ -312,14 +312,14 @@ public class TrackerControllerImpl extends Controller implements TrackerControll
 
     @Override
     public boolean isUserAnonymisation() {
-        return getTracker().userAnonymisation;
+        return getTracker().isUserAnonymisation();
     }
 
     @Override
     public void setUserAnonymisation(boolean userAnonymisation) {
         getDirtyConfig().userAnonymisation = userAnonymisation;
         getDirtyConfig().userAnonymisationUpdated = true;
-        getTracker().userAnonymisation = userAnonymisation;
+        getTracker().setUserAnonymisation(userAnonymisation);
     }
 
     @Nullable


### PR DESCRIPTION
Issue #549 

Anonymises additional properties when `TrackerConfiguration.userAnonymisation` is enabled. In particular, the following additional properties are anonymised:

* Session context entity
   * `previousSessionId` – otherwise one could recreate the whole user journey from the chain of sessions and basically recreate a user id
* Subject
   * `userId` – also anonymised in the JavaScript tracker
   * `domainUserId` – also anonymised in the JavaScript tracker
   * `networkUserId` – anonymised when server anonymisation is enabled, I think it makes sense to also anonymise if it is set client-side
   * `ipAddress` – anonymised when server anonymisation is enabled, I think it makes sense to also anonymise if it is set client-side


## Documentation

Anonymous tracking is a tracker feature that enables anonymising various user and session identifiers to support user privacy in case consent for tracking the identifiers is not given.

On mobile, the following user and session identifiers can be anonymised:

* Client-side user identifiers:
   * `userId` in the [Session](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2) context entity
   * IDFA identifiers (`appleIdfa` and `appleIdfv` for iOS, `androidIdfa` for Android) in the [Platform](http://iglucentral.com/schemas/com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2) context entity
   * `userId`, `domainUserId`, `networkUserId`, `ipAddress` if they are set in `Subject`
* Client-side session identifiers: `sessionId` and `previousSessionId` in Session entity.
* Server-side user identifiers: `network_userid` and `user_ipaddress` event properties.