### PR TITLE
Add emitter configuration support to remote configuration (close #607)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/ConfigurationBundle.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/ConfigurationBundle.kt
@@ -26,6 +26,7 @@ class ConfigurationBundle @JvmOverloads constructor(
     var trackerConfiguration: TrackerConfiguration? = null
     var subjectConfiguration: SubjectConfiguration? = null
     var sessionConfiguration: SessionConfiguration? = null
+    var emitterConfiguration: EmitterConfiguration? = null
     
     val configurations: List<Configuration>
         get() {
@@ -34,6 +35,7 @@ class ConfigurationBundle @JvmOverloads constructor(
             trackerConfiguration?.let { array.add(it) }
             subjectConfiguration?.let { array.add(it) }
             sessionConfiguration?.let { array.add(it) }
+            emitterConfiguration?.let { array.add(it) }
             return array
         }
 
@@ -56,6 +58,9 @@ class ConfigurationBundle @JvmOverloads constructor(
         
         json = jsonObject.optJSONObject("sessionConfiguration")
         json?.let { sessionConfiguration = SessionConfiguration(it) }
+
+        json = jsonObject.optJSONObject("emitterConfiguration")
+        json?.let { emitterConfiguration = EmitterConfiguration(it) }
     }
 
     fun updateSourceConfig(sourceBundle: ConfigurationBundle) {
@@ -75,6 +80,10 @@ class ConfigurationBundle @JvmOverloads constructor(
             if (sessionConfiguration == null) sessionConfiguration = SessionConfiguration()
             sessionConfiguration?.sourceConfig = it
         }
+        sourceBundle.emitterConfiguration?.let {
+            if (emitterConfiguration == null) emitterConfiguration = EmitterConfiguration()
+            emitterConfiguration?.sourceConfig = it
+        }
     }
 
     // Copyable
@@ -84,6 +93,7 @@ class ConfigurationBundle @JvmOverloads constructor(
         copy.trackerConfiguration = trackerConfiguration
         copy.subjectConfiguration = subjectConfiguration
         copy.sessionConfiguration = sessionConfiguration
+        copy.emitterConfiguration = emitterConfiguration
         return copy
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.kt
@@ -17,6 +17,7 @@ import com.snowplowanalytics.core.emitter.EmitterDefaults
 import com.snowplowanalytics.snowplow.emitter.BufferOption
 import com.snowplowanalytics.snowplow.emitter.EventStore
 import com.snowplowanalytics.snowplow.network.RequestCallback
+import org.json.JSONObject
 
 /**
  * Configure how the tracker should send the events to the collector.     
@@ -29,7 +30,7 @@ import com.snowplowanalytics.snowplow.network.RequestCallback
  *   - byteLimitGet: 40000 bytes
  *   - byteLimitPost: 40000 bytes
  */
-open class EmitterConfiguration : Configuration, EmitterConfigurationInterface {
+open class EmitterConfiguration() : Configuration, EmitterConfigurationInterface {
 
     private var _isPaused: Boolean? = null
     internal var isPaused: Boolean
@@ -179,5 +180,30 @@ open class EmitterConfiguration : Configuration, EmitterConfigurationInterface {
             .requestCallback(requestCallback)
             .customRetryForStatusCodes(customRetryForStatusCodes)
             .serverAnonymisation(serverAnonymisation)
+    }
+
+    // JSON Formatter
+    /**
+     * This constructor is used in remote configuration.
+     */
+    constructor(jsonObject: JSONObject) : this() {
+        if (jsonObject.has("bufferOption")) {
+            _bufferOption = BufferOption.valueOf(jsonObject.getString("bufferOption"))
+        }
+        if (jsonObject.has("emitRange")) { _emitRange = jsonObject.getInt("emitRange") }
+        if (jsonObject.has("threadPoolSize")) { _threadPoolSize = jsonObject.getInt("threadPoolSize") }
+        if (jsonObject.has("byteLimitGet")) { _byteLimitGet = jsonObject.getLong("byteLimitGet") }
+        if (jsonObject.has("byteLimitPost")) { _byteLimitPost = jsonObject.getLong("byteLimitPost") }
+        if (jsonObject.has("serverAnonymisation")) { _serverAnonymisation = jsonObject.getBoolean("serverAnonymisation") }
+        if (jsonObject.has("customRetryForStatusCodes")) {
+            val customRetryForStatusCodes = mutableMapOf<Int, Boolean>()
+            val customRetryForStatusCodesJson = jsonObject.getJSONObject("customRetryForStatusCodes")
+            val keys = customRetryForStatusCodesJson.keys()
+            while (keys.hasNext()) {
+                val key = keys.next()
+                customRetryForStatusCodes[key.toInt()] = customRetryForStatusCodesJson.getBoolean(key)
+            }
+            _customRetryForStatusCodes = customRetryForStatusCodes
+        }
     }
 }


### PR DESCRIPTION
Issue #607

This PR adds support for loading the emitter configuration in remote configuration. The following properties of emitter configuration can be loaded:

* bufferOption
* emitRange
* threadPoolSize
* byteLimitGet
* byteLimitPost
* customRetryForStatusCodes
* serverAnonymisation

Other ones such as the event store and request callback can not be serialized in remote configuration but can be supplied through default configuration.