### PR TITLE
Refactor event interface and rename contexts to entities (close #573)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
@@ -3,6 +3,9 @@ package com.snowplowanalytics.snowplow.internal.tracker
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.snowplowanalytics.core.emitter.Emitter
+import com.snowplowanalytics.core.statemachine.State
+import com.snowplowanalytics.core.statemachine.StateMachineInterface
+import com.snowplowanalytics.core.statemachine.StateManager
 import com.snowplowanalytics.core.tracker.*
 import com.snowplowanalytics.snowplow.event.*
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
@@ -39,7 +42,7 @@ class StateManagerTest {
         var mockState = trackerState.getState("identifier") as MockState?
         Assert.assertEquals(1, mockState!!.value.toLong())
         
-        var e: InspectableEvent = TrackerEvent(eventInc, trackerState)
+        var e = TrackerEvent(eventInc, trackerState)
         var entities = stateManager.entitiesForProcessedEvent(e)
         var data = entities[0].map["data"] as Map<String?, Int>?
         Assert.assertEquals(1, data!!["value"]!!.toInt().toLong())
@@ -93,7 +96,7 @@ class StateManagerTest {
         val trackerState = stateManager.trackerStateForProcessedEvent(eventInc)
         val state = trackerState.getState("identifier")
         Assert.assertNull(state)
-        val e: InspectableEvent = TrackerEvent(eventInc, trackerState)
+        val e = TrackerEvent(eventInc, trackerState)
         val entities = stateManager.entitiesForProcessedEvent(e)
         Assert.assertEquals(0, entities.size.toLong())
     }
@@ -338,7 +341,7 @@ class StateManagerTest {
             }
         })
         val trackerState = stateManager.trackerStateForProcessedEvent(eventInc)
-        val e: InspectableEvent = TrackerEvent(eventInc, trackerState)
+        val e = TrackerEvent(eventInc, trackerState)
         val entities = stateManager.entitiesForProcessedEvent(e)
         Assert.assertEquals(2, entities.size.toLong())
     }
@@ -355,7 +358,7 @@ class StateManagerTest {
             }
         })
         val trackerState = stateManager.trackerStateForProcessedEvent(eventInc)
-        val e: InspectableEvent = TrackerEvent(eventInc, trackerState)
+        val e = TrackerEvent(eventInc, trackerState)
         val entities = stateManager.entitiesForProcessedEvent(e)
         Assert.assertEquals(1, entities.size.toLong())
     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
@@ -281,14 +281,14 @@ class EventSendingTest {
     }
 
     @Throws(JSONException::class)
-    fun getSessionData(contexts: JSONArray): JSONObject? {
-        for (i in 0 until contexts.length()) {
+    fun getSessionData(entities: JSONArray): JSONObject? {
+        for (i in 0 until entities.length()) {
             val sessionSchema =
                 "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2"
-            val context = contexts[i] as JSONObject
-            val schema = context["schema"] as String
+            val entity = entities[i] as JSONObject
+            val schema = entity["schema"] as String
             if (schema == sessionSchema) {
-                return context["data"] as JSONObject
+                return entity["data"] as JSONObject
             }
         }
         return null
@@ -460,7 +460,7 @@ class EventSendingTest {
     fun trackPageView(tracker: Tracker) {
         tracker.track(PageView("pageUrl").pageTitle("pageTitle").referrer("pageReferrer"))
         tracker.track(
-            PageView("pageUrl").pageTitle("pageTitle").referrer("pageReferrer").contexts(
+            PageView("pageUrl").pageTitle("pageTitle").referrer("pageReferrer").entities(
                 customContext
             )
         )
@@ -472,7 +472,7 @@ class EventSendingTest {
         )
         tracker.track(
             Structured("category", "action").label("label").property("property").value(0.00)
-                .contexts(
+                .entities(
                     customContext
                 )
         )
@@ -480,13 +480,13 @@ class EventSendingTest {
 
     private fun trackScreenView(tracker: Tracker) {
         tracker.track(ScreenView("screenName"))
-        tracker.track(ScreenView("screenName").contexts(customContext))
+        tracker.track(ScreenView("screenName").entities(customContext))
     }
 
     private fun trackTimings(tracker: Tracker) {
         tracker.track(Timing("category", "variable", 1).label("label"))
         tracker.track(
-            Timing("category", "variable", 1).label("label").contexts(
+            Timing("category", "variable", 1).label("label").entities(
                 customContext
             )
         )
@@ -501,7 +501,7 @@ class EventSendingTest {
         )
         tracker.track(SelfDescribing(test))
         tracker.track(
-            SelfDescribing(test).contexts(
+            SelfDescribing(test).entities(
                 customContext
             )
         )
@@ -519,7 +519,7 @@ class EventSendingTest {
         tracker.track(
             EcommerceTransaction("order-1", 42.50, items).affiliation("affiliation").taxValue(2.50)
                 .shipping(5.00).city("Sydney").state("NSW").country("Australia").currency("AUD")
-                .contexts(
+                .entities(
                     customContext
                 )
         )
@@ -543,7 +543,7 @@ class EventSendingTest {
         )
         tracker.track(
             ConsentGranted("gexpiry", "gid", "dversion").documentDescription("gdesc")
-                .documentName("dname").documents(documents).contexts(
+                .documentName("dname").documents(documents).entities(
                 customContext
             )
         )
@@ -567,7 +567,7 @@ class EventSendingTest {
         )
         tracker.track(
             ConsentWithdrawn(false, "gid", "dversion").documentDescription("gdesc")
-                .documentName("dname").documents(documents).contexts(
+                .documentName("dname").documents(documents).entities(
                 customContext
             )
         )

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkState.kt
@@ -10,7 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 class DeepLinkState(val url: String, val referrer: String?) : State {
     var readyForOutput = false

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkStateMachine.kt
@@ -10,7 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 import com.snowplowanalytics.core.constants.TrackerConstants
 import com.snowplowanalytics.snowplow.entity.DeepLink

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleState.kt
@@ -1,3 +1,3 @@
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 class LifecycleState(val isForeground: Boolean, val index: Int?) : State

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleStateMachine.kt
@@ -1,4 +1,4 @@
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 import com.snowplowanalytics.snowplow.entity.LifecycleEntity
 import com.snowplowanalytics.snowplow.event.Background

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/State.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/State.kt
@@ -1,0 +1,3 @@
+package com.snowplowanalytics.core.statemachine
+
+interface State 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateFuture.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateFuture.kt
@@ -1,4 +1,4 @@
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 import com.snowplowanalytics.snowplow.event.Event
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineEvent.kt
@@ -10,28 +10,23 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.tracker
+package com.snowplowanalytics.core.statemachine
 
-import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent
 
 /**
  * The inspectable properties of the event used to generate context entities.
  */
-interface InspectableEvent {
+interface StateMachineEvent : InspectableEvent {
     /**
-     * The schema of the event
+     * The tracker state at the time the event was sent.
      */
-    val schema: String?
+    val state: TrackerStateSnapshot
+
     /**
-     * The name of the event
+     * Add payload values to the event.
+     * @param payload Map of values to add to the event payload
+     * @return Whether or not the values have been successfully added to the event payload
      */
-    val name: String?
-    /**
-     * The payload of the event
-     */
-    val payload: Map<String, Any>
-    /**
-     * The list of context entities
-     */
-    val entities: MutableList<SelfDescribingJson>
+    fun addPayloadValues(payload: Map<String, Any>): Boolean
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineInterface.kt
@@ -1,4 +1,4 @@
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 import com.snowplowanalytics.snowplow.event.Event
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateManager.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateManager.kt
@@ -1,9 +1,8 @@
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
 import com.snowplowanalytics.snowplow.event.Event
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
-import com.snowplowanalytics.snowplow.tracker.InspectableEvent
 import java.util.*
 
 class StateManager {
@@ -107,7 +106,7 @@ class StateManager {
     }
 
     @Synchronized
-    fun entitiesForProcessedEvent(event: InspectableEvent): List<SelfDescribingJson> {
+    fun entitiesForProcessedEvent(event: StateMachineEvent): List<SelfDescribingJson> {
         val result: MutableList<SelfDescribingJson> = LinkedList()
         val stateMachines: MutableList<StateMachineInterface> = LinkedList()
         val stateMachinesForSchema: List<StateMachineInterface>? =
@@ -133,7 +132,7 @@ class StateManager {
     }
 
     @Synchronized
-    fun addPayloadValuesToEvent(event: InspectableEvent): Boolean {
+    fun addPayloadValuesToEvent(event: StateMachineEvent): Boolean {
         var failures = 0
         val stateMachines: MutableList<StateMachineInterface> = LinkedList()
         val stateMachinesForSchema: List<StateMachineInterface>? =

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/TrackerState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/TrackerState.kt
@@ -1,4 +1,4 @@
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 class TrackerState : TrackerStateSnapshot {
     private var trackerState = HashMap<String, StateFuture>()

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/TrackerStateSnapshot.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/TrackerStateSnapshot.kt
@@ -1,4 +1,4 @@
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.statemachine
 
 interface TrackerStateSnapshot {
     fun getState(stateIdentifier: String): State?

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ScreenState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ScreenState.kt
@@ -3,6 +3,7 @@ package com.snowplowanalytics.core.tracker
 import androidx.annotation.RestrictTo
 import com.snowplowanalytics.core.constants.Parameters
 import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.statemachine.State
 import com.snowplowanalytics.core.utils.Util.uUIDString
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 import com.snowplowanalytics.snowplow.payload.TrackerPayload

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ScreenStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ScreenStateMachine.kt
@@ -2,6 +2,8 @@ package com.snowplowanalytics.core.tracker
 
 import com.snowplowanalytics.core.constants.Parameters
 import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.statemachine.State
+import com.snowplowanalytics.core.statemachine.StateMachineInterface
 import com.snowplowanalytics.snowplow.event.Event
 import com.snowplowanalytics.snowplow.event.ScreenView
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/State.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/State.kt
@@ -1,3 +1,0 @@
-package com.snowplowanalytics.core.tracker
-
-interface State 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerEvent.kt
@@ -12,31 +12,33 @@
  */
 package com.snowplowanalytics.core.tracker
 
+import com.snowplowanalytics.core.statemachine.StateMachineEvent
+import com.snowplowanalytics.core.statemachine.TrackerState
+import com.snowplowanalytics.core.statemachine.TrackerStateSnapshot
 import com.snowplowanalytics.snowplow.event.AbstractPrimitive
 import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
 import com.snowplowanalytics.snowplow.event.Event
 import com.snowplowanalytics.snowplow.event.TrackerError
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
-import com.snowplowanalytics.snowplow.tracker.InspectableEvent
 import java.util.*
 
 class TrackerEvent @JvmOverloads constructor(event: Event, state: TrackerStateSnapshot? = null) :
-    InspectableEvent {
+    StateMachineEvent {
     
     override var schema: String? = null
     override var name: String? = null
     override lateinit var payload: MutableMap<String, Any>
     override lateinit var state: TrackerStateSnapshot
-    
+    override lateinit var entities: MutableList<SelfDescribingJson>
+
     var eventId: UUID = UUID.randomUUID()
     var timestamp: Long = System.currentTimeMillis()
     var trueTimestamp: Long?
-    var contexts: MutableList<SelfDescribingJson>
     var isPrimitive = false
     var isService: Boolean
 
     init {
-        contexts = event.contexts.toMutableList()
+        entities = event.entities.toMutableList()
         trueTimestamp = event.trueTimestamp
         payload = HashMap(event.dataPayload)
         

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerWebViewInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerWebViewInterface.kt
@@ -143,7 +143,7 @@ class TrackerWebViewInterface {
         if (context != null) {
             val contextEntities = parseContext(context)
             if (contextEntities.isNotEmpty()) {
-                event.contexts(contextEntities)
+                event.entities(contextEntities)
             }
         }
         if (trackers == null || trackers.isEmpty()) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractEvent.kt
@@ -35,9 +35,15 @@ abstract class AbstractEvent : Event {
     // Builder methods
     
     /** Adds a list of contexts.  */
-    fun contexts(contexts: List<SelfDescribingJson>?): AbstractEvent {
-        contexts?.let { customContexts.addAll(contexts) }
+    fun entities(entities: List<SelfDescribingJson>?): AbstractEvent {
+        entities?.let { customContexts.addAll(entities) }
         return this
+    }
+
+    /** Adds a list of contexts.  */
+    @Deprecated("Please use `entities()`")
+    fun contexts(contexts: List<SelfDescribingJson>?): AbstractEvent {
+        return entities(contexts)
     }
 
     /** Set the custom timestamp of the event.  */
@@ -51,8 +57,11 @@ abstract class AbstractEvent : Event {
     /**
      * @return the event custom context
      */
-    override val contexts: List<SelfDescribingJson>
+    override val entities: List<SelfDescribingJson>
         get() = ArrayList(customContexts)
+
+    override val contexts: List<SelfDescribingJson>
+        get() = entities
 
     override fun beginProcessing(tracker: Tracker) {}
     override fun endProcessing(tracker: Tracker) {}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Event.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/Event.kt
@@ -20,8 +20,14 @@ import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
  */
 interface Event {
     /**
-     * @return the event custom contexts
+     * @return the event custom context entities
      */
+    val entities: List<SelfDescribingJson>
+
+    /**
+     * @return the event custom context entities
+     */
+    @Deprecated("Please use `entities`")
     val contexts: List<SelfDescribingJson>
 
     /**

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/SessionState.kt
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.snowplow.tracker
 
 import com.snowplowanalytics.core.constants.Parameters
-import com.snowplowanalytics.core.tracker.State
+import com.snowplowanalytics.core.statemachine.State
 
 class SessionState(
     val firstEventId: String,


### PR DESCRIPTION
Issue #573

This PR refactors the `InspectableEvent` interface to remove the `state` property and `addPayloadValues` which were used only internally in state machines. Having the `state` property in the published event interface required us to also publish various other state classes that were only internal.

I extracted the `state` and `addPayloadValues` to another interface – `StateMachineEvent` which is only internal within the tracker, not published. The `TrackerEvent` class which implemented `InspectableEvent` now also implements the `StateMachineEvent`.

Additionally, there is inconsistent naming of context entities in the tracker – they are called `contexts` in events and `entities` in state machines. Since entities better reflects our more recent thinking about how to name them, I adopted that. I kept the `contexts` properties in events but deprecated them in favor of `entities`.