### PR TITLE
Release/5.4.0

### DIFF
--- a/snowplow-demo-java/src/main/java/com/snowplowanalytics/snowplowtrackerdemojava/Demo.java
+++ b/snowplow-demo-java/src/main/java/com/snowplowanalytics/snowplowtrackerdemojava/Demo.java
@@ -53,6 +53,8 @@ import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration;
 import com.snowplowanalytics.snowplow.controller.EmitterController;
 import com.snowplowanalytics.snowplow.controller.SessionController;
 import com.snowplowanalytics.snowplow.controller.TrackerController;
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceScreenEntity;
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceUserEntity;
 import com.snowplowanalytics.snowplow.emitter.BufferOption;
 import com.snowplowanalytics.snowplow.globalcontexts.GlobalContext;
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform;
@@ -67,13 +69,12 @@ import com.snowplowanalytics.snowplow.util.TimeMeasure;
 import com.snowplowanalytics.snowplowtrackerdemojava.utils.DemoUtils;
 import com.snowplowanalytics.snowplowtrackerdemojava.utils.TrackerEvents;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 import static com.snowplowanalytics.core.utils.Util.addToMap;
 
@@ -266,6 +267,12 @@ public class Demo extends Activity implements LoggerDelegate {
             Snowplow.getDefaultTracker().getEmitter().setRequestCallback(getRequestCallback());
             callbackTrackerReady.accept(true);
         });
+        Objects.requireNonNull(Snowplow.getDefaultTracker()).getEcommerce().setEcommerceScreen(
+            new EcommerceScreenEntity(
+                    "demo_app_screen"
+                    
+            )
+        );
         return true;
     }
 
@@ -339,6 +346,9 @@ public class Demo extends Activity implements LoggerDelegate {
                 plugin
         );
         Snowplow.subscribeToWebViewEvents(_webView);
+        Objects.requireNonNull(Snowplow.getDefaultTracker()).getEcommerce().setEcommerceUser(
+                new EcommerceUserEntity("ecomm_user_id")
+        );
         return true;
     }
 
@@ -349,7 +359,7 @@ public class Demo extends Activity implements LoggerDelegate {
             return;
         }
         TrackerEvents.trackAll(tracker);
-        eventsCreated += 11;
+        eventsCreated += 20;
         final String made = "Made: " + eventsCreated;
         runOnUiThread(() -> _eventsCreated.setText(made));
     }

--- a/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/Demo.kt
+++ b/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/Demo.kt
@@ -37,6 +37,8 @@ import com.snowplowanalytics.snowplow.Snowplow.defaultTracker
 import com.snowplowanalytics.snowplow.Snowplow.setup
 import com.snowplowanalytics.snowplow.Snowplow.subscribeToWebViewEvents
 import com.snowplowanalytics.snowplow.configuration.*
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceScreenEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceUserEntity
 import com.snowplowanalytics.snowplow.emitter.BufferOption
 import com.snowplowanalytics.snowplow.globalcontexts.GlobalContext
 import com.snowplowanalytics.snowplow.network.HttpMethod
@@ -232,6 +234,7 @@ class Demo : Activity(), LoggerDelegate {
                 defaultTracker!!.emitter.requestCallback = requestCallback
                 callbackTrackerReady.accept(true)
             })
+        defaultTracker?.ecommerce?.setEcommerceScreen(EcommerceScreenEntity("demo_app_screen", locale = "England/London"))
         return true
     }
 
@@ -303,9 +306,9 @@ class Demo : Activity(), LoggerDelegate {
         plugin.afterTrack { event: InspectableEvent -> 
             println("Tracked event with ${event.entities.size} entities")
         }
-
-        createTracker(
-            applicationContext,
+        
+        val tracker = createTracker(
+            context = applicationContext,
             namespace,
             networkConfiguration,
             trackerConfiguration,
@@ -316,6 +319,7 @@ class Demo : Activity(), LoggerDelegate {
             plugin
         )
         subscribeToWebViewEvents(_webView!!)
+        tracker.ecommerce.setEcommerceUser(EcommerceUserEntity("ecomm_user_id"))
         return true
     }
 
@@ -326,7 +330,7 @@ class Demo : Activity(), LoggerDelegate {
             return
         }
         TrackerEvents.trackAll(tracker)
-        eventsCreated += 11
+        eventsCreated += 20
         val made = "Made: $eventsCreated"
         runOnUiThread { _eventsCreated!!.text = made }
     }

--- a/snowplow-tracker/Module.md
+++ b/snowplow-tracker/Module.md
@@ -6,39 +6,6 @@ to add analytics to your mobile apps when using a
 
 With this tracker you can collect event data from your applications, games or frameworks.
 
-# Package com.snowplowanalytics.core
-Internal use. The main package for the tracker core classes.
-
-# Package com.snowplowanalytics.core.constants
-Internal use. Constants used in constructing event requests.
-
-# Package com.snowplowanalytics.core.emitter
-Internal use. Classes involved in buffering and sending events.
-
-# Package com.snowplowanalytics.core.emitter.storage
-Internal use. Classes for event storage.
-
-# Package com.snowplowanalytics.core.gdpr
-Internal use. Manages the GDPR context entity.
-
-# Package com.snowplowanalytics.core.globalcontexts
-Internal use. Manages configured GlobalContexts.
-
-# Package com.snowplowanalytics.core.remoteconfiguration
-Internal use. Classes to manage remote configuration.
-
-# Package com.snowplowanalytics.core.session
-Internal use. Session management.
-
-# Package com.snowplowanalytics.core.statemachine
-Internal use. StateMachines are used for managing various states, as well as custom provided plugins.
-
-# Package com.snowplowanalytics.core.tracker
-Internal use. Classes for tracking events plus associated data.
-
-# Package com.snowplowanalytics.core.utils
-Internal use. Core utils.
-
 # Package com.snowplowanalytics.snowplow
 The main package for the published tracker API.
 
@@ -71,3 +38,12 @@ Supplementary classes for tracker configuration.
 
 # Package com.snowplowanalytics.snowplow.util
 Published utils classes.
+
+# Package com.snowplowanalytics.snowplow.ecommerce
+Classes for tracking ecommerce activity.
+
+# Package com.snowplowanalytics.snowplow.ecommerce.entities
+Ecommerce data classes.
+
+# Package com.snowplowanalytics.snowplow.ecommerce.events
+Snowplow Ecommerce event types.

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/AddToCartTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/AddToCartTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.CartEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.AddToCartEvent
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class AddToCartTest {
+    @Test
+    fun testExpectedForm() {
+        val product1 = ProductEntity(
+            id = "product ID",
+            name = "product name",
+            category = "category",
+            price = 100,
+            listPrice = 110,
+            quantity = 2,
+            size = "small",
+            variant = "black/black",
+            brand = "Snowplow",
+            inventoryStatus = "backorder",
+            position = 1,
+            currency = "GBP",
+            creativeId = "ecomm1"
+        )
+        val product2 = ProductEntity(
+            id = "ID2",
+            price = 0.99,
+            currency = "GBP",
+            category = "category"
+        )
+        
+        val cart = CartEntity(totalValue = 123.45, currency = "GBP")
+        
+        var event = AddToCartEvent(products = listOf(product1, product2), cart = cart)
+        var cartMap = hashMapOf<String, Any>(
+            "schema" to TrackerConstants.SCHEMA_ECOMMERCE_CART,
+            "data" to hashMapOf<String, Any>(
+                Parameters.ECOMM_CART_VALUE to 123.45,
+                Parameters.ECOMM_CART_CURRENCY to "GBP"
+            )
+        )
+        
+        val data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.add_to_cart.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_NAME))
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_CART_ID))
+        
+        var entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(3, entities!!.size)
+        Assert.assertEquals(cartMap, entities[2].map)
+        
+        event = AddToCartEvent(listOf(product1), CartEntity(0.5, "USD", "id"))
+        cartMap = hashMapOf(
+            "schema" to TrackerConstants.SCHEMA_ECOMMERCE_CART,
+            "data" to hashMapOf<String, Any>(
+                Parameters.ECOMM_CART_VALUE to 0.5,
+                Parameters.ECOMM_CART_CURRENCY to "USD",
+                Parameters.ECOMM_CART_ID to "id",
+            ))
+        
+        entities = event.entitiesForProcessing
+        Assert.assertEquals(cartMap, entities!![1].map)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/CheckoutStepTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/CheckoutStepTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.events.CheckoutStepEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class CheckoutStepTest {
+    @Test
+    fun testExpectedForm() {
+        val event = CheckoutStepEvent(step = 5,
+            "postcode",
+            shippingFullAddress = "full address",
+            deliveryMethod = "stork",
+            marketingOptIn = true
+        )
+        val map = hashMapOf<String, Any>(
+            "schema" to TrackerConstants.SCHEMA_ECOMMERCE_CHECKOUT_STEP,
+            "data" to hashMapOf<String, Any>(
+                Parameters.ECOMM_CHECKOUT_STEP to 5,
+                Parameters.ECOMM_CHECKOUT_SHIPPING_POSTCODE to "postcode",
+                Parameters.ECOMM_CHECKOUT_SHIPPING_ADDRESS to "full address",
+                Parameters.ECOMM_CHECKOUT_DELIVERY_METHOD to "stork",
+                Parameters.ECOMM_CHECKOUT_MARKETING_OPT_IN to true,
+            )
+        )
+        
+        val data: Map<String, Any?> = event.dataPayload
+        
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.checkout_step.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_CHECKOUT_STEP))
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_NAME))
+
+        val entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(1, entities!!.size)
+        Assert.assertEquals(map, entities[0].map)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/EcommerceTransactionTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/EcommerceTransactionTest.kt
@@ -12,7 +12,6 @@
  */
 package com.snowplowanalytics.snowplow.event
 
-import androidx.test.espresso.core.internal.deps.guava.collect.Lists
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.snowplowanalytics.core.constants.Parameters
 import org.junit.Assert
@@ -20,7 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class EcommerceTest {
+class EcommerceTransactionTest {
     
     @Test
     fun testExpectedForm() {

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ProductListClickTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ProductListClickTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.ProductListClickEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class ProductListClickTest {
+    @Test
+    fun testExpectedForm() {
+        val product = ProductEntity(
+            id = "product ID",
+            name = "product name",
+            category = "category",
+            price = 100,
+            listPrice = 110,
+            quantity = 2,
+            size = "small",
+            variant = "black/black",
+            brand = "Snowplow",
+            inventoryStatus = "backorder",
+            position = 1,
+            currency = "GBP",
+            creativeId = "ecomm1"
+        )
+        
+        var productListClick = ProductListClickEvent(product)
+        var data: Map<String, Any?> = productListClick.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.list_click.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_NAME))
+
+        productListClick = ProductListClickEvent(product, "seasonal_selection")
+        data = productListClick.dataPayload
+        Assert.assertTrue(data.containsKey(Parameters.ECOMM_NAME))
+        Assert.assertEquals(data[Parameters.ECOMM_NAME], "seasonal_selection")
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ProductListViewTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ProductListViewTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.ProductListViewEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class ProductListViewTest {
+    @Test
+    fun testExpectedForm() {
+        val product1 = ProductEntity(
+            id = "product ID",
+            name = "product name",
+            category = "category",
+            price = 100,
+            listPrice = 110,
+            quantity = 2,
+            size = "small",
+            variant = "black/black",
+            brand = "Snowplow",
+            inventoryStatus = "backorder",
+            position = 1,
+            currency = "GBP",
+            creativeId = "ecomm1"
+        )
+        val product2 = ProductEntity(
+            id = "ID2",
+            price = 0.99,
+            category = "category2",
+            currency = "GBP"
+        )
+        
+        var event = ProductListViewEvent(listOf(product1, product2))
+        var data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.list_view.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_NAME))
+
+        event = ProductListViewEvent(listOf(product1), "list name")
+        data = event.dataPayload
+        Assert.assertTrue(data.containsKey(Parameters.ECOMM_NAME))
+        Assert.assertEquals(data[Parameters.ECOMM_NAME], "list name")
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ProductViewTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/ProductViewTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.ProductViewEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class ProductViewTest {
+    @Test
+    fun testExpectedForm() {
+        val product = ProductEntity(
+            id = "product ID",
+            name = "product name",
+            category = "category",
+            price = 100,
+            listPrice = 110,
+            quantity = 2,
+            size = "small",
+            variant = "black/black",
+            brand = "Snowplow",
+            inventoryStatus = "backorder",
+            position = 1,
+            currency = "GBP",
+            creativeId = "ecomm1"
+        )
+        val event = ProductViewEvent(product)
+
+        val map = hashMapOf<String, Any>(
+            "schema" to TrackerConstants.SCHEMA_ECOMMERCE_PRODUCT,
+            "data" to hashMapOf<String, Any>(
+                Parameters.ECOMM_PRODUCT_ID to "product ID",
+                Parameters.ECOMM_PRODUCT_NAME to "product name",
+                Parameters.ECOMM_PRODUCT_CATEGORY to "category",
+                Parameters.ECOMM_PRODUCT_PRICE to 100,
+                Parameters.ECOMM_PRODUCT_LIST_PRICE to 110,
+                Parameters.ECOMM_PRODUCT_QUANTITY to 2,
+                Parameters.ECOMM_PRODUCT_SIZE to "small",
+                Parameters.ECOMM_PRODUCT_VARIANT to "black/black",
+                Parameters.ECOMM_PRODUCT_BRAND to "Snowplow",
+                Parameters.ECOMM_PRODUCT_INVENTORY_STATUS to "backorder",
+                Parameters.ECOMM_PRODUCT_POSITION to 1,
+                Parameters.ECOMM_PRODUCT_CURRENCY to "GBP",
+                Parameters.ECOMM_PRODUCT_CREATIVE_ID to "ecomm1"
+            )
+        )
+        
+        val data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.product_view.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_PRODUCT_ID))
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_NAME))
+
+        val entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(1, entities!!.size)
+        Assert.assertEquals(map, entities[0].map)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/PromotionClickTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/PromotionClickTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.PromotionEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.PromotionClickEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class PromotionClickTest {
+    @Test
+    fun testExpectedForm() {
+        val promotion = PromotionEntity(
+            "promo_id",
+            "name",
+            listOf("abc", "def", "xyz"),
+            4,
+            "creative",
+            "banner",
+            "top_slot"
+        )
+        val event = PromotionClickEvent(promotion)
+
+        val map = hashMapOf<String, Any>(
+            "schema" to TrackerConstants.SCHEMA_ECOMMERCE_PROMOTION,
+            "data" to hashMapOf(
+                Parameters.ECOMM_PROMO_ID to "promo_id",
+                Parameters.ECOMM_PROMO_NAME to "name",
+                Parameters.ECOMM_PROMO_PRODUCT_IDS to listOf("abc", "def", "xyz"),
+                Parameters.ECOMM_PROMO_POSITION to 4,
+                Parameters.ECOMM_PROMO_CREATIVE_ID to "creative",
+                Parameters.ECOMM_PROMO_TYPE to "banner",
+                Parameters.ECOMM_PROMO_SLOT to "top_slot"
+            )
+        )
+        
+        val data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.promo_click.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_NAME))
+
+        val entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(1, entities!!.size)
+        Assert.assertEquals(map, entities[0].map)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/PromotionViewTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/PromotionViewTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.PromotionEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.PromotionViewEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class PromotionViewTest {
+    @Test
+    fun testExpectedForm() {
+        val promotion = PromotionEntity("promo_id")
+        val event = PromotionViewEvent(promotion)
+        val data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.promo_view.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_NAME))
+
+        val entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(1, entities!!.size)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/RefundTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/RefundTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.RefundEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class RefundTest {
+    @Test
+    fun testExpectedForm() {
+        val product1 = ProductEntity(
+            id = "product ID",
+            name = "product name",
+            category = "category",
+            currency = "JPY",
+            price = 123456789
+        )
+
+        val event = RefundEvent("id", currency = "USD", refundAmount = 123.45, products = listOf(product1))
+
+        val map = hashMapOf<String, Any>(
+            "schema" to TrackerConstants.SCHEMA_ECOMMERCE_REFUND,
+            "data" to hashMapOf(
+                Parameters.ECOMM_REFUND_ID to "id",
+                Parameters.ECOMM_REFUND_CURRENCY to "USD",
+                Parameters.ECOMM_REFUND_AMOUNT to 123.45,
+            )
+        )
+        
+        val data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.refund.toString(), data[Parameters.ECOMM_TYPE])
+
+        val entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(2, entities!!.size)
+        Assert.assertEquals(map, entities[1].map)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/RemoveFromCartTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/RemoveFromCartTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.CartEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.RemoveFromCartEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class RemoveFromCartTest {
+    @Test
+    fun testExpectedForm() {
+        val product1 = ProductEntity(
+            id = "product ID",
+            name = "product name",
+            category = "category",
+            price = 100,
+            listPrice = 110,
+            quantity = 2,
+            size = "small",
+            variant = "black/black",
+            brand = "Snowplow",
+            inventoryStatus = "backorder",
+            position = 1,
+            currency = "GBP",
+            creativeId = "ecomm1"
+        )
+        val product2 = ProductEntity(
+            id = "ID2",
+            category = "category2",
+            price = 0.99,
+            currency = "GBP"
+        )
+        
+        val cart = CartEntity(totalValue = 123.45, currency = "GBP")
+        
+        val event = RemoveFromCartEvent(listOf(product1, product2), cart)
+        val data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.remove_from_cart.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_NAME))
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_CART_CURRENCY))
+
+        val entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(3, entities!!.size)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/TransactionErrorTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/TransactionErrorTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.ErrorType
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.TransactionEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.TransactionErrorEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.TransactionEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class TransactionErrorTest {
+    @Test
+    fun testExpectedForm() {
+        val transaction = TransactionEntity(
+        "transactionId",
+        9876543.21,
+        "GBP",
+        "cash",
+        1
+        )
+
+        val event = TransactionErrorEvent(
+            transaction,
+            errorCode = "E-001",
+            errorShortcode = "shortcode",
+            errorDescription = "description",
+            errorType = ErrorType.Soft,
+            resolution = "resolution"
+        )
+
+        val map = hashMapOf<String, Any>(
+            "schema" to TrackerConstants.SCHEMA_ECOMMERCE_TRANSACTION_ERROR,
+            "data" to hashMapOf(
+                Parameters.ECOMM_TRANSACTION_ERROR_CODE to "E-001",
+                Parameters.ECOMM_TRANSACTION_ERROR_SHORTCODE to "shortcode",
+                Parameters.ECOMM_TRANSACTION_ERROR_DESCRIPTION to "description",
+                Parameters.ECOMM_TRANSACTION_ERROR_TYPE to "soft",
+                Parameters.ECOMM_TRANSACTION_ERROR_RESOLUTION to "resolution"
+            )
+        )
+        
+        val data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.trns_error.toString(), data[Parameters.ECOMM_TYPE])
+
+        val entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(2, entities!!.size)
+        Assert.assertEquals(map, entities[0].map)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/TransactionTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/event/TransactionTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.TransactionEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.TransactionEvent
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class TransactionTest {
+    @Test
+    fun testExpectedForm() {
+        val product1 = ProductEntity(
+            id = "product ID",
+            name = "product name",
+            category = "category",
+            currency = "JPY",
+            price = 123456789
+        )
+        val product2 = ProductEntity(
+            id = "id",
+            price = 0.99,
+            category = "category2",
+            currency = "GBP"
+        )
+        
+        val transaction = TransactionEntity(
+        "transactionId",
+        8999,
+        "EUR",
+        "visa",
+        2000
+        )
+
+        val event = TransactionEvent(transaction, products = listOf(product1, product2))
+
+        val map = hashMapOf<String, Any>(
+            "schema" to TrackerConstants.SCHEMA_ECOMMERCE_TRANSACTION,
+            "data" to hashMapOf(
+                Parameters.ECOMM_TRANSACTION_ID to "transactionId",
+                Parameters.ECOMM_TRANSACTION_REVENUE to 8999,
+                Parameters.ECOMM_TRANSACTION_CURRENCY to "EUR",
+                Parameters.ECOMM_TRANSACTION_PAYMENT_METHOD to "visa",
+                Parameters.ECOMM_TRANSACTION_QUANTITY to 2000,
+            )
+        )
+        
+        val data: Map<String, Any?> = event.dataPayload
+        Assert.assertNotNull(data)
+        Assert.assertEquals(EcommerceAction.transaction.toString(), data[Parameters.ECOMM_TYPE])
+        Assert.assertFalse(data.containsKey(Parameters.ECOMM_TRANSACTION_REVENUE))
+
+        val entities = event.entitiesForProcessing
+        Assert.assertNotNull(entities)
+        Assert.assertEquals(3, entities!!.size)
+        Assert.assertEquals(map, entities[2].map)
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/EcommerceTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/EcommerceTest.kt
@@ -1,0 +1,700 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.internal.tracker
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.Snowplow
+import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration
+import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration
+import com.snowplowanalytics.snowplow.controller.TrackerController
+import com.snowplowanalytics.snowplow.ecommerce.entities.CartEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceScreenEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceUserEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.AddToCartEvent
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.PromotionEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.TransactionEntity
+import com.snowplowanalytics.snowplow.ecommerce.events.CheckoutStepEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.ProductListClickEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.ProductListViewEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.ProductViewEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.PromotionClickEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.PromotionViewEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.RefundEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.RemoveFromCartEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.TransactionErrorEvent
+import com.snowplowanalytics.snowplow.ecommerce.events.TransactionEvent
+import com.snowplowanalytics.snowplow.event.*
+import com.snowplowanalytics.snowplow.network.HttpMethod
+import com.snowplowanalytics.snowplow.network.Request
+import com.snowplowanalytics.snowplow.tracker.MockNetworkConnection
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+import kotlin.collections.ArrayList
+
+@RunWith(AndroidJUnit4::class)
+class EcommerceTest {
+    
+    @Test
+    @Throws(Exception::class)
+    fun productView() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+        
+        val product = ProductEntity(
+            "id", 
+            price = 12.34, 
+            currency = "GBP", 
+            name = "lovely product", 
+            position = 1,
+            category = "accessories"
+        )
+        tracker.track(ProductViewEvent(product))
+        waitForEvents(networkConnection, 1)
+        
+        Assert.assertEquals(1, networkConnection.countRequests())
+        
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val productEntities = getProductEntities(request)
+        
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.product_view.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_NAME))
+        
+        Assert.assertEquals(1, productEntities.size)
+        Assert.assertEquals("id", productEntities[0].get(Parameters.ECOMM_PRODUCT_ID))
+        Assert.assertEquals(12.34, productEntities[0].get(Parameters.ECOMM_PRODUCT_PRICE))
+        Assert.assertEquals("GBP", productEntities[0].get(Parameters.ECOMM_PRODUCT_CURRENCY))
+        Assert.assertEquals("lovely product", productEntities[0].get(Parameters.ECOMM_PRODUCT_NAME))
+        Assert.assertEquals(1, productEntities[0].get(Parameters.ECOMM_PRODUCT_POSITION))
+        
+        Assert.assertFalse(productEntities[0].has(Parameters.ECOMM_PRODUCT_LIST_PRICE))
+        Assert.assertFalse(productEntities[0].has(Parameters.ECOMM_PRODUCT_VARIANT))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun productListClick() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        val product = ProductEntity(
+            "id",
+            price = 5.00,
+            currency = "EUR",
+            category = "misc"
+        )
+        tracker.track(ProductListClickEvent(product))
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        var request = networkConnection.allRequests[0]
+        var event = getEvent(request)
+        val productEntities = getProductEntities(request)
+        
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.list_click.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_NAME))
+
+        Assert.assertEquals(1, productEntities.size)
+        Assert.assertEquals("id", productEntities[0].get(Parameters.ECOMM_PRODUCT_ID))
+        Assert.assertEquals(5, productEntities[0].get(Parameters.ECOMM_PRODUCT_PRICE))
+        Assert.assertEquals("EUR", productEntities[0].get(Parameters.ECOMM_PRODUCT_CURRENCY))
+        Assert.assertFalse(productEntities[0].has(Parameters.ECOMM_PRODUCT_POSITION))
+
+        tracker.track(ProductListClickEvent(product, "list name"))
+        waitForEvents(networkConnection, 2)
+        
+        request = networkConnection.allRequests[1]
+        event = getEvent(request)
+        Assert.assertEquals("list name", event.getJSONObject("data").getString("name"))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun productListView() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        val product1 = ProductEntity(
+            "id",
+            price = 0.99,
+            currency = "CAD",
+            category = "motors"
+        )
+        val product2 = ProductEntity(
+            "id2",
+            price = 1000,
+            currency = "AUD",
+            name = "snowplow",
+            category = "ploughs",
+            listPrice = 1500.0,
+            size = "large",
+            variant = "shiny",
+            inventoryStatus = "in_stock",
+            creativeId = "plow_promo"
+        )
+        
+        tracker.track(ProductListViewEvent(listOf(product1, product2), "specials"))
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val productEntities = getProductEntities(request)
+        
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.list_view.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertEquals("specials", event.getJSONObject("data").getString("name"))
+
+        Assert.assertEquals(2, productEntities.size)
+        
+        var entity = productEntities[0]
+        Assert.assertEquals("id", entity.get(Parameters.ECOMM_PRODUCT_ID))
+        Assert.assertEquals(0.99, entity.get(Parameters.ECOMM_PRODUCT_PRICE))
+        Assert.assertEquals("CAD", entity.get(Parameters.ECOMM_PRODUCT_CURRENCY))
+        Assert.assertFalse(entity.has(Parameters.ECOMM_PRODUCT_NAME))
+
+        entity = productEntities[1]
+        Assert.assertEquals("id2", entity.get(Parameters.ECOMM_PRODUCT_ID))
+        Assert.assertEquals(1000, entity.get(Parameters.ECOMM_PRODUCT_PRICE))
+        Assert.assertEquals("AUD", entity.get(Parameters.ECOMM_PRODUCT_CURRENCY))
+        Assert.assertEquals("large", entity.get(Parameters.ECOMM_PRODUCT_SIZE))
+        Assert.assertEquals("shiny", entity.get(Parameters.ECOMM_PRODUCT_VARIANT))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun addToCart() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        val product1 = ProductEntity(
+            "id1",
+            price = 0.99,
+            category = "flour",
+            currency = "USD",
+        )
+
+        tracker.track(AddToCartEvent(listOf(product1), CartEntity(100, "GBP")))
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val productEntities = getProductEntities(request)
+        val cartEntities = getCartEntities(request)
+
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.add_to_cart.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_NAME))
+
+        Assert.assertEquals(1, productEntities.size)
+        Assert.assertEquals(1, cartEntities.size)
+
+        Assert.assertEquals("id1", productEntities[0].get(Parameters.ECOMM_PRODUCT_ID))
+
+        val cart = cartEntities[0]
+        Assert.assertEquals(100, cart.get(Parameters.ECOMM_CART_VALUE))
+        Assert.assertEquals("GBP", cart.get(Parameters.ECOMM_CART_CURRENCY))
+        Assert.assertFalse(cart.has(Parameters.ECOMM_CART_ID))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun removeFromCart() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        val product = ProductEntity(
+            "product123",
+            price = 200000,
+            currency = "JPY",
+            category = "kitchen"
+        )
+
+        tracker.track(RemoveFromCartEvent(listOf(product), CartEntity(400000, "JPY", "cart567")))
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val productEntities = getProductEntities(request)
+        val cartEntities = getCartEntities(request)
+
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.remove_from_cart.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_NAME))
+
+        Assert.assertEquals(1, productEntities.size)
+        Assert.assertEquals(1, cartEntities.size)
+
+        Assert.assertEquals("product123", productEntities[0].get(Parameters.ECOMM_PRODUCT_ID))
+
+        val cart = cartEntities[0]
+        Assert.assertEquals(400000, cart.get(Parameters.ECOMM_CART_VALUE))
+        Assert.assertEquals("JPY", cart.get(Parameters.ECOMM_CART_CURRENCY))
+        Assert.assertEquals("cart567", cart.get(Parameters.ECOMM_CART_ID))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun checkoutStep() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        tracker.track(CheckoutStepEvent(step = 1, couponCode = "WELCOME2023"))
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val checkoutEntities = getCheckoutEntities(request)
+
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.checkout_step.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_NAME))
+
+        Assert.assertEquals(1, checkoutEntities.size)
+
+        Assert.assertEquals(1, checkoutEntities[0].get(Parameters.ECOMM_CHECKOUT_STEP))
+        Assert.assertEquals("WELCOME2023", checkoutEntities[0].get(Parameters.ECOMM_CHECKOUT_COUPON_CODE))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun transaction() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        val product1 = ProductEntity("id1", currency = "CHF", price = 10.99, category = "climbing")
+        val product2 = ProductEntity("id2", currency = "CHF", price = 4, category = "boxing")
+        
+        val transaction = TransactionEntity(
+            transactionId = "id123",
+            revenue = 5,
+            currency = "CHF",
+            paymentMethod = "credit_card",
+            totalQuantity = 2
+        )
+
+        tracker.track(TransactionEvent(transaction, products = listOf(product1, product2)))
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val productEntities = getProductEntities(request)
+        val transactionEntities = getTransactionEntities(request)
+
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.transaction.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_NAME))
+
+        Assert.assertEquals(2, productEntities.size)
+        Assert.assertEquals(1, transactionEntities.size)
+
+        Assert.assertEquals("id1", productEntities[0].get(Parameters.ECOMM_PRODUCT_ID))
+
+        val entity = transactionEntities[0]
+        Assert.assertEquals(5, entity.get(Parameters.ECOMM_TRANSACTION_REVENUE))
+        Assert.assertEquals("CHF", entity.get(Parameters.ECOMM_TRANSACTION_CURRENCY))
+        Assert.assertEquals("id123", entity.get(Parameters.ECOMM_TRANSACTION_ID))
+        Assert.assertEquals("credit_card", entity.get(Parameters.ECOMM_TRANSACTION_PAYMENT_METHOD))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun transactionError() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        val transaction = TransactionEntity(
+            transactionId = "id123",
+            revenue = 5,
+            currency = "CHF",
+            paymentMethod = "credit_card",
+            totalQuantity = 2
+        )
+        
+        val errorEvent = TransactionErrorEvent(
+            transaction,
+            "code",
+            "processor_declined",
+            "user_details_invalid"
+        )
+
+        tracker.track(errorEvent)
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val errorEntities = getTransactionErrorEntities(request)
+        val transactionEntities = getTransactionEntities(request)
+
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.trns_error.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_NAME))
+
+        Assert.assertEquals(1, errorEntities.size)
+        Assert.assertEquals(1, transactionEntities.size)
+
+        val entity = errorEntities[0]
+        Assert.assertEquals("code", entity.get(Parameters.ECOMM_TRANSACTION_ERROR_CODE))
+        Assert.assertEquals("processor_declined", entity.get(Parameters.ECOMM_TRANSACTION_ERROR_SHORTCODE))
+        Assert.assertEquals("user_details_invalid", entity.get(Parameters.ECOMM_TRANSACTION_ERROR_DESCRIPTION))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun promotionView() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        val promo = PromotionEntity(
+            "promo1",
+            productIds = listOf("product1", "product2", "product3"),
+        )
+
+        tracker.track(PromotionViewEvent(promo))
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val promoEntities = getPromoEntities(request)
+
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.promo_view.toString(), event.getJSONObject("data").getString("type"))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_NAME))
+
+        Assert.assertEquals(1, promoEntities.size)
+
+        Assert.assertEquals("promo1", promoEntities[0].get(Parameters.ECOMM_PROMO_ID))
+        Assert.assertEquals("[\"product1\",\"product2\",\"product3\"]", promoEntities[0].get(Parameters.ECOMM_PROMO_PRODUCT_IDS).toString())
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun promotionClick() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        val promo = PromotionEntity(
+            "promo1",
+        )
+
+        tracker.track(PromotionClickEvent(promo))
+        waitForEvents(networkConnection, 1)
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        println(request.payload)
+        val event = getEvent(request)
+        val promoEntities = getPromoEntities(request)
+
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.promo_click.toString(), event.getJSONObject("data").getString("type"))
+
+        Assert.assertEquals(1, promoEntities.size)
+
+        Assert.assertEquals("promo1", promoEntities[0].get(Parameters.ECOMM_PROMO_ID))
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun refund() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+        
+        val product1 = ProductEntity("productId", category = "roses", price = 24.99, currency = "CAD")
+        val product2 = ProductEntity("id2", category = "gloves", price = 3.56, currency = "CAD")
+        
+        tracker.track(RefundEvent("refund_123",
+            currency = "GBP",
+            refundAmount = 1.00,
+            products = listOf(product1, product2))
+        )
+        waitForEvents(networkConnection, 1)
+        
+        Assert.assertEquals(1, networkConnection.countRequests())
+
+        val request = networkConnection.allRequests[0]
+        val event = getEvent(request)
+        val productEntities = getProductEntities(request)
+        val refundEntities = getRefundEntities(request)
+
+        Assert.assertEquals(TrackerConstants.SCHEMA_ECOMMERCE_ACTION, event.getString("schema"))
+        Assert.assertEquals(EcommerceAction.refund.toString(), event.getJSONObject("data").getString("type"))
+
+        Assert.assertEquals(1, refundEntities.size)
+        Assert.assertEquals(2, productEntities.size)
+
+        Assert.assertEquals("refund_123", refundEntities[0].get(Parameters.ECOMM_REFUND_ID))
+        Assert.assertEquals("GBP", refundEntities[0].get(Parameters.ECOMM_REFUND_CURRENCY))
+        Assert.assertEquals(1, refundEntities[0].get(Parameters.ECOMM_REFUND_AMOUNT))
+        Assert.assertFalse(event.getJSONObject("data").has(Parameters.ECOMM_REFUND_REASON))
+    }
+    
+    @Test
+    fun addsPageEntity() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+        
+        tracker.ecommerce.setEcommerceScreen(EcommerceScreenEntity(type = "listing", language = "DE", locale = "DE"))
+        
+        tracker.track(ScreenView("screen"))
+        waitForEvents(networkConnection, 1)
+        
+        var request = networkConnection.allRequests[0]
+        var pageEntities = getPageEntities(request)
+
+        Assert.assertEquals(1, pageEntities.size)
+        Assert.assertEquals("DE", pageEntities[0].get("language"))
+        Assert.assertEquals("listing", pageEntities[0].get("type"))
+        Assert.assertEquals("DE", pageEntities[0].get("locale"))
+
+
+        // replacing earlier Page
+        tracker.ecommerce.setEcommerceScreen(EcommerceScreenEntity(type = "home_screen", language = "EN-GB"))
+
+        tracker.track(Structured("category", "action"))
+        waitForEvents(networkConnection, 2)
+
+        request = networkConnection.allRequests[1]
+        pageEntities = getPageEntities(request)
+        
+        Assert.assertEquals(1, pageEntities.size)
+        Assert.assertEquals("EN-GB", pageEntities[0].get("language"))
+        Assert.assertEquals("home_screen", pageEntities[0].get("type"))
+        Assert.assertFalse(pageEntities[0].has("locale"))
+        
+        // removing Page
+        tracker.ecommerce.removeEcommerceScreen()
+        tracker.track(ScreenView("productA"))
+        waitForEvents(networkConnection, 3)
+
+        request = networkConnection.allRequests[2]
+        pageEntities = getPageEntities(request)
+
+        Assert.assertEquals(0, pageEntities.size)
+    }
+
+    @Test
+    fun addsUserEntity() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val tracker = getTracker(networkConnection)
+
+        tracker.ecommerce.setEcommerceUser(EcommerceUserEntity("user_id"))
+
+        tracker.track(ScreenView("screen"))
+        waitForEvents(networkConnection, 1)
+
+        var request = networkConnection.allRequests[0]
+        var userEntities = getUserEntities(request)
+
+        Assert.assertEquals(1, userEntities.size)
+        Assert.assertEquals("user_id", userEntities[0].get("id"))
+        Assert.assertFalse(userEntities[0].has("is_guest"))
+
+        // replacing earlier User
+        tracker.ecommerce.setEcommerceUser(EcommerceUserEntity("a_new_user", false, "email@email.com"))
+
+        tracker.track(Structured("category", "action"))
+        waitForEvents(networkConnection, 2)
+
+        request = networkConnection.allRequests[1]
+        userEntities = getUserEntities(request)
+
+        Assert.assertEquals(1, userEntities.size)
+        Assert.assertEquals("a_new_user", userEntities[0].get("id"))
+        Assert.assertEquals(false, userEntities[0].get("is_guest"))
+        Assert.assertEquals("email@email.com", userEntities[0].get("email"))
+
+        // removing User
+        tracker.ecommerce.removeEcommerceUser()
+        tracker.track(ScreenView("productA"))
+        waitForEvents(networkConnection, 3)
+
+        request = networkConnection.allRequests[2]
+        userEntities = getUserEntities(request)
+
+        Assert.assertEquals(0, userEntities.size)
+    }
+    
+
+    // Helpers
+    private fun getTracker(networkConnection: MockNetworkConnection): TrackerController {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        
+        val networkConfig = NetworkConfiguration(networkConnection)
+        val trackerConfig = TrackerConfiguration("appId").base64encoding(false)
+
+        Snowplow.removeAllTrackers()
+        return Snowplow.createTracker(
+            context,
+            "ns${Math.random()}",
+            networkConfig,
+            trackerConfig
+        )
+    }
+
+    @Throws(Exception::class)
+    fun waitForEvents(networkConnection: MockNetworkConnection, eventsExpected: Int) {
+        var i = 0
+        while (i < 10 && networkConnection.countRequests() == eventsExpected - 1) {
+            Thread.sleep(1000)
+            i++
+        }
+    }
+
+    private fun getEvent(request: Request) : JSONObject {
+        return JSONObject(request.payload.map["ue_pr"] as String)
+            .getJSONObject("data")
+    }
+
+    private fun getProductEntities(request: Request) : ArrayList<JSONObject> {
+        val relevantEntities = ArrayList<JSONObject>()
+        val allEntities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until allEntities.length()) {
+            if (allEntities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_PRODUCT) {
+                relevantEntities.add(allEntities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return relevantEntities
+    }
+
+    private fun getCartEntities(request: Request) : ArrayList<JSONObject> {
+        val relevantEntities = ArrayList<JSONObject>()
+        val allEntities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until allEntities.length()) {
+            if (allEntities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_CART) {
+                relevantEntities.add(allEntities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return relevantEntities
+    }
+
+    private fun getCheckoutEntities(request: Request) : ArrayList<JSONObject> {
+        val relevantEntities = ArrayList<JSONObject>()
+        val allEntities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until allEntities.length()) {
+            if (allEntities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_CHECKOUT_STEP) {
+                relevantEntities.add(allEntities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return relevantEntities
+    }
+
+    private fun getPromoEntities(request: Request) : ArrayList<JSONObject> {
+        val relevantEntities = ArrayList<JSONObject>()
+        val allEntities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until allEntities.length()) {
+            if (allEntities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_PROMOTION) {
+                relevantEntities.add(allEntities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return relevantEntities
+    }
+
+    private fun getTransactionEntities(request: Request) : ArrayList<JSONObject> {
+        val relevantEntities = ArrayList<JSONObject>()
+        val allEntities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until allEntities.length()) {
+            if (allEntities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_TRANSACTION) {
+                relevantEntities.add(allEntities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return relevantEntities
+    }
+
+    private fun getTransactionErrorEntities(request: Request) : ArrayList<JSONObject> {
+        val relevantEntities = ArrayList<JSONObject>()
+        val allEntities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until allEntities.length()) {
+            if (allEntities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_TRANSACTION_ERROR) {
+                relevantEntities.add(allEntities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return relevantEntities
+    }
+
+    private fun getRefundEntities(request: Request) : ArrayList<JSONObject> {
+        val relevantEntities = ArrayList<JSONObject>()
+        val allEntities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until allEntities.length()) {
+            if (allEntities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_REFUND) {
+                relevantEntities.add(allEntities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return relevantEntities
+    }
+    
+    private fun getPageEntities(request: Request) : ArrayList<JSONObject> {
+        val pageEntities = ArrayList<JSONObject>()
+        val entities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until entities.length()) {
+            if (entities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_PAGE) {
+                pageEntities.add(entities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return pageEntities
+    }
+
+    private fun getUserEntities(request: Request) : ArrayList<JSONObject> {
+        val userEntities = ArrayList<JSONObject>()
+        val entities = JSONObject(request.payload.map["co"] as String)
+            .getJSONArray("data")
+
+        for (i in 0 until entities.length()) {
+            if (entities.getJSONObject(i).getString("schema") == TrackerConstants.SCHEMA_ECOMMERCE_USER) {
+                userEntities.add(entities.getJSONObject(i).getJSONObject("data"))
+            }
+        }
+        return userEntities
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/Parameters.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/Parameters.kt
@@ -77,6 +77,88 @@ object Parameters {
     const val TI_ITEM_PRICE = "ti_pr"
     const val TI_ITEM_QUANTITY = "ti_qu"
     const val TI_ITEM_CURRENCY = "ti_cu"
+    
+    // Snowplow Ecommerce
+    const val ECOMM_TYPE = "type"
+    const val ECOMM_NAME = "name"
+    
+    // Snowplow Ecommerce Product
+    const val ECOMM_PRODUCT_ID = "id"
+    const val ECOMM_PRODUCT_NAME = "name"
+    const val ECOMM_PRODUCT_CATEGORY = "category"
+    const val ECOMM_PRODUCT_PRICE = "price"
+    const val ECOMM_PRODUCT_LIST_PRICE = "list_price"
+    const val ECOMM_PRODUCT_QUANTITY = "quantity"
+    const val ECOMM_PRODUCT_SIZE = "size"
+    const val ECOMM_PRODUCT_VARIANT = "variant"
+    const val ECOMM_PRODUCT_BRAND = "brand"
+    const val ECOMM_PRODUCT_INVENTORY_STATUS = "inventory_status"
+    const val ECOMM_PRODUCT_POSITION = "position"
+    const val ECOMM_PRODUCT_CURRENCY = "currency"
+    const val ECOMM_PRODUCT_CREATIVE_ID = "creative_id"
+    
+    // Snowplow Ecommerce Cart
+    const val ECOMM_CART_ID = "cart_id"
+    const val ECOMM_CART_VALUE = "total_value"
+    const val ECOMM_CART_CURRENCY = "currency"
+    
+    // Snowplow Ecommerce Transaction
+    const val ECOMM_TRANSACTION_ID = "transaction_id"
+    const val ECOMM_TRANSACTION_REVENUE = "revenue"
+    const val ECOMM_TRANSACTION_CURRENCY = "currency"
+    const val ECOMM_TRANSACTION_PAYMENT_METHOD = "payment_method"
+    const val ECOMM_TRANSACTION_QUANTITY = "total_quantity"
+    const val ECOMM_TRANSACTION_TAX = "tax"
+    const val ECOMM_TRANSACTION_SHIPPING = "shipping"
+    const val ECOMM_TRANSACTION_DISCOUNT_CODE = "discount_code"
+    const val ECOMM_TRANSACTION_DISCOUNT_AMOUNT = "discount_amount"
+    const val ECOMM_TRANSACTION_CREDIT_ORDER = "credit_order"
+
+    // Snowplow Ecommerce Transaction Error
+    const val ECOMM_TRANSACTION_ERROR_CODE = "error_code"
+    const val ECOMM_TRANSACTION_ERROR_SHORTCODE = "error_shortcode"
+    const val ECOMM_TRANSACTION_ERROR_DESCRIPTION = "error_description"
+    const val ECOMM_TRANSACTION_ERROR_TYPE = "error_type"
+    const val ECOMM_TRANSACTION_ERROR_RESOLUTION = "resolution"
+
+    // Snowplow Ecommerce Checkout Step
+    const val ECOMM_CHECKOUT_STEP = "step"
+    const val ECOMM_CHECKOUT_SHIPPING_POSTCODE = "shipping_postcode"
+    const val ECOMM_CHECKOUT_BILLING_POSTCODE = "billing_postcode"
+    const val ECOMM_CHECKOUT_SHIPPING_ADDRESS = "shipping_full_address"
+    const val ECOMM_CHECKOUT_BILLING_ADDRESS = "billing_full_address"
+    const val ECOMM_CHECKOUT_DELIVERY_PROVIDER = "delivery_provider"
+    const val ECOMM_CHECKOUT_DELIVERY_METHOD = "delivery_method"
+    const val ECOMM_CHECKOUT_COUPON_CODE = "coupon_code"
+    const val ECOMM_CHECKOUT_ACCOUNT_TYPE = "account_type"
+    const val ECOMM_CHECKOUT_PAYMENT_METHOD = "payment_method"
+    const val ECOMM_CHECKOUT_PROOF_OF_PAYMENT = "proof_of_payment"
+    const val ECOMM_CHECKOUT_MARKETING_OPT_IN = "marketing_opt_in"
+
+    // Snowplow Ecommerce Promo
+    const val ECOMM_PROMO_ID = "id"
+    const val ECOMM_PROMO_NAME = "name"
+    const val ECOMM_PROMO_PRODUCT_IDS = "product_ids"
+    const val ECOMM_PROMO_POSITION = "position"
+    const val ECOMM_PROMO_CREATIVE_ID = "creative_id"
+    const val ECOMM_PROMO_TYPE = "type"
+    const val ECOMM_PROMO_SLOT = "slot"
+
+    // Snowplow Ecommerce Refund
+    const val ECOMM_REFUND_ID = "transaction_id"
+    const val ECOMM_REFUND_CURRENCY = "currency"
+    const val ECOMM_REFUND_AMOUNT = "refund_amount"
+    const val ECOMM_REFUND_REASON = "refund_reason"
+
+    // Snowplow Ecommerce Screen/Page
+    const val ECOMM_SCREEN_TYPE = "type"
+    const val ECOMM_SCREEN_LANGUAGE = "language"
+    const val ECOMM_SCREEN_LOCALE = "locale"
+
+    // Snowplow Ecommerce User
+    const val ECOMM_USER_ID = "id"
+    const val ECOMM_USER_GUEST = "is_guest"
+    const val ECOMM_USER_EMAIL = "email"
 
     // Screen View
     const val SV_ID = "id"

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/TrackerConstants.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/TrackerConstants.kt
@@ -45,6 +45,26 @@ object TrackerConstants {
     const val SCHEMA_GDPR = "iglu:com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0"
     const val SCHEMA_DIAGNOSTIC_ERROR =
         "iglu:com.snowplowanalytics.snowplow/diagnostic_error/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_ACTION = 
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/snowplow_ecommerce_action/jsonschema/1-0-2"
+    const val SCHEMA_ECOMMERCE_PRODUCT =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/product/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_CART =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/cart/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_TRANSACTION =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/transaction/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_TRANSACTION_ERROR =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/transaction_error/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_CHECKOUT_STEP =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/checkout_step/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_PROMOTION =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/promotion/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_REFUND =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/refund/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_USER =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/user/jsonschema/1-0-0"
+    const val SCHEMA_ECOMMERCE_PAGE =
+        "iglu:com.snowplowanalytics.snowplow.ecommerce/page/jsonschema/1-0-0"
     const val POST_CONTENT_TYPE = "application/json; charset=utf-8"
     const val EVENT_PAGE_VIEW = "pv"
     const val EVENT_STRUCTURED = "se"

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/ecommerce/EcommerceAction.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/ecommerce/EcommerceAction.kt
@@ -10,28 +10,22 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.tracker
-
-import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+package com.snowplowanalytics.core.ecommerce
 
 /**
- * The inspectable properties of a tracked event, used in the GlobalContexts API to generate context entities.
+ * Available types of ecommerce action. Each one is a different event type.
  */
-interface InspectableEvent {
-    /**
-     * The schema of the event
-     */
-    val schema: String?
-    /**
-     * The name of the event
-     */
-    val name: String?
-    /**
-     * The payload of the event
-     */
-    val payload: MutableMap<String, Any>
-    /**
-     * The list of context entities
-     */
-    val entities: MutableList<SelfDescribingJson>
+enum class EcommerceAction {
+    // lowercase to match the schema
+    add_to_cart,
+    remove_from_cart,
+    product_view,
+    list_click,
+    list_view,
+    promo_click,
+    promo_view,
+    checkout_step,
+    transaction,
+    trns_error,
+    refund
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/ecommerce/EcommerceControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/ecommerce/EcommerceControllerImpl.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.core.ecommerce
+
+import androidx.annotation.RestrictTo
+import com.snowplowanalytics.core.tracker.ServiceProviderInterface
+import com.snowplowanalytics.snowplow.configuration.PluginConfiguration
+import com.snowplowanalytics.snowplow.ecommerce.EcommerceController
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceScreenEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceUserEntity
+
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+class EcommerceControllerImpl(val serviceProvider: ServiceProviderInterface) : EcommerceController {
+
+    override fun setEcommerceScreen(screen: EcommerceScreenEntity) {
+        val plugin = PluginConfiguration("ecommercePageTypePluginInternal")
+        plugin.entities { listOf(screen.entity) }
+        serviceProvider.addPlugin(plugin)
+    }
+
+    override fun setEcommerceUser(user: EcommerceUserEntity) {
+        val plugin = PluginConfiguration("ecommerceUserPluginInternal")
+        plugin.entities { listOf(user.entity) }
+        serviceProvider.addPlugin(plugin)
+    }
+
+    override fun removeEcommerceScreen() {
+        serviceProvider.removePlugin("ecommercePageTypePluginInternal")
+    }
+
+    override fun removeEcommerceUser() {
+        serviceProvider.removePlugin("ecommerceUserPluginInternal")
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
@@ -46,12 +46,12 @@ class PlatformContext(
     }
 
     /**
-     * Initializes PlatformContext with default update intervals – 0.1s for updating platform information and 10s for updating network information.
+     * Initializes PlatformContext with default update intervals – 1s for updating platform information and 10s for updating network information.
      *
      * @param context the Android context
      */
     constructor(platformContextProperties: List<PlatformContextProperty>?,
-                context: Context) : this(100, (10 * 1000).toLong(), DeviceInfoMonitor(), platformContextProperties, context)
+                context: Context) : this(1000, (10 * 1000).toLong(), DeviceInfoMonitor(), platformContextProperties, context)
 
     fun getMobileContext(userAnonymisation: Boolean): SelfDescribingJson? {
         updateEphemeralDictsIfNecessary()

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -14,6 +14,7 @@ package com.snowplowanalytics.core.tracker
 
 import android.content.Context
 import androidx.annotation.RestrictTo
+import com.snowplowanalytics.core.ecommerce.EcommerceControllerImpl
 import com.snowplowanalytics.core.emitter.*
 import com.snowplowanalytics.core.gdpr.Gdpr
 import com.snowplowanalytics.core.gdpr.GdprControllerImpl
@@ -47,6 +48,9 @@ class ServiceProvider(
     private var subjectController: SubjectControllerImpl? = null
     private var sessionController: SessionControllerImpl? = null
     private var gdprController: GdprControllerImpl? = null
+    override val ecommerceController: EcommerceControllerImpl by lazy {
+        EcommerceControllerImpl(this)
+    }
     override val pluginsController: PluginsControllerImpl by lazy {
         PluginsControllerImpl(this)
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProviderInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProviderInterface.kt
@@ -12,6 +12,7 @@
  */
 package com.snowplowanalytics.core.tracker
 
+import com.snowplowanalytics.core.ecommerce.EcommerceControllerImpl
 import com.snowplowanalytics.core.emitter.*
 import com.snowplowanalytics.core.gdpr.GdprControllerImpl
 import com.snowplowanalytics.core.globalcontexts.GlobalContextsControllerImpl
@@ -39,6 +40,7 @@ interface ServiceProviderInterface {
     fun getOrMakeSessionController(): SessionControllerImpl
     val pluginsController: PluginsControllerImpl
     val mediaController: MediaController
+    val ecommerceController: EcommerceControllerImpl
 
     // Configuration Updates
     val trackerConfiguration: TrackerConfiguration

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -504,11 +504,12 @@ class Tracker(
         setApplicationInstallEventTimestamp(event)
         addBasicPropertiesToPayload(payload, event)
         addStateMachinePayloadValues(event)
-        event.wrapPropertiesToPayload(payload, base64Encoded=base64Encoded)
 
         // Context entities
         addBasicContexts(event)
         addStateMachineEntities(event)
+        
+        event.wrapPropertiesToPayload(payload, base64Encoded=base64Encoded)
         event.wrapEntitiesToPayload(payload, base64Encoded=base64Encoded)
 
         // Decide whether to track the event or not

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerControllerImpl.kt
@@ -14,6 +14,7 @@ package com.snowplowanalytics.core.tracker
 
 import androidx.annotation.RestrictTo
 import com.snowplowanalytics.core.Controller
+import com.snowplowanalytics.core.ecommerce.EcommerceControllerImpl
 import com.snowplowanalytics.core.session.SessionControllerImpl
 import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration
 import com.snowplowanalytics.snowplow.controller.*
@@ -41,6 +42,9 @@ class TrackerControllerImpl  // Constructors
         get() = serviceProvider.getOrMakeGlobalContextsController()
     val sessionController: SessionControllerImpl
         get() = serviceProvider.getOrMakeSessionController()
+    
+    override val ecommerce: EcommerceControllerImpl
+        get() = serviceProvider.ecommerceController
     override val session: SessionController?
         get() {
             val sessionController = sessionController

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/Snowplow.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/Snowplow.kt
@@ -23,11 +23,8 @@ import com.snowplowanalytics.snowplow.configuration.ConfigurationState
 import com.snowplowanalytics.core.remoteconfiguration.RemoteConfigurationBundle
 import com.snowplowanalytics.core.tracker.ServiceProvider
 import com.snowplowanalytics.core.tracker.TrackerWebViewInterface
+import com.snowplowanalytics.snowplow.configuration.*
 
-import com.snowplowanalytics.snowplow.configuration.Configuration
-import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration
-import com.snowplowanalytics.snowplow.configuration.RemoteConfiguration
-import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration
 import com.snowplowanalytics.snowplow.controller.TrackerController
 import com.snowplowanalytics.snowplow.network.HttpMethod
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/TrackerController.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/TrackerController.kt
@@ -13,6 +13,7 @@
 package com.snowplowanalytics.snowplow.controller
 
 import com.snowplowanalytics.core.tracker.TrackerConfigurationInterface
+import com.snowplowanalytics.snowplow.ecommerce.EcommerceController
 import com.snowplowanalytics.snowplow.event.Event
 import com.snowplowanalytics.snowplow.media.controller.MediaController
 import java.util.*
@@ -84,6 +85,12 @@ interface TrackerController : TrackerConfigurationInterface {
      * Media controller for managing media tracking instances and tracking media events.
      */
     val media: MediaController
+
+    /**
+     * Controller for ecommerce
+     * Note: don't retain the reference. It may change on tracker reconfiguration.
+     */
+    val ecommerce: EcommerceController
     
     // Methods
     

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/EcommerceController.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/EcommerceController.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce
+
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceScreenEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.EcommerceUserEntity
+
+/**
+ * Controller for managing Ecommerce entities.
+ */
+interface EcommerceController {
+
+    /**
+     * Add an ecommerce Screen/Page entity to all subsequent events (not just ecommerce events).
+     * @param screen A EcommerceScreenEntity.
+     */
+    fun setEcommerceScreen(screen: EcommerceScreenEntity)
+
+    /**
+     * Add an ecommerce User entity to all subsequent events (not just ecommerce events).
+     * @param user A EcommerceUserEntity.
+     */
+    fun setEcommerceUser(user: EcommerceUserEntity)
+
+    /**
+     * Stop adding a Screen/Page entity to events.
+     */
+    fun removeEcommerceScreen()
+
+    /**
+     * Stop adding a User entity to events.
+     */
+    fun removeEcommerceUser()
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/ErrorType.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/ErrorType.kt
@@ -10,28 +10,20 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.snowplow.tracker
 
-import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+package com.snowplowanalytics.snowplow.ecommerce
 
-/**
- * The inspectable properties of a tracked event, used in the GlobalContexts API to generate context entities.
- */
-interface InspectableEvent {
-    /**
-     * The schema of the event
-     */
-    val schema: String?
-    /**
-     * The name of the event
-     */
-    val name: String?
-    /**
-     * The payload of the event
-     */
-    val payload: MutableMap<String, Any>
-    /**
-     * The list of context entities
-     */
-    val entities: MutableList<SelfDescribingJson>
+/** Type of transaction error. */
+enum class ErrorType {
+    /// The customer must provide another form of payment e.g. the card has expired.
+    Hard,
+    /// Temporary issues where retrying might be successful e.g. processor declined the transaction.
+    Soft;
+
+    override fun toString(): String {
+        return when (this) {
+            Hard -> "hard"
+            Soft -> "soft"
+        }
+    }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/CartEntity.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/CartEntity.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.entities
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Provided to certain Ecommerce events. The Cart properties will be sent with the event as a 
+ * Cart entity.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/cart/jsonschema/1-0-0
+ */
+data class CartEntity @JvmOverloads constructor(
+    /**
+     * The total value of the cart after this interaction.
+     */
+    var totalValue: Number,
+
+    /**
+     * The currency used for this cart (ISO 4217).
+     */
+    var currency: String,
+
+    /**
+     * The unique ID representing this cart.
+     */
+    var cartId: String? = null
+) {
+    internal val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_CART,
+            mapOf<String, Any?>(
+                Parameters.ECOMM_CART_ID to cartId,
+                Parameters.ECOMM_CART_VALUE to totalValue,
+                Parameters.ECOMM_CART_CURRENCY to currency,
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/EcommerceScreenEntity.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/EcommerceScreenEntity.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.entities
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Add ecommerce Screen/Page details. It is designed to help with grouping insights by 
+ * screen/page type, e.g. Product description, Product list, Home.
+ */
+data class EcommerceScreenEntity @JvmOverloads constructor(
+    /**
+     * The type of screen that was visited, e.g. homepage, product details, cart, checkout, etc.
+     * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/page/jsonschema/1-0-0
+     */
+    var type: String,
+
+    /**
+     * The language that the screen is based in.
+     */
+    var language: String? = null,
+
+    /**
+     * The locale version of the app that is running.
+     */
+    var locale: String? = null,
+
+) {
+    internal val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_PAGE,
+            mapOf<String, Any?>(
+                Parameters.ECOMM_SCREEN_TYPE to type,
+                Parameters.ECOMM_SCREEN_LANGUAGE to language,
+                Parameters.ECOMM_SCREEN_LOCALE to locale
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/EcommerceUserEntity.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/EcommerceUserEntity.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.entities
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Add ecommerce User details. It is designed to help in modeling guest/non-guest account activity.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/user/jsonschema/1-0-0
+ */
+data class EcommerceUserEntity @JvmOverloads constructor(
+    /**
+     * The user ID.
+     */
+    var id: String,
+
+    /**
+     * Whether or not the user is a guest.
+     */
+    var isGuest: Boolean? = null,
+
+    /**
+     * The user's email address.
+     */
+    var email: String? = null,
+
+) {
+    internal val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_USER,
+            mapOf<String, Any?>(
+                Parameters.ECOMM_USER_ID to id,
+                Parameters.ECOMM_USER_GUEST to isGuest,
+                Parameters.ECOMM_USER_EMAIL to email
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/ProductEntity.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/ProductEntity.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.entities
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Provided to certain Ecommerce events. The Product properties will be sent with the event as a 
+ * Product entity.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/product/jsonschema/1-0-0
+ */
+data class ProductEntity @JvmOverloads constructor(
+    /**
+     * The SKU or product ID.
+     */
+    var id: String,
+
+    /**
+     * The category the product belongs to.
+     * Use a consistent separator to express multiple levels. E.g. Woman/Shoes/Sneakers.
+     */
+    var category: String,
+
+    /**
+     * The currency in which the product is being priced (ISO 4217).
+     */
+    var currency: String,
+
+    /**
+     * The price of the product at the current time.
+     */
+    var price: Number,
+
+    /**
+     * The recommended or list price of a product.
+     */
+    var listPrice: Number? = null,
+
+    /**
+     * The name or title of the product.
+     */
+    var name: String? = null,
+
+    /**
+     * The quantity of the product taking part in the action. Used for Cart events.
+     */
+    var quantity: Int? = null,
+
+    /**
+     * The size of the product.
+     */
+    var size: String? = null,
+
+    /**
+     * The variant of the product.
+     */
+    var variant: String? = null,
+
+    /**
+     * The brand of the product.
+     */
+    var brand: String? = null,
+
+    /**
+     * The inventory status of the product (e.g. in stock, out of stock, preorder, backorder, etc).
+     */
+    var inventoryStatus: String? = null,
+
+    /**
+     * The position the product was presented in a list of products (search results, product list page, etc).
+     */
+    var position: Int? = null,
+
+    /**
+     * Identifier, name, or url for the creative presented on the associated promotion.
+     */
+    var creativeId: String? = null
+) {
+    internal val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_PRODUCT,
+            mapOf<String, Any?>(
+                Parameters.ECOMM_PRODUCT_ID to id,
+                Parameters.ECOMM_PRODUCT_NAME to name,
+                Parameters.ECOMM_PRODUCT_CATEGORY to category,
+                Parameters.ECOMM_PRODUCT_PRICE to price,
+                Parameters.ECOMM_PRODUCT_LIST_PRICE to listPrice,
+                Parameters.ECOMM_PRODUCT_QUANTITY to quantity,
+                Parameters.ECOMM_PRODUCT_SIZE to size,
+                Parameters.ECOMM_PRODUCT_VARIANT to variant,
+                Parameters.ECOMM_PRODUCT_BRAND to brand,
+                Parameters.ECOMM_PRODUCT_INVENTORY_STATUS to inventoryStatus,
+                Parameters.ECOMM_PRODUCT_POSITION to position,
+                Parameters.ECOMM_PRODUCT_CURRENCY to currency,
+                Parameters.ECOMM_PRODUCT_CREATIVE_ID to creativeId
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/PromotionEntity.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/PromotionEntity.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.entities
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Provided to certain Ecommerce events. The Promotion properties will be sent with the event as a
+ * Promotion entity.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/promotion/jsonschema/1-0-0
+ */
+data class PromotionEntity @JvmOverloads constructor(
+    /**
+     * The ID of the promotion.
+     */
+    var id: String,
+    
+    /**
+     * The name of the promotion.
+     */
+    var name: String? = null,
+    
+    /**
+     * List of SKUs or product IDs showcased in the promotion.
+     */
+    var productIds: List<String>? = null,
+    
+    /**
+     * The position the promotion was presented in a list of promotions such as a banner or slider, e.g. 2.
+     */
+    var position: Int? = null,
+    
+    /**
+     * Identifier, name, or url for the creative presented on the promotion.
+     */
+    var creativeId: String? = null,
+    
+    /**
+     * Type of the promotion delivery mechanism. E.g. popup, banner, intra-content.
+     */
+    var type: String? = null,
+    
+    /**
+     * The UI slot in which the promotional content was added to.
+     */
+    var slot: String? = null
+) {
+    internal val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_PROMOTION,
+            mapOf(
+                Parameters.ECOMM_PROMO_ID to id,
+                Parameters.ECOMM_PROMO_NAME to name,
+                Parameters.ECOMM_PROMO_PRODUCT_IDS to productIds,
+                Parameters.ECOMM_PROMO_POSITION to position,
+                Parameters.ECOMM_PROMO_CREATIVE_ID to creativeId,
+                Parameters.ECOMM_PROMO_TYPE to type,
+                Parameters.ECOMM_PROMO_SLOT to slot
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/TransactionEntity.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/entities/TransactionEntity.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.entities
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Provided to certain Ecommerce events. The Transaction properties will be sent with the event as a
+ * Transaction entity.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/transaction/jsonschema/1-0-0
+ */
+data class TransactionEntity @JvmOverloads constructor(
+    /**
+     * The ID of the transaction.
+     */
+    var transactionId: String,
+
+    /**
+     * The total value of the transaction.
+     */
+    var revenue: Number,
+
+    /**
+     * The currency used for the transaction (ISO 4217).
+     */
+    var currency: String,
+
+    /**
+     * The payment method used for the transaction.
+     */
+    var paymentMethod: String,
+
+    /**
+     * Total quantity of items in the transaction.
+     */
+    var totalQuantity: Int,
+
+    /**
+     * Total amount of tax on the transaction.
+     */
+    var tax: Number? = null,
+
+    /**
+     * Total cost of shipping on the transaction.
+     */
+    var shipping: Number? = null,
+
+    /**
+     * Discount code used.
+     */
+    var discountCode: String? = null,
+
+    /**
+     * Discount amount taken off.
+     */
+    var discountAmount: Number? = null,
+
+    /**
+     * Whether the transaction is a credit order or not.
+     */
+    var creditOrder: Boolean? = null
+) {
+    internal val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_TRANSACTION,
+            mapOf<String, Any?>(
+                Parameters.ECOMM_TRANSACTION_ID to transactionId,
+                Parameters.ECOMM_TRANSACTION_REVENUE to revenue,
+                Parameters.ECOMM_TRANSACTION_CURRENCY to currency,
+                Parameters.ECOMM_TRANSACTION_PAYMENT_METHOD to paymentMethod,
+                Parameters.ECOMM_TRANSACTION_QUANTITY to totalQuantity,
+                Parameters.ECOMM_TRANSACTION_TAX to tax,
+                Parameters.ECOMM_TRANSACTION_SHIPPING to shipping,
+                Parameters.ECOMM_TRANSACTION_DISCOUNT_CODE to discountCode,
+                Parameters.ECOMM_TRANSACTION_DISCOUNT_AMOUNT to discountAmount,
+                Parameters.ECOMM_TRANSACTION_CREDIT_ORDER to creditOrder
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/AddToCartEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/AddToCartEvent.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.CartEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a product or products being added to cart.
+ *
+ * @param products - List of product(s) that were added to the cart.
+ * @param cart - State of the cart after this addition.
+ */
+class AddToCartEvent(
+    /**
+     * List of product(s) that were added to the cart.
+     */
+    var products: List<ProductEntity>,
+
+    /**
+     * State of the cart after the addition.
+     */
+    var cart: CartEntity
+    ) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload[Parameters.ECOMM_TYPE] = EcommerceAction.add_to_cart.toString()
+            return payload
+        }
+    
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() {
+            val entities = mutableListOf<SelfDescribingJson>()
+            for (product in products) {
+                entities.add(product.entity)
+            }
+            entities.add(cart.entity)
+            return entities
+        }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/CheckoutStepEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/CheckoutStepEvent.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a checkout step.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/checkout_step/jsonschema/1-0-0
+ *
+ * @param step Checkout step index.
+ * @param shippingPostcode Shipping address postcode.
+ * @param billingPostcode Billing address postcode.
+ * @param shippingFullAddress Full shipping address.
+ * @param billingFullAddress Full billing address.
+ * @param deliveryProvider Can be used to discern delivery providers e.g. DHL, PostNL etc.
+ * @param deliveryMethod Store pickup, standard delivery, express delivery, international, etc.
+ * @param couponCode Coupon applied at checkout.
+ * @param accountType Type of account used on checkout, e.g. existing user, guest.
+ * @param paymentMethod Any kind of payment method the user selected to proceed. Card, PayPal, Alipay etc.
+ * @param proofOfPayment E.g. invoice or receipt.
+ * @param marketingOptIn If opted in to marketing campaigns to the email address.
+ */
+class CheckoutStepEvent @JvmOverloads constructor(
+    /** Checkout step index. */
+    var step: Int,
+    
+    /** Shipping address postcode. */
+    var shippingPostcode: String? = null,
+    
+    /** Billing address postcode. */
+    var billingPostcode: String? = null,
+    
+    /** Full shipping address. */
+    var shippingFullAddress: String? = null,
+    
+    /** Full billing address. */
+    var billingFullAddress: String? = null,
+    
+    /** Can be used to discern delivery providers DHL, PostNL etc. */
+    var deliveryProvider: String? = null,
+    
+    /** E.g. store pickup, standard delivery, express delivery, international. */
+    var deliveryMethod: String? = null,
+    
+    /** Coupon applied at checkout. */
+    var couponCode: String? = null,
+    
+    /** Type of account used on checkout, e.g. existing user, guest. */
+    var accountType: String? = null,
+    
+    /** Any kind of payment method the user selected to proceed. Card, PayPal, Alipay etc. */
+    var paymentMethod: String? = null,
+    
+    /** E.g. invoice or receipt */
+    var proofOfPayment: String? = null,
+    
+    /** If opted in to marketing campaigns to the email address. */
+    var marketingOptIn: Boolean? = null
+) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload["type"] = EcommerceAction.checkout_step.toString()
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() = listOf(entity)
+    
+    private val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_CHECKOUT_STEP,
+            mapOf(
+                Parameters.ECOMM_CHECKOUT_STEP to step,
+                Parameters.ECOMM_CHECKOUT_SHIPPING_POSTCODE to shippingPostcode,
+                Parameters.ECOMM_CHECKOUT_BILLING_POSTCODE to billingPostcode,
+                Parameters.ECOMM_CHECKOUT_SHIPPING_ADDRESS to shippingFullAddress,
+                Parameters.ECOMM_CHECKOUT_BILLING_ADDRESS to billingFullAddress,
+                Parameters.ECOMM_CHECKOUT_DELIVERY_PROVIDER to deliveryProvider,
+                Parameters.ECOMM_CHECKOUT_DELIVERY_METHOD to deliveryMethod,
+                Parameters.ECOMM_CHECKOUT_COUPON_CODE to couponCode,
+                Parameters.ECOMM_CHECKOUT_ACCOUNT_TYPE to accountType,
+                Parameters.ECOMM_CHECKOUT_PAYMENT_METHOD to paymentMethod,
+                Parameters.ECOMM_CHECKOUT_PROOF_OF_PAYMENT to proofOfPayment,
+                Parameters.ECOMM_CHECKOUT_MARKETING_OPT_IN to marketingOptIn
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/ProductListClickEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/ProductListClickEvent.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a product list click or selection event.
+ *
+ * @param product - Information about the product that was selected.
+ * @param name - The list name.
+ */
+class ProductListClickEvent @JvmOverloads constructor(var product: ProductEntity, var name: String? = null) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload["type"] = EcommerceAction.list_click.toString()
+            name?.let { payload["name"] = it }
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() = listOf(product.entity)
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/ProductListViewEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/ProductListViewEvent.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a product list view.
+ *
+ * @param products - List of products viewed.
+ * @param name - The list name.
+ */
+class ProductListViewEvent @JvmOverloads constructor(var products: List<ProductEntity>, var name: String? = null) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload["type"] = EcommerceAction.list_view.toString()
+            name?.let { payload["name"] = it }
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() {
+            val entities = mutableListOf<SelfDescribingJson>()
+            for (product in products) {
+                entities.add(product.entity)
+            }
+            return entities
+        }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/ProductViewEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/ProductViewEvent.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a product view/detail.
+ *
+ * @param product - The product that was viewed in a product detail page.
+ */
+class ProductViewEvent(var product: ProductEntity) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload[Parameters.ECOMM_TYPE] = EcommerceAction.product_view.toString()
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() = listOf(product.entity)
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/PromotionClickEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/PromotionClickEvent.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.PromotionEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a promotion click or selection.
+ *
+ * @param promotion - The promotion selected.
+ */
+class PromotionClickEvent(var promotion: PromotionEntity) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload["type"] = EcommerceAction.promo_click.toString()
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() = listOf(promotion.entity)
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/PromotionViewEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/PromotionViewEvent.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.PromotionEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a promotion view.
+ *
+ * @param promotion - The promotion viewed.
+ */
+class PromotionViewEvent(var promotion: PromotionEntity) : AbstractSelfDescribing() {
+
+    /** The event schema. */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload["type"] = EcommerceAction.promo_view.toString()
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() = listOf(promotion.entity)
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/RefundEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/RefundEvent.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a refund event. Use the same transaction ID as for the original Transaction event.
+ * Provide a list of products to specify certain products to be refunded, otherwise the whole transaction 
+ * will be marked as refunded.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/refund/jsonschema/1-0-0
+ *
+ * @param transactionId The ID of the relevant transaction.
+ * @param currency The currency in which the product(s) are being priced (ISO 4217).
+ * @param refundAmount The monetary amount refunded.
+ * @param refundReason Reason for refunding the whole or part of the transaction.
+ * @param products The products to be refunded.
+ */
+class RefundEvent @JvmOverloads constructor(
+    /** The ID of the relevant transaction. */
+    var transactionId: String,
+    
+    /** The monetary amount refunded. */
+    var refundAmount: Number,
+
+    /** The currency in which the product is being priced (ISO 4217). */
+    var currency: String,
+    
+    /** Reason for refunding the whole or part of the transaction. */
+    var refundReason: String? = null, 
+    
+    /** The products to be refunded. */
+    var products: List<ProductEntity>? = null
+) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload["type"] = EcommerceAction.refund.toString()
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() {
+            val entities = mutableListOf<SelfDescribingJson>()
+            products?.let {
+                for (product in it) {
+                    entities.add(product.entity)
+                }
+            }
+            entities.add(entity)
+            return entities
+        }
+
+    private val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_REFUND,
+            mapOf<String, Any?>(
+                Parameters.ECOMM_REFUND_ID to transactionId,
+                Parameters.ECOMM_REFUND_CURRENCY to currency,
+                Parameters.ECOMM_REFUND_AMOUNT to refundAmount,
+                Parameters.ECOMM_REFUND_REASON to refundReason
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/RemoveFromCartEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/RemoveFromCartEvent.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.CartEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a product or products being removed from cart.
+ *
+ * @param products - List of product(s) that were removed from the cart.
+ * @param cart - State of the cart after this addition.
+ */
+class RemoveFromCartEvent @JvmOverloads constructor(
+    /**
+     * List of product(s) that were removed from the cart.
+     */
+    var products: List<ProductEntity>,
+
+    /**
+     * State of the cart after the removal.
+     */
+    var cart: CartEntity
+) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload[Parameters.ECOMM_TYPE] = EcommerceAction.remove_from_cart.toString()
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() {
+            val entities = mutableListOf<SelfDescribingJson>()
+            for (product in products) {
+                entities.add(product.entity)
+            }
+            entities.add(cart.entity)
+            return entities
+        }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/TransactionErrorEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/TransactionErrorEvent.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.ErrorType
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.TransactionEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a transaction error event.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/transaction_error/jsonschema/1-0-0
+ *
+ * @param transaction The TransactionEntity details.
+ * @param errorCode Error-identifying code for the transaction issue, e.g. E522.
+ * @param errorShortcode Shortcode for the error that occurred in the transaction.
+ * @param errorDescription Longer description for the error that occurred in the transaction.
+ * @param errorType Type of error.
+ * @param resolution The resolution selected for the error scenario.
+ */
+class TransactionErrorEvent @JvmOverloads constructor(
+    /**
+    * The transaction details.
+    */
+    var transaction: TransactionEntity,
+
+    /**
+    * Error-identifying code for the transaction issue, e.g. E522.
+    */
+    var errorCode: String? = null,
+
+    /**
+    * Shortcode for the error that occurred in the transaction e.g. declined_by_stock_api, declined_by_payment_method, card_declined, pm_card_radarBlock.
+    */
+    var errorShortcode: String? = null,
+
+    /**
+    * Longer description for the error that occurred in the transaction.
+    */
+    var errorDescription: String? = null,
+
+    /**
+    * Type of error. Hard error types mean the customer must provide another form of payment e.g. an expired card.
+    * Soft errors can be the result of temporary issues where retrying might be successful e.g. processor declined the transaction.
+    */
+    var errorType: ErrorType? = null,
+
+    /**
+    * The resolution selected for the error scenario e.g. retry_allowed, user_blacklisted, block_gateway, contact_user, default.
+    */
+    var resolution: String? = null
+) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload["type"] = EcommerceAction.trns_error.toString()
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() {
+            val entities = mutableListOf<SelfDescribingJson>()
+            entities.add(entity)
+            entities.add(transaction.entity)
+            return entities
+        }
+
+    private val entity: SelfDescribingJson
+        get() = SelfDescribingJson(
+            TrackerConstants.SCHEMA_ECOMMERCE_TRANSACTION_ERROR,
+            mapOf(
+                Parameters.ECOMM_TRANSACTION_ERROR_CODE to errorCode,
+                Parameters.ECOMM_TRANSACTION_ERROR_SHORTCODE to errorShortcode,
+                Parameters.ECOMM_TRANSACTION_ERROR_DESCRIPTION to errorDescription,
+                Parameters.ECOMM_TRANSACTION_ERROR_TYPE to errorType.toString(),
+                Parameters.ECOMM_TRANSACTION_ERROR_RESOLUTION to resolution
+            ).filter { it.value != null }
+        )
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/TransactionEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/ecommerce/events/TransactionEvent.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.ecommerce.events
+
+import com.snowplowanalytics.core.constants.Parameters
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.ecommerce.EcommerceAction
+import com.snowplowanalytics.snowplow.ecommerce.entities.ProductEntity
+import com.snowplowanalytics.snowplow.ecommerce.entities.TransactionEntity
+import com.snowplowanalytics.snowplow.event.AbstractSelfDescribing
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+
+/**
+ * Track a transaction event.
+ * Entity schema: iglu:com.snowplowanalytics.snowplow.ecommerce/transaction/jsonschema/1-0-0
+ *
+ * @param transaction The TransactionEntity details.
+ * @param products The product(s) included in the transaction.
+ */
+class TransactionEvent @JvmOverloads constructor(
+    /**
+    * The transaction details.
+    */
+    var transaction: TransactionEntity,
+    
+    /**
+    * Products in the transaction.
+    */
+    var products: List<ProductEntity>? = null
+) : AbstractSelfDescribing() {
+
+    /** The event schema */
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_ECOMMERCE_ACTION
+    
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            payload["type"] = EcommerceAction.transaction.toString()
+            return payload
+        }
+
+    override val entitiesForProcessing: List<SelfDescribingJson>?
+        get() {
+            val entities = mutableListOf<SelfDescribingJson>()
+            products?.let { 
+                for (product in it) {
+                    entities.add(product.entity)
+                }
+            }
+            entities.add(transaction.entity)
+            return entities
+        }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/AbstractEvent.kt
@@ -32,6 +32,10 @@ abstract class AbstractEvent : Event {
      */
     override var trueTimestamp: Long? = null
     
+    /** Used for events whose properties are added as entities, e.g. Ecommerce events */
+    open val entitiesForProcessing: List<SelfDescribingJson>?
+        get() = null
+    
     // Builder methods
 
     /** Adds a list of context entities to the existing ones. */
@@ -58,12 +62,24 @@ abstract class AbstractEvent : Event {
      * @return the event custom context entities
      */
     override val entities: MutableList<SelfDescribingJson>
-        get() = customContexts
+        get() {
+            if (isProcessing) {
+                entitiesForProcessing?.let {
+                    return (customContexts + it).toMutableList()
+                }
+            }
+            return customContexts
+        }
 
     @Deprecated("Old nomenclature", ReplaceWith("entities"))
     override val contexts: List<SelfDescribingJson>
         get() = entities
 
-    override fun beginProcessing(tracker: Tracker) {}
-    override fun endProcessing(tracker: Tracker) {}
+    private var isProcessing = false
+    override fun beginProcessing(tracker: Tracker) {
+        isProcessing = true
+    }
+    override fun endProcessing(tracker: Tracker) {
+        isProcessing = false
+    }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/EcommerceTransaction.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/EcommerceTransaction.kt
@@ -20,7 +20,9 @@ import com.snowplowanalytics.core.tracker.Tracker
  * @param orderId Identifier of the order.
  * @param totalValue Total amount of the order.
  * @param items Items purchased.
+ * @Deprecated Use the ecommerce package instead
  */
+@Deprecated("Use the ecommerce package instead")
 class EcommerceTransaction(
     orderId: String,
     totalValue: Double,

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/EcommerceTransactionItem.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/EcommerceTransactionItem.kt
@@ -19,7 +19,9 @@ import com.snowplowanalytics.core.constants.TrackerConstants
  * @param sku Stock Keeping Unit of the item.
  * @param price Price of the item.
  * @param quantity Quantity of the item.
+ * @Deprecated Use the ecommerce package instead
  */
+@Deprecated("Use the ecommerce package instead")
 class EcommerceTransactionItem(sku: String, price: Double, quantity: Int) : AbstractPrimitive() {
     /** Stock Keeping Unit of the item.  */
     val sku: String


### PR DESCRIPTION
This release brings Snowplow ecommerce tracking to our Android and iOS trackers. We've added 11 new event types to make tracking and modeling ecommerce user behaviour easier. It's the same API as for the Snowplow ecommerce plugin in the JavaScript tracker, and the mobile data is already supported by the ecommerce data model. Check out the documentation to find out how to enable this, and stay tuned for the mobile version of the Ecommerce Accelerator.

This release also updates the interval for refreshing properties in the platform context entity from 0.1s to 1s in order to reduce CPU usage.

### Changelog

**Enhancements**
* Add Snowplow ecommerce events and entities (#611)
* Increase interval for updating platform context properties from 0.1s to 1s (#624)