### PR TITLE
Add custom HTTP headers configuration (close #276)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/NetworkConnectionTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/NetworkConnectionTest.kt
@@ -264,6 +264,38 @@ class NetworkConnectionTest {
         mockServer.shutdown()
     }
 
+    @Test
+    @Throws(IOException::class, InterruptedException::class)
+    fun testAddsCustomRequestHeadersForPostRequest() {
+        val mockServer = getMockServer(200)
+        val connection = OkHttpNetworkConnectionBuilder(getMockServerURI(mockServer)!!, context)
+            .method(HttpMethod.POST)
+            .requestHeaders(mapOf("foo" to "bar"))
+            .build()
+        val payload: Payload = TrackerPayload()
+        payload.add("key", "value")
+        connection.sendRequests(listOf(Request(payload, 2)))
+        val req = mockServer.takeRequest(60, TimeUnit.SECONDS)
+        Assert.assertEquals("bar", req!!.getHeader("foo"))
+        mockServer.shutdown()
+    }
+
+    @Test
+    @Throws(IOException::class, InterruptedException::class)
+    fun testAddsCustomRequestHeadersForGetRequest() {
+        val mockServer = getMockServer(200)
+        val connection = OkHttpNetworkConnectionBuilder(getMockServerURI(mockServer)!!, context)
+            .method(HttpMethod.GET)
+            .requestHeaders(mapOf("foo" to "bar"))
+            .build()
+        val payload: Payload = TrackerPayload()
+        payload.add("key", "value")
+        connection.sendRequests(listOf(Request(payload, 2)))
+        val req = mockServer.takeRequest(60, TimeUnit.SECONDS)
+        Assert.assertEquals("bar", req!!.getHeader("foo"))
+        mockServer.shutdown()
+    }
+
     // Service methods
     private fun assertGETRequest(req: RecordedRequest?) {
         Assert.assertNotNull(req)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
@@ -158,6 +158,7 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
                             .client(client)
                             .cookieJar(cookieJar)
                             .serverAnonymisation(serverAnonymisation)
+                            .requestHeaders(requestHeaders)
                             .build()
                     }
             }
@@ -183,6 +184,7 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
                         .client(client)
                         .cookieJar(cookieJar)
                         .serverAnonymisation(serverAnonymisation)
+                        .requestHeaders(requestHeaders)
                         .build()
                 }
                 
@@ -225,6 +227,7 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
                         .client(client)
                         .cookieJar(cookieJar)
                         .serverAnonymisation(serverAnonymisation)
+                        .requestHeaders(requestHeaders)
                         .build()
                 }
                 
@@ -263,6 +266,7 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
                         .client(client)
                         .cookieJar(cookieJar)
                         .serverAnonymisation(serverAnonymisation)
+                        .requestHeaders(requestHeaders)
                         .build()
                 }
             }
@@ -284,6 +288,7 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
                         .client(client)
                         .cookieJar(cookieJar)
                         .serverAnonymisation(serverAnonymisation)
+                        .requestHeaders(requestHeaders)
                         .build()
                 }
                 
@@ -319,6 +324,7 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
                         .client(client)
                         .cookieJar(cookieJar)
                         .serverAnonymisation(serverAnonymisation)
+                        .requestHeaders(requestHeaders)
                         .build()
                 }
             }
@@ -329,6 +335,32 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
         get() = _customRetryForStatusCodes.get()
         set(value) {
             _customRetryForStatusCodes.set(value ?: HashMap())
+        }
+
+    /**
+     * The request headers for the emitter
+     */
+    var requestHeaders: Map<String, String>? = null
+        /**
+         * Updates the request headers for the emitter.
+         * Ignored if using a custom network connection.
+         */
+        set(requestHeaders) {
+            field = requestHeaders
+            if (!isCustomNetworkConnection && builderFinished) {
+                networkConnection = emitTimeout?.let {
+                    OkHttpNetworkConnectionBuilder(uri, context)
+                        .method(httpMethod)
+                        .tls(tlsVersions)
+                        .emitTimeout(it)
+                        .customPostPath(customPostPath)
+                        .client(client)
+                        .cookieJar(cookieJar)
+                        .serverAnonymisation(serverAnonymisation)
+                        .requestHeaders(requestHeaders)
+                        .build()
+                }
+            }
         }
 
     /**
@@ -356,6 +388,7 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
                     .client(client)
                     .cookieJar(cookieJar)
                     .serverAnonymisation(serverAnonymisation)
+                    .requestHeaders(requestHeaders)
                     .build()
             }
         } else {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/NetworkConfigurationInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/NetworkConfigurationInterface.kt
@@ -20,12 +20,35 @@ import okhttp3.CookieJar
 import okhttp3.OkHttpClient
 
 interface NetworkConfigurationInterface {
+    /** URL (without schema/protocol) used to send events to the collector. */
     val endpoint: String?
+    /** Method used to send events to the collector. */
     val method: HttpMethod?
+    /** Protocol used to send events to the collector. */
     val protocol: Protocol?
+    /** Custom `NetworkConnection` instance to use for sending events. */
     val networkConnection: NetworkConnection?
+    /** A custom path which will be added to the endpoint URL to specify the complete URL of the collector when paired with the POST method. */
     val customPostPath: String?
+    /**
+     * The timeout set for the requests to the collector.
+     * The maximum timeout for emitting events. If emit time exceeds this value
+     * TimeOutException will be thrown.
+     */
     val timeout: Int?
+    /**
+     * An OkHttp client that will be used in the emitter. You can provide your
+     * own if you want to share your Singleton client's interceptors, connection pool etc.
+     * By default a new [OkHttpClient] is created when the tracker is instantiated.
+     */
     val okHttpClient: OkHttpClient?
+    /**
+     * An OkHttp cookie jar to override the default
+     * [CollectorCookieJar](com.snowplowanalytics.snowplow.network.CollectorCookieJar)
+     * that stores cookies in SharedPreferences.
+     * A cookie jar provided here will be ignored if a custom `okHttpClient` is configured.
+     */
     val okHttpCookieJar: CookieJar?
+    /** Custom headers to add to HTTP requests to the collector. */
+    val requestHeaders: Map<String, String>?
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -239,6 +239,7 @@ class ServiceProvider(
             emitter.requestCallback = emitterConfiguration.requestCallback
             emitter.customRetryForStatusCodes = emitterConfiguration.customRetryForStatusCodes
             emitter.serverAnonymisation = emitterConfiguration.serverAnonymisation
+            emitter.requestHeaders = networkConfig.requestHeaders
         }
         
         val emitter = Emitter(context, endpoint, builder)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/NetworkConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/NetworkConfiguration.kt
@@ -92,6 +92,11 @@ class NetworkConfiguration : NetworkConfigurationInterface, Configuration {
         get() = _okHttpCookieJar ?: sourceConfig?.okHttpCookieJar
         set(value) { _okHttpCookieJar = value }
 
+    private var _requestHeaders: Map<String, String>? = null
+    override var requestHeaders: Map<String, String>?
+        get() = _requestHeaders ?: sourceConfig?.requestHeaders
+        set(value) { _requestHeaders = value }
+
     // Constructors
     
     /**
@@ -178,6 +183,14 @@ class NetworkConfiguration : NetworkConfigurationInterface, Configuration {
      */
     fun okHttpCookieJar(okHttpCookieJar: CookieJar): NetworkConfiguration {
         this.okHttpCookieJar = okHttpCookieJar
+        return this
+    }
+
+    /**
+     * Custom headers to add to HTTP requests to the collector.
+     */
+    fun requestHeaders(requestHeaders: Map<String, String>): NetworkConfiguration {
+        this.requestHeaders = requestHeaders
         return this
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
@@ -49,6 +49,7 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
     private val emitTimeout: Int
     private val customPostPath: String?
     private val serverAnonymisation: Boolean
+    private val requestHeaders: Map<String, String>?
     private var client: OkHttpClient? = null
     private val uriBuilder: Uri.Builder
     override val uri: Uri
@@ -69,6 +70,7 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
         var cookieJar: CookieJar? = null // Optional
         var customPostPath: String? = null //Optional
         var serverAnonymisation = EmitterDefaults.serverAnonymisation // Optional
+        var requestHeaders: Map<String, String>? = null // Optional
 
         /**
          * GET or POST.
@@ -167,6 +169,14 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
         }
 
         /**
+         * A map of custom HTTP headers to add to the request.
+         */
+        fun requestHeaders(requestHeaders: Map<String, String>?): OkHttpNetworkConnectionBuilder {
+            this.requestHeaders = requestHeaders
+            return this
+        }
+
+        /**
          * Creates a new OkHttpNetworkConnection
          *
          * @return a new OkHttpNetworkConnection object
@@ -198,6 +208,7 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
         emitTimeout = builder.emitTimeout
         customPostPath = builder.customPostPath
         serverAnonymisation = builder.serverAnonymisation
+        requestHeaders = builder.requestHeaders
         
         val tlsArguments = TLSArguments(builder.tlsVersions)
         uriBuilder = Uri.parse(networkUri).buildUpon()
@@ -298,6 +309,11 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
         if (serverAnonymisation) {
             builder.header("SP-Anonymous", "*")
         }
+        requestHeaders?.let {
+            it.forEach { (key, value) ->
+                builder.header(key, value)
+            }
+        }
         return builder.build()
     }
 
@@ -318,6 +334,11 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
             .post(reqBody)
         if (serverAnonymisation) {
             builder.header("SP-Anonymous", "*")
+        }
+        requestHeaders?.let {
+            it.forEach { (key, value) ->
+                builder.header(key, value)
+            }
         }
         return builder.build()
     }


### PR DESCRIPTION
Issue #276

Add the `requestHeaders` option to the `NetworkConfiguration` similar like on the iOS tracker to let users supply custom HTTP headers for requests to the collector.