### PR TITLE
Truncate language in platform context entity to max 8 characters (close #621)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/MockDeviceInfoMonitor.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/MockDeviceInfoMonitor.kt
@@ -87,10 +87,14 @@ class MockDeviceInfoMonitor : DeviceInfoMonitor() {
             return 70000
         }
 
-    override val language: String?
+    private var _language: String? = "sk"
+    override var language: String?
         get() {
             increaseMethodAccessCount("language")
-            return "sk"
+            return _language
+        }
+        set(value) {
+            _language = value
         }
 
     override fun getResolution(context: Context): String? {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContextTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/PlatformContextTest.kt
@@ -233,6 +233,19 @@ class PlatformContextTest {
         Assert.assertFalse(sdjData.containsKey(Parameters.IS_PORTRAIT))
     }
 
+    @Test
+    fun truncatesLanguageToMax8Chars() {
+        val deviceInfoMonitor = MockDeviceInfoMonitor()
+        deviceInfoMonitor.language = "1234567890"
+        val platformContext = PlatformContext(0, 0, deviceInfoMonitor, null, context)
+
+        val sdj = platformContext.getMobileContext(false)
+        Assert.assertNotNull(sdj)
+        val sdjData = sdj!!.map["data"] as Map<*, *>
+
+        Assert.assertEquals("12345678", sdjData[Parameters.MOBILE_LANGUAGE])
+    }
+
     // --- PRIVATE
     private val context: Context
         get() = InstrumentationRegistry.getInstrumentation().targetContext

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
@@ -124,7 +124,7 @@ class PlatformContext(
         }
         // Language
         if (shouldTrack(PlatformContextProperty.LANGUAGE)) {
-            addToMap(Parameters.MOBILE_LANGUAGE, deviceInfoMonitor.language, pairs)
+            addToMap(Parameters.MOBILE_LANGUAGE, deviceInfoMonitor.language?.take(8), pairs)
         }
 
         setEphemeralPlatformDict()


### PR DESCRIPTION
Issue #621

This PR handles situations where the language property in the `mobile_context` entity was longer than 8 characters, which caused validation errors as the property has a `maxLength` setting of 8 chars.