### PR TITLE
Track new properties in platform context version 1-0-3 and make it configurable which properties to track (close #598)

### DIFF
--- a/snowplow-demo-kotlin/build.gradle
+++ b/snowplow-demo-kotlin/build.gradle
@@ -40,4 +40,5 @@ dependencies {
     implementation project(':snowplow-android-tracker')
     implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.browser:browser:1.5.0'
+    implementation 'com.google.android.gms:play-services-appset:16.0.2'
 }

--- a/snowplow-demo-kotlin/src/main/AndroidManifest.xml
+++ b/snowplow-demo-kotlin/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
         >
         <activity
             android:name=".MainActivity"
-            android:screenOrientation="portrait"
+            android:screenOrientation="fullSensor"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -30,7 +30,7 @@
         <activity
             android:name=".Demo"
             android:label="@string/title_activity_demo"
-            android:screenOrientation="portrait">
+            android:screenOrientation="fullSensor">
         </activity>
     </application>
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/MockDeviceInfoMonitor.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/MockDeviceInfoMonitor.kt
@@ -87,6 +87,32 @@ class MockDeviceInfoMonitor : DeviceInfoMonitor() {
             return 70000
         }
 
+    override val language: String?
+        get() {
+            increaseMethodAccessCount("language")
+            return "sk"
+        }
+
+    override fun getResolution(context: Context): String? {
+        increaseMethodAccessCount("getResolution")
+        return "1024x768"
+    }
+
+    override fun getScale(context: Context): Float? {
+        increaseMethodAccessCount("getScale")
+        return 2.0f
+    }
+
+    override fun getIsPortrait(context: Context): Boolean? {
+        increaseMethodAccessCount("getIsPortrait")
+        return true
+    }
+
+    override fun getAppSetIdAndScope(context: Context): Pair<String, String>? {
+        increaseMethodAccessCount("getAppSetIdAndScope")
+        return Pair("XXX", "app")
+    }
+
     fun getMethodAccessCount(methodName: String): Int {
         return if (methodAccessCounts.containsKey(methodName)) {
             methodAccessCounts[methodName]!!

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
@@ -129,7 +129,7 @@ class StateManagerTest {
             tracker.base64Encoded = false
             tracker.logLevel = LogLevel.VERBOSE
         }
-        val tracker = Tracker(emitter, "namespace", "appId", context, trackerBuilder)
+        val tracker = Tracker(emitter, "namespace", "appId", null, context, trackerBuilder)
 
         // Send events
         tracker.track(Timing("category", "variable", 123))
@@ -223,7 +223,7 @@ class StateManagerTest {
             tracker.base64Encoded = false
             tracker.logLevel = LogLevel.VERBOSE
         }
-        val tracker = Tracker(emitter, "namespace", "appId", context, trackerBuilder)
+        val tracker = Tracker(emitter, "namespace", "appId", null, context, trackerBuilder)
 
         // Send events
         tracker.track(Timing("category", "variable", 123))
@@ -298,7 +298,7 @@ class StateManagerTest {
             tracker.sessionContext = false
             tracker.platformContextEnabled = false
         }
-        val tracker = Tracker(emitter, "namespace", "appId", context, trackerBuilder)
+        val tracker = Tracker(emitter, "namespace", "appId", null, context, trackerBuilder)
 
         // Send events
         tracker.track(Timing("category", "variable", 123))

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
@@ -107,7 +107,7 @@ class TrackerTest {
             tracker.installAutotracking = installTracking
             tracker.applicationContext = true
         }
-        Companion.tracker = Tracker(emitter, "myNamespace", "myAppId", context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, "myNamespace", "myAppId", null, context, trackerBuilder)
         return Companion.tracker
     }
 
@@ -209,7 +209,7 @@ class TrackerTest {
             tracker.screenViewAutotracking = false
         }
         Companion.tracker =
-            Tracker(emitter!!, namespace, "testTrackWithNoContext", context, trackerBuilder)
+            Tracker(emitter!!, namespace, "testTrackWithNoContext", null, context, trackerBuilder)
         val eventStore = emitter.eventStore
         if (eventStore != null) {
             val isClean = eventStore.removeAllEvents()
@@ -273,7 +273,7 @@ class TrackerTest {
             tracker.screenViewAutotracking = false
         }
         Companion.tracker =
-            Tracker(emitter!!, namespace, "testTrackWithNoContext", context, trackerBuilder)
+            Tracker(emitter!!, namespace, "testTrackWithNoContext", null, context, trackerBuilder)
         
         Log.i("testTrackWithNoContext", "Send ScreenView event")
         Companion.tracker!!.track(ScreenView("name"))
@@ -325,7 +325,7 @@ class TrackerTest {
             tracker.exceptionAutotracking = false
             tracker.screenViewAutotracking = false
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
         Companion.tracker!!.pauseEventTracking()
         val eventId = Companion.tracker!!.track(ScreenView("name"))
         Assert.assertNull(eventId)
@@ -359,7 +359,7 @@ class TrackerTest {
             tracker.foregroundTimeout = 5
             tracker.backgroundTimeout = 5
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
         Assert.assertNotNull(Companion.tracker!!.session)
         Companion.tracker!!.resumeSessionChecking()
         Thread.sleep(2000)
@@ -388,7 +388,7 @@ class TrackerTest {
             tracker.foregroundTimeout = 5
             tracker.backgroundTimeout = 5
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
         val screenState = Companion.tracker!!.getScreenState()
         Assert.assertNotNull(screenState)
         var screenStateMapWrapper: Map<String, Any?> = screenState!!.getCurrentScreen(true).map
@@ -431,7 +431,7 @@ class TrackerTest {
             tracker.exceptionAutotracking = true
             tracker.screenViewAutotracking = false
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
         Assert.assertTrue(Companion.tracker!!.exceptionAutotracking)
         Assert.assertEquals(
             ExceptionHandler::class.java,
@@ -459,7 +459,7 @@ class TrackerTest {
             tracker.exceptionAutotracking = false
             tracker.screenViewAutotracking = false
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
         val handler1 = ExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler(handler1)
         Assert.assertEquals(
@@ -489,7 +489,7 @@ class TrackerTest {
             tracker.foregroundTimeout = 5
             tracker.backgroundTimeout = 5
         }
-        Companion.tracker = Tracker(emitter, "ns", "myAppId", context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, "ns", "myAppId", null, context, trackerBuilder)
         
         Companion.tracker!!.track(Structured("c", "a"))
         val sessionIdStart = Companion.tracker!!.session!!.state!!.sessionId

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/LoggingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/LoggingTest.kt
@@ -71,6 +71,7 @@ class LoggingTest {
             emitter!!,
             "namespace",
             "myAppId",
+            null,
             ApplicationProvider.getApplicationContext(),
             trackerBuilder
         )
@@ -105,6 +106,7 @@ class LoggingTest {
             emitter!!,
             "namespace",
             "myAppId",
+            null,
             ApplicationProvider.getApplicationContext(),
             trackerBuilder
         )
@@ -138,6 +140,7 @@ class LoggingTest {
             emitter!!,
             "namespace",
             "myAppId",
+            null,
             ApplicationProvider.getApplicationContext(),
             trackerBuilder
         )

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.kt
@@ -218,7 +218,7 @@ class SessionTest {
             tracker.foregroundTimeout = 100
             tracker.backgroundTimeout = 2
         }
-        val tracker = Tracker(emitter, "tracker", "app", context, trackerBuilder)
+        val tracker = Tracker(emitter, "tracker", "app", null, context, trackerBuilder)
         val session = tracker.session
         
         getSessionContext(session, "event_1", timestamp, false)
@@ -257,7 +257,7 @@ class SessionTest {
             tracker.foregroundTimeout = 100
             tracker.backgroundTimeout = 2
         }
-        val tracker = Tracker(emitter, "tracker", "app", context, trackerBuilder)
+        val tracker = Tracker(emitter, "tracker", "app", null, context, trackerBuilder)
         val session = tracker.session
         getSessionContext(session, "event_1", timestamp, false)
         var sessionState = session!!.state
@@ -338,8 +338,8 @@ class SessionTest {
             tracker.foregroundTimeout = 20
             tracker.backgroundTimeout = 20
         }
-        val tracker1 = Tracker(emitter, "tracker1", "app", context, trackerBuilder)
-        val tracker2 = Tracker(emitter, "tracker2", "app", context, trackerBuilder)
+        val tracker1 = Tracker(emitter, "tracker1", "app", null, context, trackerBuilder)
+        val tracker2 = Tracker(emitter, "tracker2", "app", null, context, trackerBuilder)
         val session1 = tracker1.session
         val session2 = tracker2.session
         session1!!.getSessionContext("session1-fake-id1", timestamp, false)
@@ -364,7 +364,7 @@ class SessionTest {
         val id2 = session2.state!!.sessionId
 
         // Recreate tracker2
-        val tracker2b = Tracker(emitter, "tracker2", "app", context, trackerBuilder)
+        val tracker2b = Tracker(emitter, "tracker2", "app", null, context, trackerBuilder)
         tracker2b.session!!.getSessionContext("session2b-fake-id3", timestamp, false)
         val initialValue2b = tracker2b.session!!.sessionIndex?.toLong()
         val previousId2b = tracker2b.session!!.state!!.previousSessionId

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
@@ -220,6 +220,7 @@ class EventSendingTest {
             emitter,
             ns,
             "myAppId",
+            null,
             InstrumentationRegistry.getInstrumentation().targetContext,
             trackerBuilder
         )

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/Parameters.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/Parameters.kt
@@ -120,6 +120,12 @@ object Parameters {
     const val BATTERY_STATE = "batteryState"
     const val AVAILABLE_STORAGE = "availableStorage"
     const val TOTAL_STORAGE = "totalStorage"
+    const val IS_PORTRAIT = "isPortrait"
+    const val MOBILE_RESOLUTION = "resolution"
+    const val MOBILE_LANGUAGE = "language"
+    const val MOBILE_SCALE = "scale"
+    const val APP_SET_ID = "appSetId"
+    const val APP_SET_ID_SCOPE = "appSetIdScope"
 
     // Geolocation context
     const val LATITUDE = "latitude"

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/TrackerConstants.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/TrackerConstants.kt
@@ -34,7 +34,7 @@ object TrackerConstants {
         "iglu:com.snowplowanalytics.snowplow/consent_document/jsonschema/1-0-0"
     const val GEOLOCATION_SCHEMA =
         "iglu:com.snowplowanalytics.snowplow/geolocation_context/jsonschema/1-1-0"
-    const val MOBILE_SCHEMA = "iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-2"
+    const val MOBILE_SCHEMA = "iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-3"
     const val SESSION_SCHEMA = "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2"
     const val APPLICATION_ERROR_SCHEMA =
         "iglu:com.snowplowanalytics.snowplow/application_error/jsonschema/1-0-0"

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
@@ -15,9 +15,11 @@ package com.snowplowanalytics.core.tracker
 import android.content.Context
 import com.snowplowanalytics.core.constants.Parameters
 import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.emitter.Executor
 import com.snowplowanalytics.core.utils.DeviceInfoMonitor
 import com.snowplowanalytics.core.utils.Util.addToMap
 import com.snowplowanalytics.core.utils.Util.mapHasKeys
+import com.snowplowanalytics.snowplow.configuration.PlatformContextProperty
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 
 /**
@@ -32,6 +34,7 @@ class PlatformContext(
     private val platformDictUpdateFrequency: Long,
     private val networkDictUpdateFrequency: Long,
     private val deviceInfoMonitor: DeviceInfoMonitor,
+    private val platformContextProperties: List<PlatformContextProperty>?,
     private val context: Context
 ) {
     private val pairs: MutableMap<String, Any> = HashMap()
@@ -47,7 +50,8 @@ class PlatformContext(
      *
      * @param context the Android context
      */
-    constructor(context: Context) : this(100, (10 * 1000).toLong(), DeviceInfoMonitor(), context)
+    constructor(platformContextProperties: List<PlatformContextProperty>?,
+                context: Context) : this(100, (10 * 1000).toLong(), DeviceInfoMonitor(), platformContextProperties, context)
 
     fun getMobileContext(userAnonymisation: Boolean): SelfDescribingJson? {
         updateEphemeralDictsIfNecessary()
@@ -90,54 +94,153 @@ class PlatformContext(
         addToMap(Parameters.OS_VERSION, deviceInfoMonitor.osVersion, pairs)
         addToMap(Parameters.DEVICE_MODEL, deviceInfoMonitor.deviceModel, pairs)
         addToMap(Parameters.DEVICE_MANUFACTURER, deviceInfoMonitor.deviceVendor, pairs)
-        addToMap(
-            Parameters.CARRIER, deviceInfoMonitor.getCarrier(
-                context
-            ), pairs
-        )
-        addToMap(
-            Parameters.PHYSICAL_MEMORY, deviceInfoMonitor.getPhysicalMemory(
-                context
-            ), pairs
-        )
-        addToMap(Parameters.TOTAL_STORAGE, deviceInfoMonitor.totalStorage, pairs)
-        setEphemeralPlatformDict()
-        setEphemeralNetworkDict()
-    }
-
-    private fun setEphemeralPlatformDict() {
-        lastUpdatedEphemeralPlatformDict = System.currentTimeMillis()
-        val currentIdfa = pairs[Parameters.ANDROID_IDFA]
-        if (currentIdfa == null || currentIdfa.toString().isEmpty()) {
+        // Carrier
+        if (shouldTrack(PlatformContextProperty.CARRIER)) {
             addToMap(
-                Parameters.ANDROID_IDFA, deviceInfoMonitor.getAndroidIdfa(
+                Parameters.CARRIER, deviceInfoMonitor.getCarrier(
                     context
                 ), pairs
             )
         }
-        val batteryInfo = deviceInfoMonitor.getBatteryStateAndLevel(
-            context
-        )
-        if (batteryInfo != null) {
-            addToMap(Parameters.BATTERY_STATE, batteryInfo.first, pairs)
-            addToMap(Parameters.BATTERY_LEVEL, batteryInfo.second, pairs)
+        // Physical memory
+        if (shouldTrack(PlatformContextProperty.PHYSICAL_MEMORY)) {
+            addToMap(
+                Parameters.PHYSICAL_MEMORY, deviceInfoMonitor.getPhysicalMemory(
+                    context
+                ), pairs
+            )
         }
-        addToMap(
-            Parameters.SYSTEM_AVAILABLE_MEMORY, deviceInfoMonitor.getSystemAvailableMemory(
+        // Total storage
+        if (shouldTrack(PlatformContextProperty.TOTAL_STORAGE)) {
+            addToMap(Parameters.TOTAL_STORAGE, deviceInfoMonitor.totalStorage, pairs)
+        }
+        // Resolution
+        if (shouldTrack(PlatformContextProperty.RESOLUTION)) {
+            addToMap(Parameters.MOBILE_RESOLUTION, deviceInfoMonitor.getResolution(context), pairs)
+        }
+        // Scale
+        if (shouldTrack(PlatformContextProperty.SCALE)) {
+            addToMap(Parameters.MOBILE_SCALE, deviceInfoMonitor.getScale(context), pairs)
+        }
+        // Language
+        if (shouldTrack(PlatformContextProperty.LANGUAGE)) {
+            addToMap(Parameters.MOBILE_LANGUAGE, deviceInfoMonitor.language, pairs)
+        }
+
+        setEphemeralPlatformDict()
+        setEphemeralNetworkDict()
+        setAppSetId()
+    }
+
+    private fun setEphemeralPlatformDict() {
+        lastUpdatedEphemeralPlatformDict = System.currentTimeMillis()
+
+        // IDFA
+        if (shouldTrack(PlatformContextProperty.ANDROID_IDFA)) {
+            val currentIdfa = pairs[Parameters.ANDROID_IDFA]
+            if (currentIdfa == null || currentIdfa.toString().isEmpty()) {
+                addToMap(
+                    Parameters.ANDROID_IDFA, deviceInfoMonitor.getAndroidIdfa(
+                        context
+                    ), pairs
+                )
+            }
+        }
+        // Battery
+        val trackBatState = shouldTrack(PlatformContextProperty.BATTERY_STATE)
+        val trackBatLevel = shouldTrack(PlatformContextProperty.BATTERY_LEVEL)
+        if (trackBatState || trackBatLevel) {
+            val batteryInfo = deviceInfoMonitor.getBatteryStateAndLevel(
                 context
-            ), pairs
-        )
-        addToMap(Parameters.AVAILABLE_STORAGE, deviceInfoMonitor.availableStorage, pairs)
+            )
+            if (batteryInfo != null) {
+                if (trackBatState) { addToMap(Parameters.BATTERY_STATE, batteryInfo.first, pairs) }
+                if (trackBatLevel) { addToMap(Parameters.BATTERY_LEVEL, batteryInfo.second, pairs) }
+            }
+        }
+        // Memory
+        if (shouldTrack(PlatformContextProperty.SYSTEM_AVAILABLE_MEMORY)) {
+            addToMap(
+                Parameters.SYSTEM_AVAILABLE_MEMORY, deviceInfoMonitor.getSystemAvailableMemory(
+                    context
+                ), pairs
+            )
+        }
+        // Storage
+        if (shouldTrack(PlatformContextProperty.AVAILABLE_STORAGE)) {
+            addToMap(Parameters.AVAILABLE_STORAGE, deviceInfoMonitor.availableStorage, pairs)
+        }
+        // Is portrait
+        if (shouldTrack(PlatformContextProperty.IS_PORTRAIT)) {
+            addToMap(Parameters.IS_PORTRAIT, deviceInfoMonitor.getIsPortrait(context), pairs)
+        }
     }
 
     private fun setEphemeralNetworkDict() {
         lastUpdatedEphemeralNetworkDict = System.currentTimeMillis()
+
+        val trackType = shouldTrack(PlatformContextProperty.NETWORK_TYPE)
+        val trackTech = shouldTrack(PlatformContextProperty.NETWORK_TECHNOLOGY)
+        if (!trackType && !trackTech) { return }
+
         val networkInfo = deviceInfoMonitor.getNetworkInfo(context)
-        addToMap(
-            Parameters.NETWORK_TECHNOLOGY,
-            deviceInfoMonitor.getNetworkTechnology(networkInfo),
-            pairs
+        if (trackType) {
+            addToMap(
+                Parameters.NETWORK_TECHNOLOGY,
+                deviceInfoMonitor.getNetworkTechnology(networkInfo),
+                pairs
+            )
+        }
+        if (trackTech) {
+            addToMap(
+                Parameters.NETWORK_TYPE,
+                deviceInfoMonitor.getNetworkType(networkInfo),
+                pairs
+            )
+        }
+    }
+
+    /**
+     * Sets the app set information.
+     * The info has to be read on a background thread which often means that the first few
+     * tracked events will miss the info. To prevent that happening on the second start-up
+     * of the app, the info is saved in general prefs and read from there.
+     */
+    private fun setAppSetId() {
+        val trackId = shouldTrack(PlatformContextProperty.APP_SET_ID)
+        val trackScope = shouldTrack(PlatformContextProperty.APP_SET_ID_SCOPE)
+        if (!trackId && !trackScope) { return }
+
+        val generalPref = context.getSharedPreferences(
+            TrackerConstants.SNOWPLOW_GENERAL_VARS,
+            Context.MODE_PRIVATE
         )
-        addToMap(Parameters.NETWORK_TYPE, deviceInfoMonitor.getNetworkType(networkInfo), pairs)
+        val appSetId = generalPref.getString(Parameters.APP_SET_ID, null)
+        val appSetIdScope = generalPref.getString(Parameters.APP_SET_ID_SCOPE, null)
+
+        if (appSetId != null && appSetIdScope != null) {
+            if (trackId) { addToMap(Parameters.APP_SET_ID, appSetId, pairs) }
+            if (trackScope) { addToMap(Parameters.APP_SET_ID_SCOPE, appSetIdScope, pairs) }
+        } else {
+            Executor.execute(TAG) {
+                deviceInfoMonitor.getAppSetIdAndScope(context)?.let {
+                    if (trackId) { addToMap(Parameters.APP_SET_ID, it.first, pairs) }
+                    if (trackScope) { addToMap(Parameters.APP_SET_ID_SCOPE, it.second, pairs) }
+
+                    generalPref.edit()
+                        .putString(Parameters.APP_SET_ID, it.first)
+                        .putString(Parameters.APP_SET_ID_SCOPE, it.second)
+                        .apply()
+                }
+            }
+        }
+    }
+
+    private fun shouldTrack(property: PlatformContextProperty): Boolean {
+        return platformContextProperties?.contains(property) ?: true
+    }
+
+    companion object {
+        private val TAG = PlatformContext::class.java.simpleName
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -294,7 +294,14 @@ class ServiceProvider(
             }
         }
         
-        val tracker = Tracker(emitter, namespace, trackerConfig.appId, context, builder)
+        val tracker = Tracker(
+            emitter,
+            namespace,
+            trackerConfig.appId,
+            trackerConfig.platformContextProperties,
+            context,
+            builder
+        )
         
         if (trackerConfigurationUpdate.isPaused) {
             tracker.pauseEventTracking()

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -31,6 +31,7 @@ import com.snowplowanalytics.core.utils.NotificationCenter.addObserver
 import com.snowplowanalytics.core.utils.NotificationCenter.removeObserver
 import com.snowplowanalytics.core.utils.Util.getApplicationContext
 import com.snowplowanalytics.core.utils.Util.getGeoLocationContext
+import com.snowplowanalytics.snowplow.configuration.PlatformContextProperty
 import com.snowplowanalytics.snowplow.entity.DeepLink
 import com.snowplowanalytics.snowplow.event.*
 import com.snowplowanalytics.snowplow.payload.Payload
@@ -51,7 +52,13 @@ import kotlin.math.max
  * @param context The Android application context
  * @param builder A closure to set Tracker configuration
  */
-class Tracker(emitter: Emitter, val namespace: String, var appId: String, context: Context, builder: ((Tracker) -> Unit)? = null) {
+class Tracker(
+    emitter: Emitter,
+    val namespace: String,
+    var appId: String,
+    platformContextProperties: List<PlatformContextProperty>?,
+    context: Context,
+    builder: ((Tracker) -> Unit)? = null) {
     private var builderFinished = false
     private val context: Context
     private val stateManager = StateManager()
@@ -76,8 +83,8 @@ class Tracker(emitter: Emitter, val namespace: String, var appId: String, contex
     private val _dataCollection = AtomicBoolean(true)
     val dataCollection: Boolean
         get() = _dataCollection.get()
-    
-    private val platformContextManager = PlatformContext(context)
+
+    private val platformContextManager = PlatformContext(platformContextProperties, context)
 
     var emitter: Emitter = emitter
         set(emitter) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerConfigurationUpdate.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerConfigurationUpdate.kt
@@ -12,6 +12,7 @@
  */
 package com.snowplowanalytics.core.tracker
 
+import com.snowplowanalytics.snowplow.configuration.PlatformContextProperty
 import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform
 import com.snowplowanalytics.snowplow.tracker.LogLevel
@@ -39,6 +40,7 @@ class TrackerConfigurationUpdate : TrackerConfiguration {
     private var diagnosticAutotrackingUpdated = false
     private var userAnonymisationUpdated = false
     private var trackerVersionSuffixUpdated = false
+    private var platformContextPropertiesUpdated = false
 
     constructor(appId: String) : super(appId)
     constructor(appId: String, jsonObject: JSONObject) : super(appId, jsonObject)
@@ -167,5 +169,12 @@ class TrackerConfigurationUpdate : TrackerConfiguration {
         set(value) {
             super.trackerVersionSuffix = value
             trackerVersionSuffixUpdated = true
+        }
+
+    override var platformContextProperties: List<PlatformContextProperty>?
+        get() = if (sourceConfig == null || platformContextPropertiesUpdated) super.platformContextProperties else sourceConfig!!.platformContextProperties
+        set(value) {
+            super.platformContextProperties = value
+            platformContextPropertiesUpdated = true
         }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/DeviceInfoMonitor.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/DeviceInfoMonitor.kt
@@ -194,7 +194,7 @@ open class DeviceInfoMonitor {
         return "${width}x${height}"
     }
 
-    /// Scale factor used to convert logical coordinates to device coordinates of the screen (uses DisplayMetrics.density on Android)
+    /// Scale factor used to convert logical coordinates to device coordinates of the screen (uses DisplayMetrics.density)
     open fun getScale(context: Context): Float? {
         return context.resources.displayMetrics.density
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/DeviceInfoMonitor.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/DeviceInfoMonitor.kt
@@ -16,16 +16,15 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import android.net.ConnectivityManager
 import android.net.NetworkInfo
-import android.os.BatteryManager
-import android.os.Build
-import android.os.Environment
-import android.os.StatFs
+import android.os.*
 import android.telephony.TelephonyManager
 import android.util.Pair
 import com.snowplowanalytics.core.tracker.Logger
 import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration
+import java.lang.reflect.InvocationTargetException
 import java.util.*
 
 open class DeviceInfoMonitor {
@@ -183,6 +182,78 @@ open class DeviceInfoMonitor {
             return statFs.totalBytes
         }
 
+    /// Whether the device orientation is portrait (either upright or upside down)
+    open fun getIsPortrait(context: Context): Boolean? {
+        return context.resources.configuration.orientation == ORIENTATION_PORTRAIT
+    }
+
+    /// Resolution in pixels. Arrives in the form of WIDTHxHEIGHT (e.g., 1200x900). Doesn't change when device orientation changes
+    open fun getResolution(context: Context): String? {
+        val width = context.resources.displayMetrics.widthPixels
+        val height = context.resources.displayMetrics.heightPixels
+        return "${width}x${height}"
+    }
+
+    /// Scale factor used to convert logical coordinates to device coordinates of the screen (uses DisplayMetrics.density on Android)
+    open fun getScale(context: Context): Float? {
+        return context.resources.displayMetrics.density
+    }
+
+    /// System language currently used on the device (ISO 639)
+    open val language: String?
+        get() {
+            return Locale.getDefault().isO3Language
+        }
+
+    /// Android vendor ID scoped to the set of apps published under the same Google Play developer account (see https://developer.android.com/training/articles/app-set-id)
+    open fun getAppSetIdAndScope(context: Context): Pair<String, String>? {
+        // needs to be executed on the background thread
+        if (Looper.myLooper() == Looper.getMainLooper()) { return null }
+
+        try {
+            // Using Java reflection because the tracker doesn't import the gms library directly
+            // and can only use the APIs in case the user app imports it.
+
+            // equivalent of: val client = AppSet.getClient()
+            val client = invokeStaticMethod(
+                "com.google.android.gms.appset.AppSet", "getClient",
+                arrayOf(Context::class.java), context
+            ) ?: return null
+
+            // equivalent of: val task = client.getAppSetIdInfo()
+            val task = invokeInstanceMethod(
+                client, "getAppSetIdInfo", null
+            ) ?: return null
+
+            // equivalent of: val appSetInfo = Tasks.await(task)
+            val appSetInfo = invokeStaticMethod(
+                "com.google.android.gms.tasks.Tasks", "await",
+                arrayOf(Class.forName("com.google.android.gms.tasks.Task")), task
+            ) ?: return null
+
+            // equivalent of: val id = appSetInfo.getId()
+            val id = invokeInstanceMethod(appSetInfo, "getId", null) ?: return null
+
+            // equivalent of: val id = appSetInfo.getScope()
+            val scope = invokeInstanceMethod(appSetInfo, "getScope", null) ?: return null
+
+            return Pair(
+                id as String,
+                if (scope as Int == 1) { "app" } else { "developer" }
+            )
+        } catch (e: ClassNotFoundException) {
+            Logger.d(TAG, "AppSetID error: Google Play Services not found")
+        } catch (e: InvocationTargetException) {
+            Logger.d(TAG, "AppSetID error: Google Play Services not available")
+        } catch (e: Exception) {
+            Logger.d(TAG, "AppSetID error: couldn't connect to Google Play Services"
+            )
+        }
+
+        return null
+    }
+
+
     // --- PRIVATE
     private fun getMemoryInfo(context: Context): ActivityManager.MemoryInfo {
         val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
@@ -256,5 +327,7 @@ open class DeviceInfoMonitor {
             }
             return methodObject.invoke(instance, *args)
         }
+
+        private val TAG = DeviceInfoMonitor::class.java.simpleName
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PlatformContextProperty.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PlatformContextProperty.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.configuration
+
+/**
+ * Optional properties tracked in the platform context entity
+ */
+enum class PlatformContextProperty {
+    /// The carrier of the SIM inserted in the device
+    CARRIER,
+    /// Type of network the device is connected to
+    NETWORK_TYPE,
+    /// Radio access technology that the device is using
+    NETWORK_TECHNOLOGY,
+    /// Advertising identifier on Android
+    ANDROID_IDFA,
+    /// Total physical system memory in bytes
+    PHYSICAL_MEMORY,
+    /// Available memory on the system in bytes (Android only)
+    SYSTEM_AVAILABLE_MEMORY,
+    /// Remaining battery level as an integer percentage of total battery capacity
+    BATTERY_LEVEL,
+    /// Battery state for the device
+    BATTERY_STATE,
+    /// Bytes of storage remaining
+    AVAILABLE_STORAGE,
+    /// Total size of storage in bytes
+    TOTAL_STORAGE,
+    /// A Boolean indicating whether the device orientation is portrait (either upright or upside down)
+    IS_PORTRAIT,
+    /// Screen resolution in pixels. Arrives in the form of WIDTHxHEIGHT (e.g., 1200x900). Doesn't change when device orientation changes
+    RESOLUTION,
+    /// Scale factor used to convert logical coordinates to device coordinates of the screen (uses UIScreen.scale on iOS)
+    SCALE,
+    /// System language currently used on the device (ISO 639)
+    LANGUAGE,
+    /// Android vendor ID scoped to the set of apps published under the same Google Play developer account (see https://developer.android.com/training/articles/app-set-id)
+    APP_SET_ID,
+    /// Scope of the `appSetId`. Can be scoped to the app or to a developer account on an app store (all apps from the same developer on the same device will have the same ID)
+    APP_SET_ID_SCOPE
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PlatformContextProperty.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PlatformContextProperty.kt
@@ -40,7 +40,7 @@ enum class PlatformContextProperty {
     IS_PORTRAIT,
     /// Screen resolution in pixels. Arrives in the form of WIDTHxHEIGHT (e.g., 1200x900). Doesn't change when device orientation changes
     RESOLUTION,
-    /// Scale factor used to convert logical coordinates to device coordinates of the screen (uses UIScreen.scale on iOS)
+    /// Scale factor used to convert logical coordinates to device coordinates of the screen (uses DisplayMetrics.density on Android)
     SCALE,
     /// System language currently used on the device (ISO 639)
     LANGUAGE,

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
@@ -264,6 +264,7 @@ open class TrackerConfiguration(
             .diagnosticAutotracking(diagnosticAutotracking)
             .userAnonymisation(userAnonymisation)
             .trackerVersionSuffix(trackerVersionSuffix)
+            .platformContextProperties(platformContextProperties)
     }
 
     // JSON Formatter

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
@@ -13,6 +13,7 @@
 package com.snowplowanalytics.snowplow.configuration
 
 import com.snowplowanalytics.core.tracker.Logger
+import com.snowplowanalytics.core.tracker.PlatformContext
 import com.snowplowanalytics.core.tracker.TrackerConfigurationInterface
 import com.snowplowanalytics.core.tracker.TrackerDefaults
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform
@@ -67,7 +68,13 @@ open class TrackerConfiguration(
     override var diagnosticAutotracking: Boolean = TrackerDefaults.diagnosticAutotracking
     override var userAnonymisation: Boolean = TrackerDefaults.userAnonymisation
     override var trackerVersionSuffix: String? = null
-    
+
+    /**
+     * List of properties of the platform context to track.
+     * If not passed and `platformContext` is enabled, all available properties will be tracked.
+     * The required `osType`, `osVersion`, `deviceManufacturer`, and `deviceModel` properties will be tracked in the entity regardless of this setting.
+     */
+    open var platformContextProperties: List<PlatformContextProperty>? = null
 
     // Builder methods
     
@@ -224,6 +231,16 @@ open class TrackerConfiguration(
      */
     fun trackerVersionSuffix(trackerVersionSuffix: String?): TrackerConfiguration {
         this.trackerVersionSuffix = trackerVersionSuffix
+        return this
+    }
+
+    /**
+     * List of properties of the platform context to track.
+     * If not passed and `platformContext` is enabled, all available properties will be tracked.
+     * The required `osType`, `osVersion`, `deviceManufacturer`, and `deviceModel` properties will be tracked in the entity regardless of this setting.
+     */
+    fun platformContextProperties(platformContextProperties: List<PlatformContextProperty>?): TrackerConfiguration {
+        this.platformContextProperties = platformContextProperties
         return this
     }
 


### PR DESCRIPTION
Issue #598 

Adds the new properties in platform context entity (`mobile_context` schema) version 1-0-3:

Property | Description
--|--
isPortrait | A Boolean indicating whether the device orientation is portrait (either upright or upside down)
resolution | Screen resolution in pixels. Arrives in the form of WIDTHxHEIGHT (e.g., 1200x900). Doesn't change when device orientation changes
scale | Scale factor used to convert logical coordinates to device coordinates of the screen (uses UIScreen.scale on iOS and DisplayMetrics.density on Android)
language | System language currently used on the device (ISO 639)
appSetId | Android vendor ID scoped to the set of apps published under the same Google Play developer account (see https://developer.android.com/training/articles/app-set-id)
appSetIdScope | Scope of the `appSetId`. Can be scoped to the app or to a developer account on an app store (all apps from the same developer on the same device will have the same ID)

Also makes it configurable which properties should be tracked in the entity in case the user does not want to track all of them.

**Related issues**

* #569
* #565
* #450

### Limitations 

The app set ID has to be retrieved on a background thread so it is asynchronous from the tracker initialization. This means that in between the time that the tracker is initialized (`createTracker` is called) and the identifier is retrieved, there may be several events tracked without it being retrieved yet.

Unfortunately, I couldn't find a way around this. But to make the impact smaller, I set the ID to be stored in Android general preferences (persistent storage) once it is retrieved the first time. So on the second and following starts of the app, it can be read synchronously from the general prefs and can be added to all events.