### PR TITLE
Expose public constructor for ConfigurationBundle (close #550)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationBundle.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/remoteconfiguration/ConfigurationBundle.java
@@ -35,7 +35,7 @@ public class ConfigurationBundle implements Configuration {
         this(namespace, null);
     }
 
-    ConfigurationBundle(@NonNull String namespace, @Nullable NetworkConfiguration networkConfiguration) {
+    public ConfigurationBundle(@NonNull String namespace, @Nullable NetworkConfiguration networkConfiguration) {
         this.namespace = namespace;
         this.networkConfiguration = networkConfiguration;
     }


### PR DESCRIPTION
Issue #550 

Expose a public constructor for ConfigurationBundle that accepts a namespace and network configuration. Other configurations can be assigned to the public properties of the bundle object, so I didn't think it was necessary to add them to the constructor.

This is still not ideal, because the `ConfigurationBundle` class is in the `internal` package of the tracker. However, moving it out of there would be a breaking change so we need to do that in a major version.