### PR TITLE
Add ability to provide custom tracker plugins to inspect and enrich tracked events (close #574)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContextTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/globalcontexts/GlobalContextTest.kt
@@ -241,6 +241,12 @@ class GlobalContextTest {
             .base64encoding(false)
             .sessionContext(true)
         val gcConfig = GlobalContextsConfiguration(generators)
-        return createTracker(context, "aNamespace", networkConfig, trackerConfig, gcConfig)
+        return createTracker(
+            context,
+            "aNamespace" + Math.random().toString(),
+            networkConfig,
+            trackerConfig,
+            gcConfig
+        )
     }
 }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
@@ -183,7 +183,7 @@ class TrackerTest {
     fun testTrackSelfDescribingEvent() {
         shutdown()
         
-        val namespace = "myNamespace"
+        val namespace = "trackSelfDescribingEvent"
         TestUtils.createSessionSharedPreferences(context, namespace)
         val mockWebServer = getMockServer(1)
         var emitter: Emitter? = null
@@ -243,7 +243,7 @@ class TrackerTest {
     fun testTrackWithNoContext() {
         shutdown()
         
-        val namespace = "myNamespaceNoContext"
+        val namespace = "trackWithNoContext"
         TestUtils.createSessionSharedPreferences(context, namespace)
         
         val mockWebServer = getMockServer(1)
@@ -308,7 +308,7 @@ class TrackerTest {
     fun testTrackWithoutDataCollection() {
         threadCount = 30
         shutdown()
-        val namespace = "myNamespace"
+        val namespace = "trackWithoutDataCollection"
         TestUtils.createSessionSharedPreferences(context, namespace)
         val mockWebServer = getMockServer(1)
         val builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
@@ -340,7 +340,7 @@ class TrackerTest {
     fun testTrackWithSession() {
         threadCount = 30
         shutdown()
-        val namespace = "myNamespace"
+        val namespace = "trackWithSession"
         TestUtils.createSessionSharedPreferences(context, namespace)
         val mockWebServer = getMockServer(1)
         val builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
@@ -369,7 +369,7 @@ class TrackerTest {
 
     @Test
     fun testTrackScreenView() {
-        val namespace = "myNamespace"
+        val namespace = "trackScreenView"
         TestUtils.createSessionSharedPreferences(context, namespace)
         val builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
         val emitter = Emitter(
@@ -412,7 +412,7 @@ class TrackerTest {
 
     @Test
     fun testTrackUncaughtException() {
-        val namespace = "myNamespace"
+        val namespace = "trackUncaughtException"
         TestUtils.createSessionSharedPreferences(context, namespace)
         Thread.setDefaultUncaughtExceptionHandler(
             TestExceptionHandler("Illegal State Exception has been thrown!")
@@ -441,7 +441,7 @@ class TrackerTest {
 
     @Test
     fun testExceptionHandler() {
-        val namespace = "myNamespace"
+        val namespace = "exceptionHandler"
         TestUtils.createSessionSharedPreferences(context, namespace)
         val handler = TestExceptionHandler("Illegal State Exception has been thrown!")
         Thread.setDefaultUncaughtExceptionHandler(handler)

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/PluginsTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/PluginsTest.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.snowplowanalytics.snowplow.Snowplow
+import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
+import com.snowplowanalytics.snowplow.configuration.Configuration
+import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration
+import com.snowplowanalytics.snowplow.configuration.PluginConfiguration
+import com.snowplowanalytics.snowplow.controller.TrackerController
+import com.snowplowanalytics.snowplow.event.ScreenView
+import com.snowplowanalytics.snowplow.event.SelfDescribing
+import com.snowplowanalytics.snowplow.event.Structured
+import com.snowplowanalytics.snowplow.network.HttpMethod
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+import org.junit.After
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class PluginsTest {
+
+    @After
+    fun tearDown() {
+        removeAllTrackers()
+    }
+
+    // --- TESTS
+    @Test
+    fun addsEntitiesToEvent() {
+        val plugin = PluginConfiguration("plugin")
+        plugin.entities { Collections.singletonList(
+            SelfDescribingJson("schema", Collections.singletonMap("val", it.payload["se_ca"]))
+        ) }
+
+        val testPlugin = PluginConfiguration("test")
+        var expectation = false
+        testPlugin.afterTrack {
+            expectation = it.entities.filter {
+                val data = it.map["data"] as Map<*, *>?
+                it.map["schema"] == "schema" && data?.get("val") == "cat"
+            }.isNotEmpty()
+        }
+
+        val tracker = createTracker(listOf(plugin, testPlugin))
+        tracker.track(Structured("cat", "act"))
+
+        Thread.sleep(100)
+        Assert.assertTrue(expectation)
+    }
+
+    @Test
+    fun addsEntitiesFromMultiplePlugins() {
+        val plugin1 = PluginConfiguration("plugin1")
+        plugin1.entities { listOf(SelfDescribingJson("schema1", emptyMap<String, String>())) }
+
+        val plugin2 = PluginConfiguration("plugin2")
+        plugin2.entities { listOf(SelfDescribingJson("schema2", emptyMap<String, String>())) }
+
+        val testPlugin = PluginConfiguration("test")
+        var expectation = false
+        testPlugin.afterTrack {
+            expectation = it.entities.filter { it.map["schema"] == "schema1" }.size == 1 &&
+                    it.entities.filter { it.map["schema"] == "schema2" }.size == 1
+        }
+
+        val tracker = createTracker(listOf(plugin1, plugin2, testPlugin))
+        tracker.track(ScreenView("sv"))
+
+        Thread.sleep(100)
+        Assert.assertTrue(expectation)
+    }
+
+    @Test
+    fun addsEntitiesOnlyForEventsMatchingSchema() {
+        val plugin = PluginConfiguration("plugin")
+        plugin.entities(listOf("schema1")) {
+            listOf(SelfDescribingJson("xx", emptyMap<String, String>()))
+        }
+
+        var event1HasEntity: Boolean? = null
+        var event2HasEntity: Boolean? = null
+
+        val testPlugin = PluginConfiguration("test")
+        testPlugin.afterTrack {
+            if (it.schema == "schema1") {
+                event1HasEntity = it.entities.filter { it.map["schema"] == "xx" }.isNotEmpty()
+            }
+            if (it.schema == "schema2") {
+                event2HasEntity = it.entities.filter { it.map["schema"] == "xx" }.isNotEmpty()
+            }
+        }
+
+        val tracker = createTracker(listOf(plugin, testPlugin))
+        tracker.track(SelfDescribing("schema1", emptyMap()))
+        tracker.track(SelfDescribing("schema2", emptyMap()))
+
+        Thread.sleep(100)
+        Assert.assertTrue(event1HasEntity!!)
+        Assert.assertFalse(event2HasEntity!!)
+    }
+
+    @Test
+    fun callsAfterTrackOnlyForEventsMatchingSchema() {
+        var event1Called = false
+        var event2Called = false
+        var event3Called = false
+
+        val plugin = PluginConfiguration("plugin")
+        plugin.afterTrack(listOf("schema1")) {
+            if (it.schema == "schema1") { event1Called = true }
+            if (it.schema == "schema2") { event2Called = true }
+            if (it.schema == null) { event3Called = true }
+        }
+
+        val tracker = createTracker(listOf(plugin))
+        tracker.track(SelfDescribing("schema1", emptyMap()))
+        tracker.track(SelfDescribing("schema2", emptyMap()))
+        tracker.track(Structured("cat", "act"))
+
+        Thread.sleep(100)
+        Assert.assertTrue(event1Called)
+        Assert.assertFalse(event2Called)
+        Assert.assertFalse(event3Called)
+    }
+
+    @Test
+    fun callsAfterTrackOnlyForStructuredEvent() {
+        var selfDescribingCalled = false
+        var structuredCalled = false
+
+        val plugin = PluginConfiguration("plugin")
+        plugin.afterTrack(listOf("se")) {
+            if (it.schema == "schema1") { selfDescribingCalled = true }
+            if (it.schema == null) { structuredCalled = true }
+        }
+
+        val tracker = createTracker(listOf(plugin))
+        tracker.track(SelfDescribing("schema1", emptyMap()))
+        tracker.track(Structured("cat", "act"))
+
+        Thread.sleep(100)
+        Assert.assertTrue(structuredCalled)
+        Assert.assertFalse(selfDescribingCalled)
+    }
+
+    @Test
+    fun addsPluginToTracker() {
+        val tracker = createTracker(emptyList())
+
+        val plugin = PluginConfiguration("plugin")
+        var expectation = false
+        plugin.afterTrack { expectation = true }
+        tracker.plugins.addPlugin(plugin)
+
+        tracker.track(ScreenView("sv"))
+
+        Thread.sleep(100)
+        Assert.assertTrue(expectation)
+    }
+
+    @Test
+    fun removesPluginFromTracker() {
+        var pluginCalled = false
+        val plugin = PluginConfiguration("plugin")
+        plugin.afterTrack { pluginCalled = true }
+
+        val tracker = createTracker(listOf(plugin))
+        tracker.plugins.removePlugin("plugin")
+
+        tracker.track(ScreenView("sv"))
+
+        Thread.sleep(100)
+        Assert.assertFalse(pluginCalled)
+    }
+
+    // --- PRIVATE
+    private val context: Context
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun createTracker(configurations: List<Configuration>): TrackerController {
+        val networkConfig = NetworkConfiguration(MockNetworkConnection(HttpMethod.POST, 200))
+        return Snowplow.createTracker(
+            context,
+            namespace = "ns" + Math.random().toString(),
+            network = networkConfig,
+            configurations = configurations.toTypedArray()
+        )
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/gdpr/GdprControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/gdpr/GdprControllerImpl.kt
@@ -13,7 +13,7 @@ class GdprControllerImpl(serviceProvider: ServiceProviderInterface) : Controller
     private var gdpr: Gdpr? = null
     
     override val basisForProcessing: Basis?
-        get() = if (gdpr == null) { null } else gdpr!!.basisForProcessing
+        get() = gdpr?.basisForProcessing
             
     override val documentId: String?
         get() = if (gdpr == null) { null } else gdpr!!.documentId

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/globalcontexts/GlobalContextPluginConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/globalcontexts/GlobalContextPluginConfiguration.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.core.globalcontexts
+
+import com.snowplowanalytics.snowplow.configuration.PluginAfterTrackConfiguration
+import com.snowplowanalytics.snowplow.configuration.PluginConfigurationInterface
+import com.snowplowanalytics.snowplow.configuration.PluginEntitiesConfiguration
+import com.snowplowanalytics.snowplow.globalcontexts.GlobalContext
+
+class GlobalContextPluginConfiguration(
+    override val identifier: String,
+    val globalContext: GlobalContext
+) : PluginConfigurationInterface {
+
+    override val afterTrackConfiguration: PluginAfterTrackConfiguration? = null
+
+    override val entitiesConfiguration: PluginEntitiesConfiguration
+        get() = PluginEntitiesConfiguration(closure = globalContext::generateContexts)
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkStateMachine.kt
@@ -18,7 +18,7 @@ import com.snowplowanalytics.snowplow.event.DeepLinkReceived
 import com.snowplowanalytics.snowplow.event.Event
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 import com.snowplowanalytics.snowplow.tracker.InspectableEvent
-import java.util.*
+import kotlin.collections.ArrayList
 
 class DeepLinkStateMachine : StateMachineInterface {
     /*
@@ -33,6 +33,9 @@ class DeepLinkStateMachine : StateMachineInterface {
       - ReadyForOutput
       */
 
+    override val identifier: String
+        get() = ID
+
     override val subscribedEventSchemasForTransitions: List<String>
         get() = listOf(DeepLinkReceived.schema, TrackerConstants.SCHEMA_SCREEN_VIEW)
 
@@ -41,6 +44,9 @@ class DeepLinkStateMachine : StateMachineInterface {
 
     override val subscribedEventSchemasForPayloadUpdating: List<String>
         get() = ArrayList()
+
+    override val subscribedEventSchemasForAfterTrackCallback: List<String>
+        get() = emptyList()
 
     override fun transition(event: Event, state: State?): State? {
         // - Init (DL) DeepLinkReceived
@@ -77,5 +83,13 @@ class DeepLinkStateMachine : StateMachineInterface {
 
     override fun payloadValues(event: InspectableEvent, state: State?): Map<String, Any>? {
         return null
+    }
+
+    override fun afterTrack(event: InspectableEvent) {
+    }
+
+    companion object {
+        val ID: String
+            get() = "DeepLinkContext"
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleStateMachine.kt
@@ -17,6 +17,9 @@ class LifecycleStateMachine : StateMachineInterface {
      Entity Generation:
       - Visible, NotVisible
      */
+
+    override val identifier: String
+        get() = ID
     
     override val subscribedEventSchemasForTransitions: List<String>
         get() = listOf(Background.schema, Foreground.schema)
@@ -25,6 +28,9 @@ class LifecycleStateMachine : StateMachineInterface {
         get() = listOf("*")
 
     override val subscribedEventSchemasForPayloadUpdating: List<String>
+        get() = emptyList()
+
+    override val subscribedEventSchemasForAfterTrackCallback: List<String>
         get() = emptyList()
 
     override fun transition(event: Event, currentState: State?): State? {
@@ -46,5 +52,13 @@ class LifecycleStateMachine : StateMachineInterface {
 
     override fun payloadValues(event: InspectableEvent, state: State?): Map<String, Any>? {
         return null
+    }
+
+    override fun afterTrack(event: InspectableEvent) {
+    }
+
+    companion object {
+        val ID: String
+            get() = "Lifecycle"
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
@@ -47,7 +47,7 @@ class PluginStateMachine(
         return null
     }
 
-    override fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson>? {
+    override fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson> {
         return entitiesConfiguration?.closure?.apply(event) ?: emptyList()
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.core.statemachine
+
+import com.snowplowanalytics.snowplow.configuration.PluginAfterTrackConfiguration
+import com.snowplowanalytics.snowplow.configuration.PluginEntitiesConfiguration
+import com.snowplowanalytics.snowplow.event.Event
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent
+import java.util.*
+
+class PluginStateMachine(
+    override val identifier: String,
+    val entitiesConfiguration: PluginEntitiesConfiguration?,
+    val afterTrackConfiguration: PluginAfterTrackConfiguration?
+) : StateMachineInterface {
+
+    override val subscribedEventSchemasForTransitions: List<String>
+        get() = emptyList()
+
+    override val subscribedEventSchemasForEntitiesGeneration: List<String>
+        get() {
+            val config = entitiesConfiguration ?: return emptyList()
+            return config.schemas ?: Collections.singletonList("*")
+        }
+
+    override val subscribedEventSchemasForPayloadUpdating: List<String>
+        get() = emptyList()
+
+    override val subscribedEventSchemasForAfterTrackCallback: List<String>
+        get() {
+            val config = afterTrackConfiguration ?: return emptyList()
+            return config.schemas ?: Collections.singletonList("*")
+        }
+
+    override fun transition(event: Event, state: State?): State? {
+        return null
+    }
+
+    override fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson>? {
+        return entitiesConfiguration?.closure?.apply(event) ?: emptyList()
+    }
+
+    override fun payloadValues(event: InspectableEvent, state: State?): Map<String, Any>? {
+        return null
+    }
+
+    override fun afterTrack(event: InspectableEvent) {
+        afterTrackConfiguration?.closure?.accept(event)
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineInterface.kt
@@ -5,10 +5,13 @@ import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 import com.snowplowanalytics.snowplow.tracker.InspectableEvent
 
 interface StateMachineInterface {
+    val identifier: String
     val subscribedEventSchemasForTransitions: List<String>
     val subscribedEventSchemasForEntitiesGeneration: List<String>
     val subscribedEventSchemasForPayloadUpdating: List<String>
+    val subscribedEventSchemasForAfterTrackCallback: List<String>
     fun transition(event: Event, state: State?): State?
     fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson>?
     fun payloadValues(event: InspectableEvent, state: State?): Map<String, Any>?
+    fun afterTrack(event: InspectableEvent)
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PluginsControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PluginsControllerImpl.kt
@@ -20,9 +20,9 @@ class PluginsControllerImpl
     (serviceProvider: ServiceProvider) : Controller(serviceProvider), PluginsController {
 
     override val identifiers: List<String>
-    get() {
-        return serviceProvider.pluginConfigurations.map { it.identifier }
-    }
+        get() {
+            return serviceProvider.pluginConfigurations.map { it.identifier }
+        }
 
     override fun addPlugin(plugin: PluginConfigurationInterface) {
         serviceProvider.addPlugin(plugin)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PluginsControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PluginsControllerImpl.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.core.tracker
+
+import com.snowplowanalytics.core.Controller
+import com.snowplowanalytics.snowplow.configuration.PluginConfigurationInterface
+import com.snowplowanalytics.snowplow.controller.PluginsController
+
+class PluginsControllerImpl
+    (serviceProvider: ServiceProvider) : Controller(serviceProvider), PluginsController {
+
+    override val identifiers: List<String>
+    get() {
+        return serviceProvider.pluginConfigurations.map { it.identifier }
+    }
+
+    override fun addPlugin(plugin: PluginConfigurationInterface) {
+        serviceProvider.addPlugin(plugin)
+    }
+
+    override fun removePlugin(identifier: String) {
+        serviceProvider.removePlugin(identifier)
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ScreenStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ScreenStateMachine.kt
@@ -19,6 +19,9 @@ class ScreenStateMachine : StateMachineInterface {
      Entity Generation:
       - Screen
      */
+
+    override val identifier: String
+        get() = ID
     
     override val subscribedEventSchemasForTransitions: List<String>
         get() = listOf(TrackerConstants.SCHEMA_SCREEN_VIEW)
@@ -28,6 +31,9 @@ class ScreenStateMachine : StateMachineInterface {
 
     override val subscribedEventSchemasForPayloadUpdating: List<String>
         get() = listOf(TrackerConstants.SCHEMA_SCREEN_VIEW)
+
+    override val subscribedEventSchemasForAfterTrackCallback: List<String>
+        get() = emptyList()
 
     override fun transition(event: Event, state: State?): State? {
         val screenView = event as? ScreenView
@@ -78,5 +84,13 @@ class ScreenStateMachine : StateMachineInterface {
             return addedValues
         }
         return null
+    }
+
+    override fun afterTrack(event: InspectableEvent) {
+    }
+
+    companion object {
+        val ID: String
+            get() = "ScreenContext"
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProviderInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProviderInterface.kt
@@ -6,6 +6,7 @@ import com.snowplowanalytics.core.gdpr.GdprControllerImpl
 import com.snowplowanalytics.core.globalcontexts.GlobalContextsControllerImpl
 import com.snowplowanalytics.core.session.SessionConfigurationUpdate
 import com.snowplowanalytics.core.session.SessionControllerImpl
+import com.snowplowanalytics.snowplow.configuration.PluginConfigurationInterface
 
 interface ServiceProviderInterface {
     val namespace: String
@@ -24,6 +25,7 @@ interface ServiceProviderInterface {
     fun getOrMakeGlobalContextsController(): GlobalContextsControllerImpl
     fun getOrMakeSubjectController(): SubjectControllerImpl
     fun getOrMakeSessionController(): SessionControllerImpl
+    val pluginsController: PluginsControllerImpl
 
     // Configuration Updates
     val trackerConfigurationUpdate: TrackerConfigurationUpdate
@@ -32,4 +34,9 @@ interface ServiceProviderInterface {
     val emitterConfigurationUpdate: EmitterConfigurationUpdate
     val sessionConfigurationUpdate: SessionConfigurationUpdate
     val gdprConfigurationUpdate: GdprConfigurationUpdate
+
+    // Plugins
+    val pluginConfigurations: List<PluginConfigurationInterface>
+    fun addPlugin(plugin: PluginConfigurationInterface)
+    fun removePlugin(identifier: String)
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -497,7 +497,7 @@ class Tracker(emitter: Emitter, val namespace: String, var appId: String, contex
         // Context entities
         addBasicContexts(event)
         addStateMachineEntities(event)
-        event.wrapContextsToPayload(payload, base64Encoded=base64Encoded)
+        event.wrapEntitiesToPayload(payload, base64Encoded=base64Encoded)
 
         // Workaround for campaign attribution
         if (!event.isPrimitive) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerControllerImpl.kt
@@ -32,6 +32,8 @@ class TrackerControllerImpl  // Constructors
             val sessionController = sessionController
             return if (sessionController.isEnabled) sessionController else null
         }
+    override val plugins: PluginsController
+        get() = serviceProvider.pluginsController
 
     // Control methods
     override fun pause() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerEvent.kt
@@ -77,7 +77,7 @@ class TrackerEvent @JvmOverloads constructor(event: Event, state: TrackerStateSn
         entities.add(entity)
     }
 
-    fun wrapContextsToPayload(payload: Payload, base64Encoded: Boolean) {
+    fun wrapEntitiesToPayload(payload: Payload, base64Encoded: Boolean) {
         if (entities.isEmpty()) {
             return
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/GlobalContextsConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/GlobalContextsConfiguration.kt
@@ -1,5 +1,6 @@
 package com.snowplowanalytics.snowplow.configuration
 
+import com.snowplowanalytics.core.globalcontexts.GlobalContextPluginConfiguration
 import com.snowplowanalytics.core.globalcontexts.GlobalContextsConfigurationInterface
 import com.snowplowanalytics.snowplow.globalcontexts.GlobalContext
 
@@ -56,5 +57,14 @@ class GlobalContextsConfiguration(contextGenerators: MutableMap<String, GlobalCo
     // Copyable
     override fun copy(): GlobalContextsConfiguration {
         return GlobalContextsConfiguration(contextGenerators)
+    }
+
+    internal fun toPluginConfigurations(): List<GlobalContextPluginConfiguration> {
+        return contextGenerators.map {
+            GlobalContextPluginConfiguration(
+                identifier = it.key,
+                globalContext = it.value
+            )
+        }
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PluginConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PluginConfiguration.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.configuration
+
+import com.snowplowanalytics.core.statemachine.PluginStateMachine
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent
+import java.util.function.Consumer
+import java.util.function.Function
+
+/**
+ * Provides a block closure to be called after events are tracked.
+ * Optionally, you can specify the event schemas for which the block should be called.
+ *
+ * @property schemas Optional list of event schemas to call the block for. If null, the block is called for all events.
+ * @property closure Block to call after events are tracked.
+ */
+class PluginAfterTrackConfiguration(
+    val schemas: List<String>? = null,
+    val closure: Consumer<InspectableEvent>
+)
+
+/**
+ * Provides a block closure that returns a list of context entities and is called when events are tracked.
+ *  Optionally, you can specify the event schemas for which the block should be called.
+ *
+ *  @property schemas Optional list of event schemas to call the block for. If null, the block is called for all events.
+ *  @property closure Block that produces entities, called when events are tracked.
+ */
+class PluginEntitiesConfiguration(
+    val schemas: List<String>? = null,
+    val closure: Function<InspectableEvent, List<SelfDescribingJson>>
+)
+
+/**
+ * Interface for tracker plugin definition.
+ * Specifies configurations for the closures called when and after events are tracked.
+ *
+ * @property identifier Unique identifier of the plugin within the tracker.
+ * @property entitiesConfiguration Closure configuration that is called when events are tracked to generate context entities to enrich the events.
+ * @property afterTrackConfiguration Closure configuration that is called after events are tracked.
+ */
+interface PluginConfigurationInterface {
+    val identifier: String
+    val entitiesConfiguration: PluginEntitiesConfiguration?
+    val afterTrackConfiguration: PluginAfterTrackConfiguration?
+}
+
+internal fun PluginConfigurationInterface.toStateMachine(): PluginStateMachine {
+    return PluginStateMachine(
+        identifier = identifier,
+        entitiesConfiguration = entitiesConfiguration,
+        afterTrackConfiguration = afterTrackConfiguration
+    )
+}
+
+/**
+ * Configuration for a custom tracker plugin.
+ * Enables you to add closures to be called when and after events are tracked in the tracker.
+ */
+class PluginConfiguration(
+    override val identifier: String
+) : Configuration, PluginConfigurationInterface {
+    override var entitiesConfiguration: PluginEntitiesConfiguration? = null
+    override var afterTrackConfiguration: PluginAfterTrackConfiguration? = null
+
+    /**
+     * Add a closure that generates entities for a given tracked event.
+     *
+     * @param schemas Optional list of event schemas to call the closure for. If null, the closure is called for all events.
+     * @param closure Closure that produces entities, called when events are tracked.
+     */
+    fun entities(
+        schemas: List<String>? = null,
+        closure: Function<InspectableEvent, List<SelfDescribingJson>>
+    ) {
+        entitiesConfiguration = PluginEntitiesConfiguration(
+            schemas = schemas,
+            closure = closure
+        )
+    }
+
+    /**
+     * Add a closure that is called after the events are tracked.
+     * The closure is called after the events are added to event queue in Emitter, not necessarily after they are sent to the Collector.
+     *
+     * @param schemas Optional list of event schemas to call the closure for. If null, the closure is called for all events.
+     * @param closure Closure block to call after events are tracked.
+     */
+    fun afterTrack(
+        schemas: List<String>? = null,
+        closure: Consumer<InspectableEvent>
+    ) {
+        afterTrackConfiguration = PluginAfterTrackConfiguration(
+            schemas = schemas,
+            closure = closure
+        )
+    }
+
+    override fun copy(): Configuration {
+        val copy = PluginConfiguration(
+            identifier=identifier,
+        )
+        entitiesConfiguration?.let { copy.entities(schemas = it.schemas, closure = it.closure) }
+        afterTrackConfiguration?.let { copy.afterTrack(schemas = it.schemas, closure = it.closure) }
+        return copy
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/PluginsController.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/PluginsController.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015-2022 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.controller
+
+import com.snowplowanalytics.snowplow.configuration.PluginConfigurationInterface
+
+/**
+ * Controller for managing plugins initialized in the tracker
+ */
+interface PluginsController {
+    /**
+     * List of initialized plugin identifiers
+     */
+    val identifiers: List<String>
+
+    /**
+     * Add a new plugin
+     */
+    fun addPlugin(plugin: PluginConfigurationInterface)
+
+    /**
+     * Remove plugin with the identifier
+     */
+    fun removePlugin(identifier: String)
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/TrackerController.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/TrackerController.kt
@@ -56,6 +56,12 @@ interface TrackerController : TrackerConfigurationInterface {
      * @apiNote Don't retain the reference. It may change on tracker reconfiguration.
      */
     val globalContexts: GlobalContextsController
+
+    /**
+     * Controller for managing tracker plugins
+     * @apiNote Don't retain the reference. It may change on tracker reconfiguration.
+     */
+    val plugins: PluginsController
     
     // Methods
     /**


### PR DESCRIPTION
Issue #574 

Implements the ability to provide custom plugins that can intercept tracked events. Plugins provide callbacks that can enrich events with additional entities and inspect tracked events.

**Code snippet**

The API is explained in this snippet:

```kt
// identifier needs uniquely identify the plugin
val plugin = PluginConfiguration("myPlugin")

// entities closure can return context entities to enrich events
// the list of schemas to call the closure for is optional (it will be called for all events if null)
plugin.entities(listOf("iglu:...")) {
    return [
        SelfDescribingJson(schema: "iglu:xx", andData: ["yy": true])
    ]
}

// after track callback called on a background thread to inspect final tracked events
// one can also supply a list of schemas to call the closure only for specific events
plugin.afterTrack {
    print("Tracked event with $event.entities.size entities")
}

// the plugin is supplied to the tracker as a configuration
val tracker = Snowplow.createTracker(
    context = context,
    namespace = "ns",
    network = networkConfig,
    plugin
)

// one can inspect the enabled plugins and get the list of their identifiers
val pluginIdentifiers = tracker.plugins.identifiers

// add additional plugins (using PluginConfiguration as above)
tracker.plugins.addPlugin(otherPlugin)

// remove registered plugins by their identifiers
tracker.plugins.removePlugin("myPlugin")
```

**Implemented using state machines**

On the background, plugins are implemented using `PluginStateMachine` state machine. Each plugin has a separate state machine with the same identifier. The state machine calls the plugin closures in the `entities()` and `afterTrack()` functions.

**After track callback**

In order to implement the `afterTrack()` callback (which will be useful in plugins such as the one for FocalMeter, see other PR), I had to add this API to the state machines. It is called on a background thread to enable the plugins to make API requests without blocking the tracking code.

**Global context**

I changed the internal implementation of global contexts so that it is now built using plugins. This simplifies the code since we don't have deal with global contexts as a special case in `Tracker`, it is just another plugin/state machine.

The implementation was straightforward, since global context just adds entities based on some conditions which can be done in the `entities` closure in plugins.

There were no public API changes required to global context (from outside, it looks the same).

**Other refactoring in `Tracker`**

Finally, I tried to tidy up the code in the `Tracker.transformEvent()` and `Tracker.payload()` functions to make it more clear what is the sequence of the processing steps when events are tracked.