### PR TITLE
Add configuration to send requests with user ID to a Focal Meter endpoint (close #571)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/FocalMeterConfigurationTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/FocalMeterConfigurationTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.tracker
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.snowplowanalytics.snowplow.Snowplow
+import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
+import com.snowplowanalytics.snowplow.configuration.*
+import com.snowplowanalytics.snowplow.controller.TrackerController
+import com.snowplowanalytics.snowplow.event.Structured
+import com.snowplowanalytics.snowplow.network.HttpMethod
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class FocalMeterConfigurationTest {
+
+    @After
+    fun tearDown() {
+        removeAllTrackers()
+    }
+
+    // --- TESTS
+    @Test
+    fun logsSuccessfulRequest() {
+        withMockServer(200) { mockServer, endpoint ->
+            val focalMeter = FocalMeterConfiguration(endpoint)
+            val debugs = mutableListOf<String>()
+            val loggerDelegate = createLoggerDelegate(debugs = debugs)
+            val trackerConfig = TrackerConfiguration(appId = "app-id")
+            trackerConfig.logLevel(LogLevel.DEBUG)
+            trackerConfig.loggerDelegate(loggerDelegate)
+
+            val tracker = createTracker(listOf(focalMeter, trackerConfig))
+            tracker.track(Structured("cat", "act"))
+            tracker.track(Structured("cat", "act"))
+            tracker.track(Structured("cat", "act"))
+
+            Thread.sleep(1000)
+            Assert.assertEquals(
+                1,
+                debugs.filter {
+                    it.contains("Request to Kantar endpoint sent with user ID: ${tracker.session?.userId}")
+                }.size
+            )
+        }
+    }
+
+    @Test
+    fun makesAnotherRequestWhenUserIdChanges() {
+        withMockServer(200) { mockServer, endpoint ->
+            val focalMeter = FocalMeterConfiguration(endpoint)
+            val debugs = mutableListOf<String>()
+            val loggerDelegate = createLoggerDelegate(debugs = debugs)
+            val trackerConfig = TrackerConfiguration(appId = "app-id")
+            trackerConfig.logLevel(LogLevel.DEBUG)
+            trackerConfig.loggerDelegate(loggerDelegate)
+
+            val tracker = createTracker(listOf(focalMeter, trackerConfig))
+            tracker.track(Structured("cat", "act"))
+            val firstUserId = tracker.session?.userId
+            tracker.session?.startNewSession()
+            tracker.track(Structured("cat", "act"))
+            val secondUserId = tracker.session?.userId
+
+            Thread.sleep(1000)
+            Assert.assertEquals(
+                1,
+                debugs.filter {
+                    it.contains("Request to Kantar endpoint sent with user ID: ${firstUserId}")
+                }.size
+            )
+            Assert.assertEquals(
+                1,
+                debugs.filter {
+                    it.contains("Request to Kantar endpoint sent with user ID: ${secondUserId}")
+                }.size
+            )
+        }
+    }
+
+    @Test
+    fun logsFailedRequest() {
+        withMockServer(500) { mockServer, endpoint ->
+            val focalMeter = FocalMeterConfiguration(endpoint)
+            val errors = mutableListOf<String>()
+            val loggerDelegate = createLoggerDelegate(errors = errors)
+            val trackerConfig = TrackerConfiguration(appId = "app-id")
+            trackerConfig.logLevel(LogLevel.DEBUG)
+            trackerConfig.loggerDelegate(loggerDelegate)
+
+            val tracker = createTracker(listOf(focalMeter, trackerConfig))
+            tracker.track(Structured("cat", "act"))
+
+            Thread.sleep(1000)
+            Assert.assertEquals(
+                1,
+                errors.filter {
+                    it.contains("Request to Kantar endpoint failed with code: 500")
+                }.size
+            )
+        }
+    }
+
+    // --- PRIVATE
+    private val context: Context
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun createTracker(configurations: List<Configuration>): TrackerController {
+        val networkConfig = NetworkConfiguration(MockNetworkConnection(HttpMethod.POST, 200))
+        return Snowplow.createTracker(
+            context,
+            namespace = "ns" + Math.random().toString(),
+            network = networkConfig,
+            configurations = configurations.toTypedArray()
+        )
+    }
+
+    private fun withMockServer(responseCode: Int, callback: (MockWebServer, String) -> Unit) {
+        val mockServer = MockWebServer()
+        mockServer.start()
+        val mockResponse = MockResponse()
+            .setResponseCode(responseCode)
+            .setHeader("Content-Type", "application/json")
+            .setBody("")
+        mockServer.enqueue(mockResponse)
+        val endpoint = String.format("http://%s:%d", mockServer.hostName, mockServer.port)
+        callback(mockServer, endpoint)
+        mockServer.shutdown()
+    }
+
+    private fun createLoggerDelegate(
+        errors: MutableList<String> = mutableListOf(),
+        debugs: MutableList<String> = mutableListOf(),
+        verboses: MutableList<String> = mutableListOf()
+    ): LoggerDelegate {
+        return object : LoggerDelegate {
+
+            override fun error(tag: String, msg: String) {
+                errors.add(msg)
+            }
+
+            override fun debug(tag: String, msg: String) {
+                debugs.add(msg)
+            }
+
+            override fun verbose(tag: String, msg: String) {
+                verboses.add(msg)
+            }
+        }
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/session/Session.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/session/Session.kt
@@ -21,6 +21,7 @@ import com.snowplowanalytics.core.constants.Parameters
 import com.snowplowanalytics.core.constants.TrackerConstants
 import com.snowplowanalytics.core.tracker.Logger
 import com.snowplowanalytics.core.utils.Util
+import com.snowplowanalytics.snowplow.entity.ClientSessionEntity
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 import com.snowplowanalytics.snowplow.tracker.SessionState
 import com.snowplowanalytics.snowplow.tracker.SessionState.Companion.build
@@ -154,7 +155,7 @@ class Session @SuppressLint("ApplySharedPref") constructor(
                 "00000000-0000-0000-0000-000000000000"
             sessionCopy[Parameters.SESSION_PREVIOUS_ID] = null
         }
-        return SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, sessionCopy)
+        return ClientSessionEntity(sessionCopy)
     }
 
     private fun shouldUpdateSession(): Boolean {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/FocalMeterConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/FocalMeterConfiguration.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.configuration
+
+import android.net.Uri
+import com.snowplowanalytics.core.tracker.Logger
+import com.snowplowanalytics.snowplow.entity.ClientSessionEntity
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+/**
+ * This configuration tells the tracker to send requests with the user ID in session context entity
+ * to a Kantar endpoint used with FocalMeter.
+ * The request is made when the first event with a new user ID is tracked.
+ * The requests are only made if session context is enabled (default).
+ * @param kantarEndpoint The Kantar URI endpoint including the HTTP protocol to send the requests to.
+ */
+class FocalMeterConfiguration(
+    var kantarEndpoint: String
+) : Configuration, PluginConfigurationInterface {
+    private val TAG = FocalMeterConfiguration::class.java.simpleName
+
+    private var lastUserId: String? = null
+
+    override val identifier: String
+        get() = "KantarFocalMeter"
+
+    override val entitiesConfiguration: PluginEntitiesConfiguration?
+        get() = null
+
+    override val afterTrackConfiguration: PluginAfterTrackConfiguration?
+        get() = PluginAfterTrackConfiguration { event ->
+            val session = event.entities.find { it is ClientSessionEntity } as? ClientSessionEntity
+            session?.userId?.let { newUserId ->
+                if (shouldUpdate(newUserId)) {
+                    makeRequest(newUserId)
+                }
+            }
+        }
+
+    /**
+     * The Kantar URI endpoint including the HTTP protocol to send the requests to.
+     */
+    fun kantarEndpoint(kantarEndpoint: String): FocalMeterConfiguration {
+        this.kantarEndpoint = kantarEndpoint
+        return this
+    }
+
+    private fun shouldUpdate(userId: String): Boolean {
+        synchronized(this) {
+            if (lastUserId == null || lastUserId != userId) {
+                lastUserId = userId
+                return true
+            }
+            return false
+        }
+    }
+
+    private fun makeRequest(userId: String) {
+        val uriBuilder = Uri.parse(kantarEndpoint).buildUpon()
+        uriBuilder.appendQueryParameter("vendor", "snowplow")
+        uriBuilder.appendQueryParameter("cs_fpid", userId)
+        uriBuilder.appendQueryParameter("c12", "not_set")
+
+        val client = OkHttpClient.Builder()
+            .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+            .build()
+
+        val request = Request.Builder()
+            .url(uriBuilder.build().toString())
+            .build()
+
+        try {
+            val response = client.newCall(request).execute()
+            if (response.isSuccessful) {
+                Logger.d(TAG, "Request to Kantar endpoint sent with user ID: $userId")
+            } else {
+                Logger.e(TAG, "Request to Kantar endpoint failed with code: ${response.code}")
+            }
+        } catch (e: IOException) {
+            Logger.e(TAG, "Request to Kantar endpoint failed with exception: ${e.message}")
+        }
+    }
+
+    override fun copy(): Configuration {
+        return FocalMeterConfiguration(kantarEndpoint = kantarEndpoint)
+    }
+
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/entity/ClientSessionEntity.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/entity/ClientSessionEntity.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+
+package com.snowplowanalytics.snowplow.entity
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Used to represent session information
+ */
+class ClientSessionEntity(private val values: Map<String, Any?>) :
+    SelfDescribingJson(TrackerConstants.SESSION_SCHEMA, values) {
+
+    val userId: String?
+        get() = values[Parameters.SESSION_USER_ID] as String?
+}


### PR DESCRIPTION
Issue #571

Similar to PR #572 which implemented the FocalMeter configuration for the version 4, this PR implements the configuration for version 5 of the tracker. In contrast with the v4 implementation, this one makes use of the new plugin API and the `afterTrack` callback. The public API is the same as for v4.

## Documentation: Sending session user identifier to Kantar FocalMeter

The tracker has the ability to send the user identifier (`userId` present in the session context) to a [Kantar FocalMeter](https://www.virtualmeter.co.uk/focalmeter) endpoint. This integration enables measuring the audience of content through the FocalMeter router meter.

To enable this feature, you can pass the `FocalMeterConfiguration` configuration with the URL of the Kantar endpoint. For example:

```java
FocalMeterConfiguration focalMeterConfiguration = new FocalMeterConfiguration("https://thekantarendpoint.com");
Snowplow.createTracker(getApplicationContext(),
        namespace,
        networkConfiguration,
        focalMeterConfiguration
```