### PR TITLE
Fix crash with null pointer when accessing session (close #581)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/ConfigurationTest.java
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/ConfigurationTest.java
@@ -113,6 +113,15 @@ public class ConfigurationTest {
     }
 
     @Test
+    public void sessionIdEmptyBeforeSessionInitialized() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        NetworkConfiguration networkConfig = new NetworkConfiguration("fake-url", HttpMethod.POST);
+        TrackerController tracker = Snowplow.createTracker(context, "emptySessionIdTest", networkConfig);
+        String sessionId = tracker.getSession().getSessionId();
+        assertEquals("", sessionId);
+    }
+
+    @Test
     public void sessionControllerUnavailableWhenContextTurnedOff() {
         Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         NetworkConfiguration networkConfiguration = new NetworkConfiguration("fake-url", HttpMethod.POST);

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/SessionController.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/SessionController.java
@@ -15,6 +15,7 @@ public interface SessionController extends SessionConfigurationInterface {
     /**
      * The session identifier.
      * A unique identifier which is used to identify the session.
+     * Returns an empty string if accessed before the session is initialized.
      */
     @NonNull
     String getSessionId();

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/Session.java
@@ -181,7 +181,7 @@ public class Session {
      *
      * @return a SelfDescribingJson containing the session context
      */
-    @NonNull
+    @Nullable
     public synchronized SelfDescribingJson getSessionContext(@NonNull String eventId, long eventTimestamp, boolean userAnonymisation) {
         Logger.v(TAG, "Getting session context...");
         if (isSessionCheckerEnabled) {
@@ -197,6 +197,10 @@ public class Session {
             }
             lastSessionCheck = System.currentTimeMillis();
         }
+
+        SessionState state = getState();
+        if (state == null) { return null; }
+
         eventIndex += 1;
 
         Map<String, Object> sessionValues = state.getSessionValues();

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionControllerImpl.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/session/SessionControllerImpl.java
@@ -69,7 +69,12 @@ public class SessionControllerImpl extends Controller implements SessionControll
             Logger.track(TAG, "Attempt to access SessionController fields when disabled");
             return "";
         }
-        return session.getState().getSessionId();
+        SessionState state = session.getState();
+        if (state == null) {
+            Logger.track(TAG, "Attempt to access session information before session was initialized, use the onSessionUpdate callback");
+            return "";
+        }
+        return state.getSessionId();
     }
 
     @NonNull

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/internal/tracker/Tracker.java
@@ -755,7 +755,9 @@ public class Tracker {
                 return;
             }
             SelfDescribingJson sessionContextJson = sessionManager.getSessionContext(eventId, eventTimestamp, userAnonymisation);
-            event.contexts.add(sessionContextJson);
+            if (sessionContextJson != null) {
+                event.contexts.add(sessionContextJson);
+            }
         }
     }
 


### PR DESCRIPTION
Issue #581 

## Null pointer in `Session.getSessionContext`

I was able to replicate the null pointer exception reported in the issue in case session tracking is paused and no events have been tracked yet. In that case, the `state` internal variable is not initialised before being accessed. This can occur in remote configuration when the tracker re-created after retrieving a new configuration.

I created a test case that tested this scenario and fixed it by not adding the session context entity if session tracking is paused and state not initialised.

## Null pointer `SessionController.getSessionId`

This can happen when accessing the session ID before the session state is created. We should return a nullable string from the function, but that would be a breaking change here (we do that in v4). So instead I decided to just return an empty string in case the state is null.