### PR TITLE
Hardcode the anonymised session user ID (close #566)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -203,7 +203,7 @@ public class Session {
         Map<String, Object> sessionCopy = new HashMap<>(sessionValues);
         sessionCopy.put(Parameters.SESSION_EVENT_INDEX, eventIndex);
         if (userAnonymisation) {
-            sessionCopy.put(Parameters.SESSION_USER_ID, new UUID(0, 0).toString());
+            sessionCopy.put(Parameters.SESSION_USER_ID, "00000000-0000-0000-0000-000000000000");
             sessionCopy.put(Parameters.SESSION_PREVIOUS_ID, null);
         }
 


### PR DESCRIPTION
For issue #566.

When userAnonymisation is on, one of the identifiers that is anonymised is the session user ID (`userId` in `client_session`). The existing userId is replaced with a null UUID (`00000000-0000-0000-0000-000000000000`), previously generated like this: `new UUID(0, 0).toString()`.

A bug in some Motorola phones caused a truncation of the full null UUID `00000000-0000-0000-0000-000000000000` to `0000-0000` when `toString()` is called on it. In our tracker, this meant that some events were going to the Bad events rows, as the session user ID was no longer a valid UUID.

This change hardcodes the null UUID as a string.
