### PR TITLE
Add a filter API to plugins to decide whether to track an event or not (close #608)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
@@ -437,6 +437,15 @@ class StateManagerTest {
         Assert.assertEquals(1, stateMachine.afterTrackEvents.size)
         Assert.assertEquals("cat", stateMachine.afterTrackEvents.first().payload["se_ca"])
     }
+
+    @Test
+    fun testFilterReturnsSettingOfStateMachine() {
+        val stateManager = StateManager()
+        stateManager.addOrReplaceStateMachine(MockStateMachine())
+
+        Assert.assertFalse(stateManager.filter(TrackerEvent(SelfDescribing("s1", emptyMap()), TrackerState())))
+        Assert.assertTrue(stateManager.filter(TrackerEvent(SelfDescribing("s2", emptyMap()), TrackerState())))
+    }
 } // Mock classes
 
 internal class MockState(var value: Int) : State
@@ -456,6 +465,9 @@ internal open class MockStateMachine(
 
     override val subscribedEventSchemasForAfterTrackCallback: List<String>
         get() = Collections.singletonList("*")
+
+    override val subscribedEventSchemasForFiltering: List<String>
+        get() = Collections.singletonList("s1")
 
     override fun transition(event: Event, state: State?): State? {
         val e = event as SelfDescribing
@@ -496,5 +508,9 @@ internal open class MockStateMachine(
 
     override fun afterTrack(event: InspectableEvent) {
         afterTrackEvents.add(event)
+    }
+
+    override fun filter(event: InspectableEvent, state: State?): Boolean? {
+        return false
     }
 }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/PluginsTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/PluginsTest.kt
@@ -189,6 +189,28 @@ class PluginsTest {
         Assert.assertFalse(pluginCalled)
     }
 
+    @Test
+    fun filtersEvents() {
+        val filterPlugin = PluginConfiguration("filter")
+            .filter(listOf("s1")) { false }
+
+        var afterTrackCalled = false
+        val afterTrackPlugin = PluginConfiguration("afterTrack")
+            .afterTrack { afterTrackCalled = true }
+
+        val tracker = createTracker(listOf(filterPlugin, afterTrackPlugin))
+
+        tracker.track(SelfDescribing("s1", emptyMap()))
+        Thread.sleep(100)
+
+        Assert.assertFalse(afterTrackCalled)
+
+        tracker.track(SelfDescribing("s2", emptyMap()))
+        Thread.sleep(100)
+
+        Assert.assertTrue(afterTrackCalled)
+    }
+
     // --- PRIVATE
     private val context: Context
         get() = InstrumentationRegistry.getInstrumentation().targetContext

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/globalcontexts/GlobalContextPluginConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/globalcontexts/GlobalContextPluginConfiguration.kt
@@ -12,17 +12,13 @@
  */
 package com.snowplowanalytics.core.globalcontexts
 
-import com.snowplowanalytics.snowplow.configuration.PluginAfterTrackConfiguration
-import com.snowplowanalytics.snowplow.configuration.PluginConfigurationInterface
-import com.snowplowanalytics.snowplow.configuration.PluginEntitiesConfiguration
+import com.snowplowanalytics.snowplow.configuration.*
 import com.snowplowanalytics.snowplow.globalcontexts.GlobalContext
 
 class GlobalContextPluginConfiguration(
     override val identifier: String,
     val globalContext: GlobalContext
-) : PluginConfigurationInterface {
-
-    override val afterTrackConfiguration: PluginAfterTrackConfiguration? = null
+) : PluginIdentifiable, PluginEntitiesCallable {
 
     override val entitiesConfiguration: PluginEntitiesConfiguration
         get() = PluginEntitiesConfiguration(closure = globalContext::generateContexts)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkStateMachine.kt
@@ -48,6 +48,9 @@ class DeepLinkStateMachine : StateMachineInterface {
     override val subscribedEventSchemasForAfterTrackCallback: List<String>
         get() = emptyList()
 
+    override val subscribedEventSchemasForFiltering: List<String>
+        get() = emptyList()
+
     override fun transition(event: Event, state: State?): State? {
         // - Init (DL) DeepLinkReceived
         // - ReadyForOutput (DL) DeepLinkReceived
@@ -86,6 +89,10 @@ class DeepLinkStateMachine : StateMachineInterface {
     }
 
     override fun afterTrack(event: InspectableEvent) {
+    }
+
+    override fun filter(event: InspectableEvent, state: State?): Boolean? {
+        return null
     }
 
     companion object {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleStateMachine.kt
@@ -45,6 +45,9 @@ class LifecycleStateMachine : StateMachineInterface {
     override val subscribedEventSchemasForAfterTrackCallback: List<String>
         get() = emptyList()
 
+    override val subscribedEventSchemasForFiltering: List<String>
+        get() = emptyList()
+
     override fun transition(event: Event, currentState: State?): State? {
         if (event is Foreground) {
             return LifecycleState(true, event.foregroundIndex)
@@ -67,6 +70,10 @@ class LifecycleStateMachine : StateMachineInterface {
     }
 
     override fun afterTrack(event: InspectableEvent) {
+    }
+
+    override fun filter(event: InspectableEvent, state: State?): Boolean? {
+        return null
     }
 
     companion object {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
@@ -14,6 +14,7 @@ package com.snowplowanalytics.core.statemachine
 
 import com.snowplowanalytics.snowplow.configuration.PluginAfterTrackConfiguration
 import com.snowplowanalytics.snowplow.configuration.PluginEntitiesConfiguration
+import com.snowplowanalytics.snowplow.configuration.PluginFilterConfiguration
 import com.snowplowanalytics.snowplow.event.Event
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 import com.snowplowanalytics.snowplow.tracker.InspectableEvent
@@ -22,7 +23,8 @@ import java.util.*
 class PluginStateMachine(
     override val identifier: String,
     val entitiesConfiguration: PluginEntitiesConfiguration?,
-    val afterTrackConfiguration: PluginAfterTrackConfiguration?
+    val afterTrackConfiguration: PluginAfterTrackConfiguration?,
+    val filterConfiguration: PluginFilterConfiguration?
 ) : StateMachineInterface {
 
     override val subscribedEventSchemasForTransitions: List<String>
@@ -43,6 +45,12 @@ class PluginStateMachine(
             return config.schemas ?: Collections.singletonList("*")
         }
 
+    override val subscribedEventSchemasForFiltering: List<String>
+        get() {
+            val config = filterConfiguration ?: return emptyList()
+            return config.schemas ?: Collections.singletonList("*")
+        }
+
     override fun transition(event: Event, state: State?): State? {
         return null
     }
@@ -57,5 +65,9 @@ class PluginStateMachine(
 
     override fun afterTrack(event: InspectableEvent) {
         afterTrackConfiguration?.closure?.accept(event)
+    }
+
+    override fun filter(event: InspectableEvent, state: State?): Boolean? {
+        return filterConfiguration?.closure?.apply(event)
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineInterface.kt
@@ -22,8 +22,11 @@ interface StateMachineInterface {
     val subscribedEventSchemasForEntitiesGeneration: List<String>
     val subscribedEventSchemasForPayloadUpdating: List<String>
     val subscribedEventSchemasForAfterTrackCallback: List<String>
+    val subscribedEventSchemasForFiltering: List<String>
+
     fun transition(event: Event, state: State?): State?
     fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson>?
     fun payloadValues(event: InspectableEvent, state: State?): Map<String, Any>?
     fun afterTrack(event: InspectableEvent)
+    fun filter(event: InspectableEvent, state: State?): Boolean?
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PluginsControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PluginsControllerImpl.kt
@@ -13,7 +13,7 @@
 package com.snowplowanalytics.core.tracker
 
 import com.snowplowanalytics.core.Controller
-import com.snowplowanalytics.snowplow.configuration.PluginConfigurationInterface
+import com.snowplowanalytics.snowplow.configuration.PluginIdentifiable
 import com.snowplowanalytics.snowplow.controller.PluginsController
 
 class PluginsControllerImpl
@@ -24,7 +24,7 @@ class PluginsControllerImpl
             return serviceProvider.pluginConfigurations.map { it.identifier }
         }
 
-    override fun addPlugin(plugin: PluginConfigurationInterface) {
+    override fun addPlugin(plugin: PluginIdentifiable) {
         serviceProvider.addPlugin(plugin)
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ScreenStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ScreenStateMachine.kt
@@ -47,6 +47,9 @@ class ScreenStateMachine : StateMachineInterface {
     override val subscribedEventSchemasForAfterTrackCallback: List<String>
         get() = emptyList()
 
+    override val subscribedEventSchemasForFiltering: List<String>
+        get() = emptyList()
+
     override fun transition(event: Event, state: State?): State? {
         val screenView = event as? ScreenView
         val screenState: ScreenState? = if (state != null) {
@@ -99,6 +102,10 @@ class ScreenStateMachine : StateMachineInterface {
     }
 
     override fun afterTrack(event: InspectableEvent) {
+    }
+
+    override fun filter(event: InspectableEvent, state: State?): Boolean? {
+        return null
     }
 
     companion object {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -53,7 +53,7 @@ class ServiceProvider(
     }
 
     // Original configurations
-    override var pluginConfigurations: MutableList<PluginConfigurationInterface> = ArrayList()
+    override var pluginConfigurations: MutableList<PluginIdentifiable> = ArrayList()
         private set
 
     // Configuration updates
@@ -129,7 +129,7 @@ class ServiceProvider(
                     pluginConfigurations.add(plugin)
                 }
             }
-            else if (configuration is PluginConfigurationInterface) {
+            else if (configuration is PluginIdentifiable) {
                 pluginConfigurations.add(configuration)
             }
         }
@@ -355,7 +355,7 @@ class ServiceProvider(
 
     // Plugins
 
-    override fun addPlugin(plugin: PluginConfigurationInterface) {
+    override fun addPlugin(plugin: PluginIdentifiable) {
         removePlugin(plugin.identifier)
         pluginConfigurations.add(plugin)
         tracker?.addOrReplaceStateMachine(plugin.toStateMachine())

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProviderInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProviderInterface.kt
@@ -18,7 +18,7 @@ import com.snowplowanalytics.core.gdpr.GdprControllerImpl
 import com.snowplowanalytics.core.globalcontexts.GlobalContextsControllerImpl
 import com.snowplowanalytics.core.session.SessionConfigurationUpdate
 import com.snowplowanalytics.core.session.SessionControllerImpl
-import com.snowplowanalytics.snowplow.configuration.PluginConfigurationInterface
+import com.snowplowanalytics.snowplow.configuration.PluginIdentifiable
 
 interface ServiceProviderInterface {
     val namespace: String
@@ -48,7 +48,7 @@ interface ServiceProviderInterface {
     val gdprConfigurationUpdate: GdprConfigurationUpdate
 
     // Plugins
-    val pluginConfigurations: List<PluginConfigurationInterface>
-    fun addPlugin(plugin: PluginConfigurationInterface)
+    val pluginConfigurations: List<PluginIdentifiable>
+    fun addPlugin(plugin: PluginIdentifiable)
     fun removePlugin(identifier: String)
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PluginConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PluginConfiguration.kt
@@ -31,6 +31,17 @@ class PluginAfterTrackConfiguration(
 )
 
 /**
+ * Provides a closure that is called to decide whether to track a given event or not.
+ *
+ * @property schemas Optional list of event schemas to call the block for. If null, the block is called for all events.
+ * @property closure Block that returns true if the event should be tracked, false otherwise.
+ */
+class PluginFilterConfiguration(
+    val schemas: List<String>? = null,
+    val closure: Function<InspectableEvent, Boolean>
+)
+
+/**
  * Provides a block closure that returns a list of context entities and is called when events are tracked.
  *  Optionally, you can specify the event schemas for which the block should be called.
  *
@@ -43,6 +54,59 @@ class PluginEntitiesConfiguration(
 )
 
 /**
+ * Identifies a tracker plugin with a unique identifier. Required for all plugins.
+ *
+ * @property identifier Unique identifier of the plugin within the tracker.
+ */
+interface PluginIdentifiable {
+    val identifier: String
+}
+
+internal fun PluginIdentifiable.toStateMachine(): PluginStateMachine {
+    var entitiesConfiguration: PluginEntitiesConfiguration? = null
+    (this as? PluginEntitiesCallable)?.let { entitiesConfiguration = it.entitiesConfiguration }
+
+    var afterTrackConfiguration: PluginAfterTrackConfiguration? = null
+    (this as? PluginAfterTrackCallable)?.let { afterTrackConfiguration = it.afterTrackConfiguration }
+
+    var filterConfiguration: PluginFilterConfiguration? = null
+    (this as? PluginFilterCallable)?.let { filterConfiguration = it.filterConfiguration }
+
+    return PluginStateMachine(
+        identifier = identifier,
+        entitiesConfiguration = entitiesConfiguration,
+        afterTrackConfiguration = afterTrackConfiguration,
+        filterConfiguration = filterConfiguration
+    )
+}
+/**
+ * Protocol for a plugin that provides a closure to generate context entities to enrich events.
+ *
+ * @property entitiesConfiguration Closure configuration that is called when events are tracked to generate context entities to enrich the events.
+ */
+interface PluginEntitiesCallable {
+    val entitiesConfiguration: PluginEntitiesConfiguration?
+}
+
+/**
+ * Protocol for a plugin that provides a closure to call after events are tracked.
+ *
+ * @property afterTrackConfiguration Closure configuration that is called after events are tracked.
+ */
+interface PluginAfterTrackCallable {
+    val afterTrackConfiguration: PluginAfterTrackConfiguration?
+}
+
+/**
+ * Protocol for a plugin that provides a closure to decide whether to track events or not.
+ *
+ * @property filterConfiguration Closure configuration that is called to decide whether to track a given event or not.
+ */
+interface PluginFilterCallable {
+    val filterConfiguration: PluginFilterConfiguration?
+}
+
+/**
  * Interface for tracker plugin definition.
  * Specifies configurations for the closures called when and after events are tracked.
  *
@@ -50,18 +114,8 @@ class PluginEntitiesConfiguration(
  * @property entitiesConfiguration Closure configuration that is called when events are tracked to generate context entities to enrich the events.
  * @property afterTrackConfiguration Closure configuration that is called after events are tracked.
  */
-interface PluginConfigurationInterface {
-    val identifier: String
-    val entitiesConfiguration: PluginEntitiesConfiguration?
-    val afterTrackConfiguration: PluginAfterTrackConfiguration?
-}
-
-internal fun PluginConfigurationInterface.toStateMachine(): PluginStateMachine {
-    return PluginStateMachine(
-        identifier = identifier,
-        entitiesConfiguration = entitiesConfiguration,
-        afterTrackConfiguration = afterTrackConfiguration
-    )
+@Deprecated("Use PluginIdentifiable, PluginEntitiesCallable and PluginAfterTrackCallable instead")
+interface PluginConfigurationInterface : PluginIdentifiable, PluginEntitiesCallable, PluginAfterTrackCallable {
 }
 
 /**
@@ -72,9 +126,10 @@ internal fun PluginConfigurationInterface.toStateMachine(): PluginStateMachine {
  */
 class PluginConfiguration(
     override val identifier: String
-) : Configuration, PluginConfigurationInterface {
+) : Configuration, PluginIdentifiable, PluginEntitiesCallable, PluginAfterTrackCallable, PluginFilterCallable {
     override var entitiesConfiguration: PluginEntitiesConfiguration? = null
     override var afterTrackConfiguration: PluginAfterTrackConfiguration? = null
+    override var filterConfiguration: PluginFilterConfiguration? = null
 
     /**
      * Add a closure that generates entities for a given tracked event.
@@ -102,11 +157,29 @@ class PluginConfiguration(
     fun afterTrack(
         schemas: List<String>? = null,
         closure: Consumer<InspectableEvent>
-    ) {
+    ): PluginConfiguration {
         afterTrackConfiguration = PluginAfterTrackConfiguration(
             schemas = schemas,
             closure = closure
         )
+        return this
+    }
+
+    /**
+     * Add a closure that is called to decide whether to track a given event or not.
+     *
+     * @property schemas Optional list of event schemas to call the closure for. If null, the closure is called for all events.
+     * @property closure Closure block that returns true if the event should be tracked, false otherwise.
+     */
+    fun filter(
+        schemas: List<String>? = null,
+        closure: Function<InspectableEvent, Boolean>
+    ): PluginConfiguration {
+        filterConfiguration = PluginFilterConfiguration(
+            schemas = schemas,
+            closure = closure
+        )
+        return this
     }
 
     override fun copy(): Configuration {
@@ -115,6 +188,7 @@ class PluginConfiguration(
         )
         entitiesConfiguration?.let { copy.entities(schemas = it.schemas, closure = it.closure) }
         afterTrackConfiguration?.let { copy.afterTrack(schemas = it.schemas, closure = it.closure) }
+        filterConfiguration?.let { copy.filter(schemas = it.schemas, closure = it.closure) }
         return copy
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/PluginsController.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/PluginsController.kt
@@ -12,7 +12,7 @@
  */
 package com.snowplowanalytics.snowplow.controller
 
-import com.snowplowanalytics.snowplow.configuration.PluginConfigurationInterface
+import com.snowplowanalytics.snowplow.configuration.PluginIdentifiable
 
 /**
  * Controller for managing plugins initialized in the tracker.
@@ -26,7 +26,7 @@ interface PluginsController {
     /**
      * Add a new plugin.
      */
-    fun addPlugin(plugin: PluginConfigurationInterface)
+    fun addPlugin(plugin: PluginIdentifiable)
 
     /**
      * Remove plugin with the identifier.


### PR DESCRIPTION
Issue #608 

Adds a new `filter` callback to plugins which enables deciding whether to track an event or not. This can be useful for filtering auto-tracked events by the tracker.

For instance, this snippet filters screen view events to keep only ones with a specific name property:

```kotlin
plugin.filter(
    schemas = listOf(
        "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0", // screen view events
    )
) { event ->
    event.payload["name"] == "Home Screen"
}
```

## Documentation

[Here is a commit adding the documentation for the filter function](https://github.com/snowplow/documentation/commit/79410621b205fdbbcc2ef3dd20264121e15a8238).