### PR TITLE
Truncate URL scheme for page_url and page_refr properties (close #616)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/DeepLinkReceivedTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/DeepLinkReceivedTest.kt
@@ -54,8 +54,8 @@ class DeepLinkReceivedTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
 
         // Prepare DeepLinkReceived event
-        val event = DeepLinkReceived("url")
-            .referrer("referrer")
+        val event = DeepLinkReceived("someappwithaverylongscheme://url")
+            .referrer("someappwithaverylongscheme://referrer")
 
         // Setup tracker
         val trackerConfiguration = TrackerConfiguration("appId")
@@ -89,8 +89,8 @@ class DeepLinkReceivedTest {
         // Check url and referrer fields for atomic table
         val url = payload.map[Parameters.PAGE_URL] as String?
         val referrer = payload.map[Parameters.PAGE_REFR] as String?
-        Assert.assertEquals("url", url)
-        Assert.assertEquals("referrer", referrer)
+        Assert.assertEquals("someappwithavery://url", url)
+        Assert.assertEquals("someappwithavery://referrer", referrer)
     }
 
     @Test

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/utils/UtilTest.kt
@@ -22,6 +22,7 @@ import com.snowplowanalytics.core.utils.Util.joinLongList
 import com.snowplowanalytics.core.utils.Util.mapHasKeys
 import com.snowplowanalytics.core.utils.Util.serialize
 import com.snowplowanalytics.core.utils.Util.timestamp
+import com.snowplowanalytics.core.utils.Util.truncateUrlScheme
 import com.snowplowanalytics.core.utils.Util.uUIDString
 import org.junit.Assert
 import org.junit.Test
@@ -119,5 +120,24 @@ class UtilTest {
         addToMap("hello", "world", map)
         Assert.assertEquals(1, map.size.toLong())
         Assert.assertEquals("world", map["hello"])
+    }
+
+    @Test
+    fun testTruncateUrlSchemeDoesntChangeValidUrl() {
+        val url = "https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/#snowplow-events"
+        Assert.assertEquals(url, truncateUrlScheme(url))
+    }
+
+    @Test
+    fun testTruncateUrlSchemeDoesntChangeInvalidUrl() {
+        val url = "this is not a valid URL"
+        Assert.assertEquals(url, truncateUrlScheme(url))
+    }
+
+    @Test
+    fun testTruncateUrlSchemeTruncatesLongUrlScheme() {
+        val url = "12345678901234567890://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/#snowplow-events"
+        val truncated = "1234567890123456://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/#snowplow-events"
+        Assert.assertEquals(truncated, truncateUrlScheme(url))
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -31,6 +31,7 @@ import com.snowplowanalytics.core.utils.NotificationCenter.addObserver
 import com.snowplowanalytics.core.utils.NotificationCenter.removeObserver
 import com.snowplowanalytics.core.utils.Util.getApplicationContext
 import com.snowplowanalytics.core.utils.Util.getGeoLocationContext
+import com.snowplowanalytics.core.utils.Util.truncateUrlScheme
 import com.snowplowanalytics.snowplow.configuration.PlatformContextProperty
 import com.snowplowanalytics.snowplow.entity.DeepLink
 import com.snowplowanalytics.snowplow.event.*
@@ -583,10 +584,10 @@ class Tracker(
             }
         }
         if (url != null) {
-            payload.add(Parameters.PAGE_URL, url)
+            payload.add(Parameters.PAGE_URL, truncateUrlScheme(url))
         }
         if (referrer != null) {
-            payload.add(Parameters.PAGE_REFR, referrer)
+            payload.add(Parameters.PAGE_REFR, truncateUrlScheme(referrer))
         }
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/Util.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/Util.kt
@@ -363,4 +363,13 @@ object Util {
         e.printStackTrace(pw)
         return sw.toString()
     }
+
+    fun truncateUrlScheme(url: String): String {
+        val parts = url.split("://")
+        if (parts.size > 1) {
+            val updatedParts = listOf(parts.first().take(16)) + parts.drop(1)
+            return updatedParts.joinToString("://")
+        }
+        return url
+    }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/Util.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/Util.kt
@@ -364,6 +364,9 @@ object Util {
         return sw.toString()
     }
 
+    /**
+     * Truncates the scheme of a URL to 16 characters to satisfy the validation for the page_url and page_refr properties.
+     */
     fun truncateUrlScheme(url: String): String {
         val parts = url.split("://")
         if (parts.size > 1) {


### PR DESCRIPTION
Issue #616

This PR addresses the issue that the URL scheme may be quite long for deep links but the atomic events schema limits the max length of the scheme to 16 characters for page_url and page_refr properties, [see here](https://github.com/snowplow/iglu-central/blob/master/schemas/com.snowplowanalytics.snowplow/atomic/jsonschema/1-0-0#L136). This can lead to validation errors when deep links with longer URL schemes are tracked.

To solve the issue, the tracker now truncates the URL scheme in page_url and page_refr properties to 16 chars. This only affects the values in the atomic properties, the URLs in the deep link event and context entity are not truncated.