### PR TITLE
Revise the emitter behaviour

### DIFF
--- a/snowplow-demo-java/src/main/java/com/snowplowanalytics/snowplowtrackerdemojava/Demo.java
+++ b/snowplow-demo-java/src/main/java/com/snowplowanalytics/snowplowtrackerdemojava/Demo.java
@@ -296,7 +296,6 @@ public class Demo extends Activity implements LoggerDelegate {
         EmitterConfiguration emitterConfiguration = new EmitterConfiguration()
                 .requestCallback(getRequestCallback())
                 .threadPoolSize(20)
-                .emitRange(500)
                 .byteLimitPost(52000);
         TrackerConfiguration trackerConfiguration = new TrackerConfiguration(appId)
                 .logLevel(LogLevel.VERBOSE)

--- a/snowplow-demo-java/src/main/java/com/snowplowanalytics/snowplowtrackerdemojava/Demo.java
+++ b/snowplow-demo-java/src/main/java/com/snowplowanalytics/snowplowtrackerdemojava/Demo.java
@@ -295,7 +295,6 @@ public class Demo extends Activity implements LoggerDelegate {
         NetworkConfiguration networkConfiguration = new NetworkConfiguration(uri, method);
         EmitterConfiguration emitterConfiguration = new EmitterConfiguration()
                 .requestCallback(getRequestCallback())
-                .bufferOption(BufferOption.DefaultGroup)
                 .threadPoolSize(20)
                 .emitRange(500)
                 .byteLimitPost(52000);

--- a/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/Demo.kt
+++ b/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/Demo.kt
@@ -260,7 +260,7 @@ class Demo : Activity(), LoggerDelegate {
         val networkConfiguration = NetworkConfiguration(uri, method)
         val emitterConfiguration = EmitterConfiguration()
             .requestCallback(requestCallback)
-            .bufferOption(BufferOption.DefaultGroup)
+            .bufferOption(BufferOption.SmallGroup)
             .threadPoolSize(20)
             .emitRange(500)
             .byteLimitPost(52000)

--- a/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/Demo.kt
+++ b/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/Demo.kt
@@ -262,7 +262,6 @@ class Demo : Activity(), LoggerDelegate {
             .requestCallback(requestCallback)
             .bufferOption(BufferOption.SmallGroup)
             .threadPoolSize(20)
-            .emitRange(500)
             .byteLimitPost(52000)
         val trackerConfiguration = TrackerConfiguration(appId)
             .logLevel(LogLevel.VERBOSE)

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.kt
@@ -45,12 +45,12 @@ class EmitterTest {
         var builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
         var emitter = Emitter(context, "com.acme", builder)
         Assert.assertEquals(BufferOption.Single, emitter.bufferOption)
-        builder = { emitter1: Emitter -> emitter1.bufferOption = BufferOption.DefaultGroup }
+        builder = { emitter1: Emitter -> emitter1.bufferOption = BufferOption.SmallGroup }
         emitter = Emitter(context, "com.acme", builder)
-        Assert.assertEquals(BufferOption.DefaultGroup, emitter.bufferOption)
-        builder = { emitter2: Emitter -> emitter2.bufferOption = BufferOption.HeavyGroup }
+        Assert.assertEquals(BufferOption.SmallGroup, emitter.bufferOption)
+        builder = { emitter2: Emitter -> emitter2.bufferOption = BufferOption.LargeGroup }
         emitter = Emitter(context, "com.acme", builder)
-        Assert.assertEquals(BufferOption.HeavyGroup, emitter.bufferOption)
+        Assert.assertEquals(BufferOption.LargeGroup, emitter.bufferOption)
     }
 
     @Test
@@ -76,7 +76,7 @@ class EmitterTest {
         var emitter = Emitter(context, uri, builder)
         Assert.assertEquals("http://$uri/i", emitter.emitterUri)
         builder = { emitter1: Emitter ->
-            emitter1.bufferOption = BufferOption.DefaultGroup
+            emitter1.bufferOption = BufferOption.SmallGroup
             emitter1.httpMethod = HttpMethod.POST
             emitter1.requestSecurity = Protocol.HTTP
         }
@@ -86,14 +86,14 @@ class EmitterTest {
             emitter.emitterUri
         )
         builder = { emitter2: Emitter ->
-            emitter2.bufferOption = BufferOption.DefaultGroup
+            emitter2.bufferOption = BufferOption.SmallGroup
             emitter2.httpMethod = HttpMethod.GET
             emitter2.requestSecurity = Protocol.HTTPS
         }
         emitter = Emitter(context, uri, builder)
         Assert.assertEquals("https://$uri/i", emitter.emitterUri)
         builder = { emitter3: Emitter ->
-            emitter3.bufferOption = BufferOption.DefaultGroup
+            emitter3.bufferOption = BufferOption.SmallGroup
             emitter3.httpMethod = HttpMethod.POST
             emitter3.requestSecurity = Protocol.HTTPS
         }
@@ -173,8 +173,8 @@ class EmitterTest {
         Assert.assertEquals("https://$uri/i", emitter.emitterUri)
         emitter.emitterUri = "com.acme"
         Assert.assertEquals("https://com.acme/i", emitter.emitterUri)
-        emitter.bufferOption = BufferOption.HeavyGroup
-        Assert.assertEquals(BufferOption.HeavyGroup, emitter.bufferOption)
+        emitter.bufferOption = BufferOption.LargeGroup
+        Assert.assertEquals(BufferOption.LargeGroup, emitter.bufferOption)
         emitter.flush()
         emitter.flush()
         Thread.sleep(500)
@@ -189,8 +189,8 @@ class EmitterTest {
             "https://com.foo/com.snowplowanalytics.snowplow/tp2",
             emitter.emitterUri
         )
-        emitter.bufferOption = BufferOption.DefaultGroup
-        Assert.assertEquals(BufferOption.HeavyGroup, emitter.bufferOption)
+        emitter.bufferOption = BufferOption.SmallGroup
+        Assert.assertEquals(BufferOption.LargeGroup, emitter.bufferOption)
         emitter.shutdown()
         builder = { emitter1: Emitter ->
             emitter1.bufferOption = BufferOption.Single

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockNetworkConnection.kt
@@ -59,4 +59,9 @@ class MockNetworkConnection(override var httpMethod: HttpMethod, var statusCode:
     fun countRequests(): Int {
         return allRequests.size
     }
+
+    fun clear() {
+        previousRequests.clear()
+        previousResults.clear()
+    }
 }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
@@ -202,6 +202,7 @@ class EventSendingTest {
             emitter.requestSecurity = Protocol.HTTP
             emitter.emitterTick = 0
             emitter.emptyLimit = 0
+            emitter.emitRange = 1
         }
         val emitter = Emitter(InstrumentationRegistry.getInstrumentation().targetContext, uri, builder)
         val subject = Subject(InstrumentationRegistry.getInstrumentation().targetContext, null)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
@@ -422,13 +422,15 @@ class Emitter(context: Context, collectorUri: String, builder: ((Emitter) -> Uni
      */
     fun add(payload: Payload) {
         Executor.execute(TAG) {
-            eventStore?.add(payload)
-            if (isRunning.compareAndSet(false, true)) {
-                try {
-                    attemptEmit(networkConnection)
-                } catch (t: Throwable) {
-                    isRunning.set(false)
-                    Logger.e(TAG, "Received error during emission process: %s", t)
+            eventStore?.let { eventStore ->
+                eventStore.add(payload)
+                if (eventStore.size() >= bufferOption.code && isRunning.compareAndSet(false, true)) {
+                    try {
+                        attemptEmit(networkConnection)
+                    } catch (t: Throwable) {
+                        isRunning.set(false)
+                        Logger.e(TAG, "Received error during emission process: %s", t)
+                    }
                 }
             }
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterControllerImpl.kt
@@ -40,10 +40,10 @@ class EmitterControllerImpl(serviceProvider: ServiceProviderInterface) :
         }
 
     override var emitRange: Int
-        get() = emitter.sendLimit
+        get() = emitter.emitRange
         set(emitRange) {
             dirtyConfig.emitRange = emitRange
-            emitter.sendLimit = emitRange
+            emitter.emitRange = emitRange
         }
 
     override val threadPoolSize: Int

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterDefaults.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterDefaults.kt
@@ -24,9 +24,8 @@ object EmitterDefaults {
     var bufferOption = BufferOption.Single
     var httpProtocol = Protocol.HTTPS
     var tlsVersions: EnumSet<TLSVersion> = EnumSet.of(TLSVersion.TLSv1_2)
-    var emitRange: Int = 150
+    var emitRange: Int = BufferOption.LargeGroup.code
     var emitterTick = 5
-    var sendLimit = 250
     var emptyLimit = 5
     var byteLimitGet: Long = 40000
     var byteLimitPost: Long = 40000

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterDefaults.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterDefaults.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 object EmitterDefaults {
     var httpMethod = HttpMethod.POST
-    var bufferOption = BufferOption.DefaultGroup
+    var bufferOption = BufferOption.Single
     var httpProtocol = Protocol.HTTPS
     var tlsVersions: EnumSet<TLSVersion> = EnumSet.of(TLSVersion.TLSv1_2)
     var emitRange: Int = 150

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -234,7 +234,7 @@ class ServiceProvider(
             emitter.client = networkConfiguration.okHttpClient
             emitter.cookieJar = networkConfiguration.okHttpCookieJar
             emitter.emitTimeout = networkConfiguration.timeout
-            emitter.sendLimit = emitterConfiguration.emitRange
+            emitter.emitRange = emitterConfiguration.emitRange
             emitter.bufferOption = emitterConfiguration.bufferOption
             emitter.eventStore = emitterConfiguration.eventStore
             emitter.byteLimitPost = emitterConfiguration.byteLimitPost

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.kt
@@ -25,7 +25,7 @@ import org.json.JSONObject
  * Default values:
  *   - bufferOption: [BufferOption.Single]
  *   - serverAnonymisation: false
- *   - emitRange: 150 - maximum number of events to process at a time
+ *   - emitRange: 25 - maximum number of events to process at a time
  *   - threadPoolSize: 15
  *   - byteLimitGet: 40000 bytes
  *   - byteLimitPost: 40000 bytes

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/EmitterConfiguration.kt
@@ -23,7 +23,7 @@ import org.json.JSONObject
  * Configure how the tracker should send the events to the collector.     
  * 
  * Default values:
- *   - bufferOption: [BufferOption.DefaultGroup]
+ *   - bufferOption: [BufferOption.Single]
  *   - serverAnonymisation: false
  *   - emitRange: 150 - maximum number of events to process at a time
  *   - threadPoolSize: 15
@@ -45,7 +45,7 @@ open class EmitterConfiguration() : Configuration, EmitterConfigurationInterface
 
     private var _bufferOption: BufferOption? = null
     override var bufferOption: BufferOption
-        get() = _bufferOption ?: sourceConfig?.bufferOption ?: BufferOption.DefaultGroup
+        get() = _bufferOption ?: sourceConfig?.bufferOption ?: EmitterDefaults.bufferOption
         set(value) { _bufferOption = value }
 
     private var _emitRange: Int? = null
@@ -96,8 +96,7 @@ open class EmitterConfiguration() : Configuration, EmitterConfigurationInterface
     // Builders
     
     /**
-     * How many events to send in each request. By default, this is set to [BufferOption.DefaultGroup], 
-     * a maximum of 10 events per request.
+     * How many events to send in each request. By default, this is set to [BufferOption.Single].
      */
     fun bufferOption(bufferOption: BufferOption): EmitterConfiguration {
         this.bufferOption = bufferOption
@@ -205,7 +204,7 @@ open class EmitterConfiguration() : Configuration, EmitterConfigurationInterface
      */
     constructor(jsonObject: JSONObject) : this() {
         if (jsonObject.has("bufferOption")) {
-            _bufferOption = BufferOption.valueOf(jsonObject.getString("bufferOption"))
+            _bufferOption = BufferOption.fromString(jsonObject.getString("bufferOption"))
         }
         if (jsonObject.has("emitRange")) { _emitRange = jsonObject.getInt("emitRange") }
         if (jsonObject.has("threadPoolSize")) { _threadPoolSize = jsonObject.getInt("threadPoolSize") }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/BufferOption.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/BufferOption.kt
@@ -17,20 +17,35 @@ package com.snowplowanalytics.snowplow.emitter
  */
 enum class BufferOption(val code: Int) {
     /**
-     * Sends both GET and POST requests with only a single event. Can cause a spike in
-     * network traffic if used in correlation with a large amount of events.
+     * Sends both GET and POST requests with only a single event.
+     * This is the default setting.
+     * Can cause a spike in network traffic if used in correlation with a large amount of events.
      */
     Single(1),
 
     /**
-     * Sends POST requests in groups of 10 events. This is the default amount of events to
-     * package into a POST. All GET requests will still emit one at a time.
+     * Sends POST requests in groups of 10 events.
+     * All GET requests will still emit one at a time.
      */
-    DefaultGroup(10),
+    SmallGroup(10),
 
     /**
-     * Sends POST requests in groups of 25 events. Useful for situations where many events
-     * need to be sent. All GET requests will still emit one at a time.
+     * Sends POST requests in groups of 25 events.
+     * Useful for situations where many events need to be sent.
+     * All GET requests will still emit one at a time.
      */
-    HeavyGroup(25);
+    LargeGroup(25);
+
+    companion object {
+        fun fromString(string: String): BufferOption? {
+            return when (string) {
+                "Single" -> Single
+                "SmallGroup" -> SmallGroup
+                "DefaultGroup" -> SmallGroup
+                "LargeGroup" -> LargeGroup
+                "HeavyGroup" -> LargeGroup
+                else -> null
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR contains three changes:

### Flush events only when the buffer is full (#648)

Previously the buffer size configuration didn't work as intended – requests to the collector were initiated right after the event was tracked regardless of the buffer size.

This change fixes that and only makes the request once the buffer size is reached.

### Change default buffer option to single (#649)

As mentioned before, previously the buffer size was effectively equal to 1 (even though we stated it was 10). Fixing the above bug, we would now change the buffer size to 10.

Buffer size 1 is probably a better default for client side trackers to avoid losing events that don't make it to a request before an app is quit/uninstalled. Also the same is used on the JavaScript tracker.

This change sets the default buffer size to 1 (from a user's point of view there won't be a difference compared to previous versions).

### Make network requests serially in network connection (#646)

This change tries to address a problem with duplicate events often showing up in the warehouse. It is possible that this is called by sending too many parallel requests at once which causes either the requests to fail or timeout and then be retried.

After doing some tests, I discovered that making parallel requests from the client has very little benefit. The total time it takes to send all the events is very close to what it would be if requests were made serially.

The new behaviour updates how the `emitRange` configuration is used – it now tells how many events should be added to one request. For this reason, I also lowered the default value to 25.

When merging this PR, I will rebase the commits so that they show up individually in the release branch.