### PR TITLE
Add screen engagement tracking of time spent and list items scrolled on a screen (close #654)

### DIFF
--- a/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/data/Tracking.kt
+++ b/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/data/Tracking.kt
@@ -10,6 +10,7 @@ import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration
 import com.snowplowanalytics.snowplow.configuration.TrackerConfiguration
 import com.snowplowanalytics.snowplow.controller.TrackerController
 import com.snowplowanalytics.snowplow.emitter.BufferOption
+import com.snowplowanalytics.snowplow.event.ListItemView
 import com.snowplowanalytics.snowplow.event.ScreenView
 import com.snowplowanalytics.snowplow.network.HttpMethod
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
@@ -20,7 +21,10 @@ object Tracking {
     fun setup(namespace: String) : TrackerController {
         // Replace this collector endpoint with your own
         val networkConfig = NetworkConfiguration("https://23a6-82-26-43-253.ngrok.io", HttpMethod.POST)
-        val trackerConfig = TrackerConfiguration("appID").logLevel(LogLevel.DEBUG)
+        val trackerConfig = TrackerConfiguration("appID")
+            .logLevel(LogLevel.DEBUG)
+            .screenViewAutotracking(false)
+            .lifecycleAutotracking(true)
         val emitterConfig = EmitterConfiguration().bufferOption(BufferOption.Single)
 
         return Snowplow.createTracker(
@@ -45,6 +49,14 @@ object Tracking {
     ) {
         LaunchedEffect(Unit, block = {
             val event = ScreenView(screenName).entities(entities)
+            Snowplow.defaultTracker?.track(event)
+        })
+    }
+
+    @Composable
+    fun TrackListItemView(index: Int, itemsCount: Int?) {
+        LaunchedEffect(Unit, block = {
+            val event = ListItemView(index, itemsCount)
             Snowplow.defaultTracker?.track(event)
         })
     }

--- a/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/ui/SchemaDetailScreen.kt
+++ b/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/ui/SchemaDetailScreen.kt
@@ -36,8 +36,7 @@ fun SchemaDetailScreen(
         "iglu:com.snowplowanalytics.iglu/anything-a/jsonschema/1-0-0", 
         hashMapOf("name" to schemaParts.name, "vendor" to schemaParts.vendor)
     )
-    Tracking.ManuallyTrackScreenView("schema_detail", entities = listOf(entity))
-    
+
     Scaffold(
         topBar = {
             TopAppBar(

--- a/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/ui/SchemaListScreen.kt
+++ b/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/ui/SchemaListScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowForward
@@ -16,6 +17,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.snowplowanalytics.snowplowdemocompose.R
 import com.snowplowanalytics.snowplowdemocompose.data.SchemaUrlParts
+import com.snowplowanalytics.snowplowdemocompose.data.Tracking
 
 @Composable
 fun SchemaListScreen(
@@ -38,7 +40,11 @@ fun SchemaListScreen(
             if (vm.errorMessage.isEmpty()) {
                 Column(modifier = Modifier.padding(contentPadding)) {
                     LazyColumn(modifier = Modifier.fillMaxHeight()) {
-                        items(vm.schemaPartsList) { schema ->
+                        itemsIndexed(vm.schemaPartsList) { index, schema ->
+                            Tracking.TrackListItemView(
+                                index = index,
+                                itemsCount = vm.schemaPartsList.size
+                            )
                             SchemaCard(schema = schema, onClick = onSchemaClicked)
                         }
                     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
@@ -454,6 +454,9 @@ internal open class MockStateMachine(
 ) : StateMachineInterface {
     var afterTrackEvents: MutableList<InspectableEvent> = ArrayList()
 
+    override val subscribedEventSchemasForEventsBefore: List<String>
+        get() = emptyList()
+
     override val subscribedEventSchemasForTransitions: List<String>
         get() = LinkedList(listOf("inc", "dec"))
 
@@ -468,6 +471,10 @@ internal open class MockStateMachine(
 
     override val subscribedEventSchemasForFiltering: List<String>
         get() = Collections.singletonList("s1")
+
+    override fun eventsBefore(event: Event): List<Event>? {
+        return null
+    }
 
     override fun transition(event: Event, state: State?): State? {
         val e = event as SelfDescribing

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
@@ -123,6 +123,30 @@ class ScreenSummaryStateMachineTest {
         Assert.assertEquals(10, screenSummary?.get("items_count"))
     }
 
+    @Test
+    fun updatesScrollMetrics() {
+        val eventSink = EventSink()
+        val tracker = createTracker(listOf(eventSink))
+
+        tracker.track(ScreenView(name = "Screen 1"))
+        Thread.sleep(200)
+        tracker.track(ScrollChanged(yOffset= 10, contentHeight = 100))
+        Thread.sleep(200)
+        tracker.track(ScrollChanged(yOffset= 30, contentHeight = 100))
+        Thread.sleep(200)
+        tracker.track(ScrollChanged(yOffset= 20, contentHeight = 100))
+        Thread.sleep(200)
+        tracker.track(ScreenView(name = "Screen 2"))
+        Thread.sleep(200)
+
+        val events = eventSink.trackedEvents
+        Assert.assertEquals(3, events.size)
+
+        val screenSummary = getScreenSummary(events.find { it.schema == TrackerConstants.SCHEMA_SCREEN_END })
+        Assert.assertEquals(30, screenSummary?.get("max_y_offset"))
+        Assert.assertEquals(100, screenSummary?.get("content_height"))
+    }
+
     // --- PRIVATE
     private val context: Context
         get() = InstrumentationRegistry.getInstrumentation().targetContext

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.screenviews.ScreenSummaryState
+import com.snowplowanalytics.snowplow.Snowplow
+import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
+import com.snowplowanalytics.snowplow.configuration.Configuration
+import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration
+import com.snowplowanalytics.snowplow.configuration.PluginConfiguration
+import com.snowplowanalytics.snowplow.controller.TrackerController
+import com.snowplowanalytics.snowplow.event.*
+import com.snowplowanalytics.snowplow.network.HttpMethod
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+import com.snowplowanalytics.snowplow.util.EventSink
+import com.snowplowanalytics.snowplow.util.TimeTraveler
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
+@RunWith(AndroidJUnit4::class)
+class ScreenSummaryStateMachineTest {
+
+    var timeTraveler = TimeTraveler()
+
+    @Before
+    fun setUp() {
+        ScreenSummaryState.dateGenerator = { timeTraveler.generateTimestamp() }
+    }
+
+    @After
+    fun tearDown() {
+        removeAllTrackers()
+    }
+
+    // --- TESTS
+
+    @Test
+    fun tracksTransitionToBackgroundAndForeground() {
+        val eventSink = EventSink()
+        val tracker = createTracker(listOf(eventSink))
+
+        tracker.track(ScreenView(name = "Screen 1"))
+        timeTraveler.travelBy(10.toDuration(DurationUnit.SECONDS))
+        tracker.track(Background())
+        Thread.sleep(200)
+
+        timeTraveler.travelBy(5.toDuration(DurationUnit.SECONDS))
+        tracker.track(Foreground())
+        Thread.sleep(200)
+
+        val events = eventSink.trackedEvents
+        Assert.assertEquals(3, events.size)
+
+        val backgroundSummary = getScreenSummary(events.find { it.schema == Background.schema })
+        Assert.assertEquals(10.0, backgroundSummary?.get("foreground_sec"))
+        Assert.assertEquals(0.0, backgroundSummary?.get("background_sec"))
+
+        val foregroundSummary = getScreenSummary(events.find { it.schema == Foreground.schema })
+        Assert.assertEquals(10.0, foregroundSummary?.get("foreground_sec"))
+        Assert.assertEquals(5.0, foregroundSummary?.get("background_sec"))
+    }
+
+    @Test
+    fun tracksScreenEndEventWithScreenSummary() {
+        val eventSink = EventSink()
+        val tracker = createTracker(listOf(eventSink))
+
+        tracker.track(ScreenView(name = "Screen 1"))
+        Thread.sleep(200)
+        timeTraveler.travelBy(10.toDuration(DurationUnit.SECONDS))
+        tracker.track(ScreenView(name = "Screen 2"))
+        Thread.sleep(200)
+
+        val events = eventSink.trackedEvents
+        Assert.assertEquals(3, events.size)
+
+        val screenSummary = getScreenSummary(events.find { it.schema == TrackerConstants.SCHEMA_SCREEN_END })
+        Assert.assertEquals(10.0, screenSummary?.get("foreground_sec"))
+        Assert.assertEquals(0.0, screenSummary?.get("background_sec"))
+    }
+
+    @Test
+    fun updatesListMetrics() {
+        val eventSink = EventSink()
+        val tracker = createTracker(listOf(eventSink))
+
+        tracker.track(ScreenView(name = "Screen 1"))
+        Thread.sleep(200)
+        tracker.track(ListItemView(index = 1, itemsCount = 10))
+        Thread.sleep(200)
+        tracker.track(ListItemView(index = 3, itemsCount = 10))
+        Thread.sleep(200)
+        tracker.track(ListItemView(index = 2, itemsCount = 10))
+        Thread.sleep(200)
+        tracker.track(ScreenView(name = "Screen 2"))
+        Thread.sleep(200)
+
+        val events = eventSink.trackedEvents
+        Assert.assertEquals(3, events.size)
+
+        val screenSummary = getScreenSummary(events.find { it.schema == TrackerConstants.SCHEMA_SCREEN_END })
+        Assert.assertEquals(3, screenSummary?.get("last_item_index"))
+        Assert.assertEquals(10, screenSummary?.get("items_count"))
+    }
+
+    // --- PRIVATE
+    private val context: Context
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun getScreenSummary(event: InspectableEvent?): Map<String, Any?>? {
+        val entity = event?.entities?.find { it.map["schema"] == TrackerConstants.SCHEMA_SCREEN_SUMMARY }
+        return entity?.map?.get("data") as? Map<String, Any?>
+    }
+
+    private fun createTracker(configurations: List<Configuration>): TrackerController {
+        val networkConfig = NetworkConfiguration(MockNetworkConnection(HttpMethod.POST, 200))
+        return Snowplow.createTracker(
+            context,
+            namespace = "ns" + Math.random().toString(),
+            network = networkConfig,
+            configurations = configurations.toTypedArray()
+        )
+    }
+}

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
@@ -130,11 +130,11 @@ class ScreenSummaryStateMachineTest {
 
         tracker.track(ScreenView(name = "Screen 1"))
         Thread.sleep(200)
-        tracker.track(ScrollChanged(yOffset = 10, contentHeight = 100))
+        tracker.track(ScrollChanged(yOffset = 10, viewHeight = 20, contentHeight = 100))
         Thread.sleep(200)
-        tracker.track(ScrollChanged(xOffset = 15, yOffset = 30, contentWidth = 150, contentHeight = 100))
+        tracker.track(ScrollChanged(xOffset = 15, yOffset = 30, viewWidth = 15, viewHeight = 20, contentWidth = 150, contentHeight = 100))
         Thread.sleep(200)
-        tracker.track(ScrollChanged(yOffset = 20, contentHeight = 100))
+        tracker.track(ScrollChanged(yOffset = 20, viewHeight = 20, contentHeight = 100))
         Thread.sleep(200)
         tracker.track(ScreenView(name = "Screen 2"))
         Thread.sleep(200)
@@ -143,8 +143,10 @@ class ScreenSummaryStateMachineTest {
         Assert.assertEquals(3, events.size)
 
         val screenSummary = getScreenSummary(events.find { it.schema == TrackerConstants.SCHEMA_SCREEN_END })
-        Assert.assertEquals(30, screenSummary?.get("max_y_offset"))
-        Assert.assertEquals(15, screenSummary?.get("max_x_offset"))
+        Assert.assertEquals(10, screenSummary?.get("min_y_offset"))
+        Assert.assertEquals(15, screenSummary?.get("min_x_offset"))
+        Assert.assertEquals(50, screenSummary?.get("max_y_offset"))
+        Assert.assertEquals(30, screenSummary?.get("max_x_offset"))
         Assert.assertEquals(150, screenSummary?.get("content_width"))
         Assert.assertEquals(100, screenSummary?.get("content_height"))
     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
@@ -130,11 +130,11 @@ class ScreenSummaryStateMachineTest {
 
         tracker.track(ScreenView(name = "Screen 1"))
         Thread.sleep(200)
-        tracker.track(ScrollChanged(yOffset= 10, contentHeight = 100))
+        tracker.track(ScrollChanged(yOffset = 10, contentHeight = 100))
         Thread.sleep(200)
-        tracker.track(ScrollChanged(yOffset= 30, contentHeight = 100))
+        tracker.track(ScrollChanged(xOffset = 15, yOffset = 30, contentWidth = 150, contentHeight = 100))
         Thread.sleep(200)
-        tracker.track(ScrollChanged(yOffset= 20, contentHeight = 100))
+        tracker.track(ScrollChanged(yOffset = 20, contentHeight = 100))
         Thread.sleep(200)
         tracker.track(ScreenView(name = "Screen 2"))
         Thread.sleep(200)
@@ -144,6 +144,8 @@ class ScreenSummaryStateMachineTest {
 
         val screenSummary = getScreenSummary(events.find { it.schema == TrackerConstants.SCHEMA_SCREEN_END })
         Assert.assertEquals(30, screenSummary?.get("max_y_offset"))
+        Assert.assertEquals(15, screenSummary?.get("max_x_offset"))
+        Assert.assertEquals(150, screenSummary?.get("content_width"))
         Assert.assertEquals(100, screenSummary?.get("content_height"))
     }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/util/EventSink.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/util/EventSink.kt
@@ -1,0 +1,23 @@
+package com.snowplowanalytics.snowplow.util
+
+import com.snowplowanalytics.snowplow.configuration.*
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent
+
+class EventSink : Configuration, PluginIdentifiable, PluginFilterCallable {
+
+    var trackedEvents = mutableListOf<InspectableEvent>()
+
+    override val identifier: String
+        get() = "EventSink"
+
+    override val filterConfiguration: PluginFilterConfiguration?
+        get() = PluginFilterConfiguration { event ->
+            trackedEvents.add(event)
+            false
+        }
+
+    override fun copy(): Configuration {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/TrackerConstants.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/TrackerConstants.kt
@@ -65,6 +65,12 @@ object TrackerConstants {
         "iglu:com.snowplowanalytics.snowplow.ecommerce/user/jsonschema/1-0-0"
     const val SCHEMA_ECOMMERCE_PAGE =
         "iglu:com.snowplowanalytics.snowplow.ecommerce/page/jsonschema/1-0-0"
+    const val SCHEMA_SCREEN_END =
+        "iglu:com.snowplowanalytics.mobile/screen_end/jsonschema/1-0-0"
+    const val SCHEMA_SCREEN_SUMMARY =
+        "iglu:com.snowplowanalytics.mobile/screen_summary/jsonschema/1-0-0"
+    const val SCHEMA_LIST_ITEM_VIEW =
+        "iglu:com.snowplowanalytics.mobile/list_item_view/jsonschema/1-0-0"
     const val POST_CONTENT_TYPE = "application/json; charset=utf-8"
     const val EVENT_PAGE_VIEW = "pv"
     const val EVENT_STRUCTURED = "se"

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/TrackerConstants.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/constants/TrackerConstants.kt
@@ -71,6 +71,8 @@ object TrackerConstants {
         "iglu:com.snowplowanalytics.mobile/screen_summary/jsonschema/1-0-0"
     const val SCHEMA_LIST_ITEM_VIEW =
         "iglu:com.snowplowanalytics.mobile/list_item_view/jsonschema/1-0-0"
+    const val SCHEMA_SCROLL_CHANGED =
+        "iglu:com.snowplowanalytics.mobile/scroll_changed/jsonschema/1-0-0"
     const val POST_CONTENT_TYPE = "application/json; charset=utf-8"
     const val EVENT_PAGE_VIEW = "pv"
     const val EVENT_STRUCTURED = "se"

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/event/ScreenEnd.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/event/ScreenEnd.kt
@@ -10,24 +10,21 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
+package com.snowplowanalytics.snowplow.event
 
-package com.snowplowanalytics.snowplow.util
-
+import com.snowplowanalytics.core.constants.TrackerConstants
 import java.util.*
-import kotlin.time.Duration
 
-class TimeTraveler {
-    private var date: Date = Date()
+class ScreenEnd : AbstractSelfDescribing() {
 
-    fun travelBy(duration: Duration) {
-        date = Date(date.time + duration.inWholeMilliseconds)
-    }
+    // Tracker methods
+    override val dataPayload: Map<String, Any?>
+        get() {
+            val payload = HashMap<String, Any?>()
+            return payload
+        }
 
-    fun generateDate(): Date {
-        return date
-    }
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_SCREEN_END
 
-    fun generateTimestamp(): Long {
-        return date.time
-    }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenState.kt
@@ -10,7 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.screenviews
 
 import androidx.annotation.RestrictTo
 import com.snowplowanalytics.core.constants.Parameters

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenStateMachine.kt
@@ -10,7 +10,7 @@
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
  */
-package com.snowplowanalytics.core.tracker
+package com.snowplowanalytics.core.screenviews
 
 import com.snowplowanalytics.core.constants.Parameters
 import com.snowplowanalytics.core.constants.TrackerConstants
@@ -48,6 +48,9 @@ class ScreenStateMachine : StateMachineInterface {
         get() = emptyList()
 
     override val subscribedEventSchemasForFiltering: List<String>
+        get() = emptyList()
+
+    override val subscribedEventSchemasForEventsBefore: List<String>
         get() = emptyList()
 
     override fun transition(event: Event, state: State?): State? {
@@ -105,6 +108,10 @@ class ScreenStateMachine : StateMachineInterface {
     }
 
     override fun filter(event: InspectableEvent, state: State?): Boolean? {
+        return null
+    }
+
+    override fun eventsBefore(event: Event): List<Event>? {
         return null
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryState.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.core.screenviews
+
+import androidx.annotation.RestrictTo
+import com.snowplowanalytics.core.statemachine.State
+import com.snowplowanalytics.snowplow.event.ListItemView
+import java.lang.Integer.max
+
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+class ScreenSummaryState : State {
+    private var lastUpdateTimestamp = dateGenerator()
+
+    private var foregroundDuration: Long = 0
+    private var backgroundDuration: Long = 0
+    private var lastItemIndex: Int? = null
+    private var itemsCount: Int? = null
+
+    val data: Map<String, Any?>
+        get() {
+            val data = mutableMapOf<String, Any?>(
+                "foreground_sec" to foregroundDuration / 1000.0,
+                "background_sec" to backgroundDuration / 1000.0
+            )
+            lastItemIndex?.let { data["last_item_index"] = it }
+            itemsCount?.let { data["items_count"] = it }
+
+            return data
+        }
+
+    @Synchronized
+    fun updateTransitionToForeground() {
+        val currentTimestamp = dateGenerator()
+
+        backgroundDuration += currentTimestamp - lastUpdateTimestamp
+        lastUpdateTimestamp = currentTimestamp
+    }
+
+    @Synchronized
+    fun updateTransitionToBackground() {
+        val currentTimestamp = dateGenerator()
+
+        foregroundDuration += currentTimestamp - lastUpdateTimestamp
+        lastUpdateTimestamp = currentTimestamp
+    }
+
+    @Synchronized
+    fun updateForScreenEnd() {
+        val currentTimestamp = dateGenerator()
+
+        foregroundDuration += currentTimestamp - lastUpdateTimestamp
+        lastUpdateTimestamp = currentTimestamp
+    }
+
+    @Synchronized
+    fun updateWithListItemView(event: ListItemView) {
+        lastItemIndex = max(event.index, lastItemIndex ?: 0)
+        event.itemsCount?.let {
+            itemsCount = max(it, itemsCount ?: 0)
+        }
+
+    }
+
+    companion object {
+        var dateGenerator: () -> Long = { System.currentTimeMillis() }
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryState.kt
@@ -17,6 +17,7 @@ import com.snowplowanalytics.core.statemachine.State
 import com.snowplowanalytics.snowplow.event.ListItemView
 import com.snowplowanalytics.snowplow.event.ScrollChanged
 import java.lang.Integer.max
+import java.lang.Integer.min
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 class ScreenSummaryState : State {
@@ -26,6 +27,8 @@ class ScreenSummaryState : State {
     private var backgroundDuration: Long = 0
     private var lastItemIndex: Int? = null
     private var itemsCount: Int? = null
+    private var minYOffset: Int? = null
+    private var minXOffset: Int? = null
     private var maxYOffset: Int? = null
     private var maxXOffset: Int? = null
     private var contentHeight: Int? = null
@@ -39,6 +42,8 @@ class ScreenSummaryState : State {
             )
             lastItemIndex?.let { data["last_item_index"] = it }
             itemsCount?.let { data["items_count"] = it }
+            minYOffset?.let { data["min_y_offset"] = it }
+            minXOffset?.let { data["min_x_offset"] = it }
             maxYOffset?.let { data["max_y_offset"] = it }
             maxXOffset?.let { data["max_x_offset"] = it }
             contentHeight?.let { data["content_height"] = it }
@@ -77,8 +82,20 @@ class ScreenSummaryState : State {
     }
 
     fun updateWithScrollChanged(event: ScrollChanged) {
-        event.yOffset?.let { maxYOffset = max(it, maxYOffset ?: 0) }
-        event.xOffset?.let { maxXOffset = max(it, maxXOffset ?: 0) }
+        event.yOffset?.let { yOffset ->
+            var maxYOffset = yOffset
+            event.viewHeight?.let { maxYOffset += it }
+
+            minYOffset = min(yOffset, minYOffset ?: yOffset)
+            this.maxYOffset = max(maxYOffset, this.maxYOffset ?: maxYOffset)
+        }
+        event.xOffset?.let { xOffset ->
+            var maxXOffset = xOffset
+            event.viewWidth?.let { maxXOffset += it }
+
+            minXOffset = min(xOffset, minXOffset ?: xOffset)
+            this.maxXOffset = max(maxXOffset, this.maxXOffset ?: maxXOffset)
+        }
         event.contentWidth?.let { contentWidth = max(it, contentWidth ?: 0) }
         event.contentHeight?.let { contentHeight = max(it, contentHeight ?: 0) }
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryState.kt
@@ -15,6 +15,7 @@ package com.snowplowanalytics.core.screenviews
 import androidx.annotation.RestrictTo
 import com.snowplowanalytics.core.statemachine.State
 import com.snowplowanalytics.snowplow.event.ListItemView
+import com.snowplowanalytics.snowplow.event.ScrollChanged
 import java.lang.Integer.max
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -25,6 +26,8 @@ class ScreenSummaryState : State {
     private var backgroundDuration: Long = 0
     private var lastItemIndex: Int? = null
     private var itemsCount: Int? = null
+    private var maxYOffset: Int? = null
+    private var contentHeight: Int? = null
 
     val data: Map<String, Any?>
         get() {
@@ -34,11 +37,12 @@ class ScreenSummaryState : State {
             )
             lastItemIndex?.let { data["last_item_index"] = it }
             itemsCount?.let { data["items_count"] = it }
+            maxYOffset?.let { data["max_y_offset"] = it }
+            contentHeight?.let { data["content_height"] = it }
 
             return data
         }
 
-    @Synchronized
     fun updateTransitionToForeground() {
         val currentTimestamp = dateGenerator()
 
@@ -46,7 +50,6 @@ class ScreenSummaryState : State {
         lastUpdateTimestamp = currentTimestamp
     }
 
-    @Synchronized
     fun updateTransitionToBackground() {
         val currentTimestamp = dateGenerator()
 
@@ -54,7 +57,6 @@ class ScreenSummaryState : State {
         lastUpdateTimestamp = currentTimestamp
     }
 
-    @Synchronized
     fun updateForScreenEnd() {
         val currentTimestamp = dateGenerator()
 
@@ -62,13 +64,17 @@ class ScreenSummaryState : State {
         lastUpdateTimestamp = currentTimestamp
     }
 
-    @Synchronized
     fun updateWithListItemView(event: ListItemView) {
         lastItemIndex = max(event.index, lastItemIndex ?: 0)
         event.itemsCount?.let {
             itemsCount = max(it, itemsCount ?: 0)
         }
 
+    }
+
+    fun updateWithScrollChanged(event: ScrollChanged) {
+        maxYOffset = max(event.yOffset, maxYOffset ?: 0)
+        contentHeight = max(event.contentHeight, contentHeight ?: 0)
     }
 
     companion object {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryState.kt
@@ -27,7 +27,9 @@ class ScreenSummaryState : State {
     private var lastItemIndex: Int? = null
     private var itemsCount: Int? = null
     private var maxYOffset: Int? = null
+    private var maxXOffset: Int? = null
     private var contentHeight: Int? = null
+    private var contentWidth: Int? = null
 
     val data: Map<String, Any?>
         get() {
@@ -38,7 +40,9 @@ class ScreenSummaryState : State {
             lastItemIndex?.let { data["last_item_index"] = it }
             itemsCount?.let { data["items_count"] = it }
             maxYOffset?.let { data["max_y_offset"] = it }
+            maxXOffset?.let { data["max_x_offset"] = it }
             contentHeight?.let { data["content_height"] = it }
+            contentWidth?.let { data["content_width"] = it }
 
             return data
         }
@@ -73,8 +77,10 @@ class ScreenSummaryState : State {
     }
 
     fun updateWithScrollChanged(event: ScrollChanged) {
-        maxYOffset = max(event.yOffset, maxYOffset ?: 0)
-        contentHeight = max(event.contentHeight, contentHeight ?: 0)
+        event.yOffset?.let { maxYOffset = max(it, maxYOffset ?: 0) }
+        event.xOffset?.let { maxXOffset = max(it, maxXOffset ?: 0) }
+        event.contentWidth?.let { contentWidth = max(it, contentWidth ?: 0) }
+        event.contentHeight?.let { contentHeight = max(it, contentHeight ?: 0) }
     }
 
     companion object {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryStateMachine.kt
@@ -25,7 +25,7 @@ class ScreenSummaryStateMachine : StateMachineInterface {
         get() = ID
 
     override val subscribedEventSchemasForTransitions: List<String>
-        get() = listOf(TrackerConstants.SCHEMA_SCREEN_VIEW, TrackerConstants.SCHEMA_SCREEN_END, Foreground.schema, Background.schema, TrackerConstants.SCHEMA_LIST_ITEM_VIEW)
+        get() = listOf(TrackerConstants.SCHEMA_SCREEN_VIEW, TrackerConstants.SCHEMA_SCREEN_END, Foreground.schema, Background.schema, TrackerConstants.SCHEMA_LIST_ITEM_VIEW, TrackerConstants.SCHEMA_SCROLL_CHANGED)
 
     override val subscribedEventSchemasForEntitiesGeneration: List<String>
         get() = listOf(TrackerConstants.SCHEMA_SCREEN_END, Foreground.schema, Background.schema)
@@ -37,7 +37,7 @@ class ScreenSummaryStateMachine : StateMachineInterface {
         get() = emptyList()
 
     override val subscribedEventSchemasForFiltering: List<String>
-        get() = listOf(TrackerConstants.SCHEMA_LIST_ITEM_VIEW, TrackerConstants.SCHEMA_SCREEN_END)
+        get() = listOf(TrackerConstants.SCHEMA_LIST_ITEM_VIEW, TrackerConstants.SCHEMA_SCREEN_END, TrackerConstants.SCHEMA_SCROLL_CHANGED)
 
     override val subscribedEventSchemasForEventsBefore: List<String>
         get() = listOf(TrackerConstants.SCHEMA_SCREEN_VIEW)
@@ -59,6 +59,9 @@ class ScreenSummaryStateMachine : StateMachineInterface {
             }
             is ListItemView -> {
                 screenSummaryState.updateWithListItemView(event)
+            }
+            is ScrollChanged -> {
+                screenSummaryState.updateWithScrollChanged(event)
             }
         }
         return state
@@ -86,7 +89,7 @@ class ScreenSummaryStateMachine : StateMachineInterface {
         if (event.schema == TrackerConstants.SCHEMA_SCREEN_END) {
             return state != null
         }
-        // do not track list item view events
+        // do not track list item view and scroll changed events
         return false
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenSummaryStateMachine.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.core.screenviews
+
+import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.statemachine.State
+import com.snowplowanalytics.core.statemachine.StateMachineInterface
+import com.snowplowanalytics.snowplow.event.*
+import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+import com.snowplowanalytics.snowplow.tracker.InspectableEvent
+
+class ScreenSummaryStateMachine : StateMachineInterface {
+
+    override val identifier: String
+        get() = ID
+
+    override val subscribedEventSchemasForTransitions: List<String>
+        get() = listOf(TrackerConstants.SCHEMA_SCREEN_VIEW, TrackerConstants.SCHEMA_SCREEN_END, Foreground.schema, Background.schema, TrackerConstants.SCHEMA_LIST_ITEM_VIEW)
+
+    override val subscribedEventSchemasForEntitiesGeneration: List<String>
+        get() = listOf(TrackerConstants.SCHEMA_SCREEN_END, Foreground.schema, Background.schema)
+
+    override val subscribedEventSchemasForPayloadUpdating: List<String>
+        get() = emptyList()
+
+    override val subscribedEventSchemasForAfterTrackCallback: List<String>
+        get() = emptyList()
+
+    override val subscribedEventSchemasForFiltering: List<String>
+        get() = listOf(TrackerConstants.SCHEMA_LIST_ITEM_VIEW, TrackerConstants.SCHEMA_SCREEN_END)
+
+    override val subscribedEventSchemasForEventsBefore: List<String>
+        get() = listOf(TrackerConstants.SCHEMA_SCREEN_VIEW)
+
+    override fun transition(event: Event, state: State?): State? {
+        if (event is ScreenView) {
+            return ScreenSummaryState()
+        }
+        val screenSummaryState = state as ScreenSummaryState? ?: return null
+        when (event) {
+            is Foreground -> {
+                screenSummaryState.updateTransitionToForeground()
+            }
+            is Background -> {
+                screenSummaryState.updateTransitionToBackground()
+            }
+            is ScreenEnd -> {
+                screenSummaryState.updateForScreenEnd()
+            }
+            is ListItemView -> {
+                screenSummaryState.updateWithListItemView(event)
+            }
+        }
+        return state
+    }
+
+    override fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson>? {
+        val screenSummaryState = state as ScreenSummaryState? ?: return null
+
+        return listOf(
+            SelfDescribingJson(
+                TrackerConstants.SCHEMA_SCREEN_SUMMARY,
+                screenSummaryState.data
+            )
+        )
+    }
+
+    override fun payloadValues(event: InspectableEvent, state: State?): Map<String, Any>? {
+        return null
+    }
+
+    override fun afterTrack(event: InspectableEvent) {
+    }
+
+    override fun filter(event: InspectableEvent, state: State?): Boolean {
+        if (event.schema == TrackerConstants.SCHEMA_SCREEN_END) {
+            return state != null
+        }
+        // do not track list item view events
+        return false
+    }
+
+    override fun eventsBefore(event: Event): List<Event>? {
+        return listOf(ScreenEnd())
+    }
+
+    companion object {
+        val ID: String
+            get() = "ScreenSummaryContext"
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/DeepLinkStateMachine.kt
@@ -51,6 +51,9 @@ class DeepLinkStateMachine : StateMachineInterface {
     override val subscribedEventSchemasForFiltering: List<String>
         get() = emptyList()
 
+    override val subscribedEventSchemasForEventsBefore: List<String>
+        get() = emptyList()
+
     override fun transition(event: Event, state: State?): State? {
         // - Init (DL) DeepLinkReceived
         // - ReadyForOutput (DL) DeepLinkReceived
@@ -92,6 +95,10 @@ class DeepLinkStateMachine : StateMachineInterface {
     }
 
     override fun filter(event: InspectableEvent, state: State?): Boolean? {
+        return null
+    }
+
+    override fun eventsBefore(event: Event): List<Event>? {
         return null
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/LifecycleStateMachine.kt
@@ -48,6 +48,9 @@ class LifecycleStateMachine : StateMachineInterface {
     override val subscribedEventSchemasForFiltering: List<String>
         get() = emptyList()
 
+    override val subscribedEventSchemasForEventsBefore: List<String>
+        get() = emptyList()
+
     override fun transition(event: Event, currentState: State?): State? {
         if (event is Foreground) {
             return LifecycleState(true, event.foregroundIndex)
@@ -73,6 +76,10 @@ class LifecycleStateMachine : StateMachineInterface {
     }
 
     override fun filter(event: InspectableEvent, state: State?): Boolean? {
+        return null
+    }
+
+    override fun eventsBefore(event: Event): List<Event>? {
         return null
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
@@ -51,6 +51,9 @@ class PluginStateMachine(
             return config.schemas ?: Collections.singletonList("*")
         }
 
+    override val subscribedEventSchemasForEventsBefore: List<String>
+        get() = emptyList()
+
     override fun transition(event: Event, state: State?): State? {
         return null
     }
@@ -69,5 +72,9 @@ class PluginStateMachine(
 
     override fun filter(event: InspectableEvent, state: State?): Boolean? {
         return filterConfiguration?.closure?.apply(event)
+    }
+
+    override fun eventsBefore(event: Event): List<Event>? {
+        return null
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/StateMachineInterface.kt
@@ -18,12 +18,14 @@ import com.snowplowanalytics.snowplow.tracker.InspectableEvent
 
 interface StateMachineInterface {
     val identifier: String
+    val subscribedEventSchemasForEventsBefore: List<String>
     val subscribedEventSchemasForTransitions: List<String>
     val subscribedEventSchemasForEntitiesGeneration: List<String>
     val subscribedEventSchemasForPayloadUpdating: List<String>
     val subscribedEventSchemasForAfterTrackCallback: List<String>
     val subscribedEventSchemasForFiltering: List<String>
 
+    fun eventsBefore(event: Event): List<Event>?
     fun transition(event: Event, state: State?): State?
     fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson>?
     fun payloadValues(event: InspectableEvent, state: State?): Map<String, Any>?

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -272,6 +272,7 @@ class ServiceProvider(
             tracker.deepLinkContext = trackerConfiguration.deepLinkContext
             tracker.screenContext = trackerConfiguration.screenContext
             tracker.screenViewAutotracking = trackerConfiguration.screenViewAutotracking
+            tracker.screenEngagementAutotracking = trackerConfiguration.screenEngagementAutotracking
             tracker.lifecycleAutotracking = trackerConfiguration.lifecycleAutotracking
             tracker.installAutotracking = trackerConfiguration.installAutotracking
             tracker.exceptionAutotracking = trackerConfiguration.exceptionAutotracking

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerConfigurationInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerConfigurationInterface.kt
@@ -82,7 +82,7 @@ interface TrackerConfigurationInterface {
     var screenViewAutotracking: Boolean
 
     /**
-     * Whether enable tracking the screen end event and the screen summary context entity.
+     * Whether to enable tracking the screen end event and the screen summary context entity.
      * Make sure that you have lifecycle autotracking enabled for screen summary to have complete information.
      */
     var screenEngagementAutotracking: Boolean

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerConfigurationInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerConfigurationInterface.kt
@@ -82,6 +82,12 @@ interface TrackerConfigurationInterface {
     var screenViewAutotracking: Boolean
 
     /**
+     * Whether enable tracking the screen end event and the screen summary context entity.
+     * Make sure that you have lifecycle autotracking enabled for screen summary to have complete information.
+     */
+    var screenEngagementAutotracking: Boolean
+
+    /**
      * Whether enable automatic tracking of background and foreground transitions.
      * @apiNote It needs the Foreground library installed.
      */

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerControllerImpl.kt
@@ -162,6 +162,13 @@ class TrackerControllerImpl  // Constructors
             dirtyConfig.screenViewAutotracking = screenViewAutotracking
             tracker.screenViewAutotracking = screenViewAutotracking
         }
+
+    override var screenEngagementAutotracking: Boolean
+        get() = tracker.screenEngagementAutotracking
+        set(screenEngagementAutotracking) {
+            dirtyConfig.screenEngagementAutotracking = screenEngagementAutotracking
+            tracker.screenEngagementAutotracking = screenEngagementAutotracking
+        }
     
     override var lifecycleAutotracking: Boolean
         get() = tracker.lifecycleAutotracking

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerDefaults.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerDefaults.kt
@@ -34,6 +34,7 @@ object TrackerDefaults {
     var diagnosticAutotracking = false
     var lifecycleAutotracking = false
     var screenViewAutotracking = true
+    var screenEngagementAutotracking = true
     var installAutotracking = true
     var userAnonymisation = false
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
@@ -39,6 +39,7 @@ import java.util.*
  *  - screenContext: true
  *  - deepLinkContext: true
  *  - screenViewAutotracking: true
+ *  - screenEngagementAutotracking: true
  *  - lifecycleAutotracking: false
  *  - installAutotracking: true
  *  - exceptionAutotracking: true
@@ -119,6 +120,11 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
     override var screenViewAutotracking: Boolean
         get() = _screenViewAutotracking ?: sourceConfig?.screenViewAutotracking ?: TrackerDefaults.screenViewAutotracking
         set(value) { _screenViewAutotracking = value }
+
+    private var _screenEngagementAutotracking: Boolean? = null
+    override var screenEngagementAutotracking: Boolean
+        get() = _screenEngagementAutotracking ?: sourceConfig?.screenEngagementAutotracking ?: TrackerDefaults.screenEngagementAutotracking
+        set(value) { _screenEngagementAutotracking = value }
 
     private var _lifecycleAutotracking: Boolean? = null
     override var lifecycleAutotracking: Boolean
@@ -266,6 +272,15 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
     }
 
     /**
+     * Whether enable tracking the screen end event and the screen summary context entity.
+     * Make sure that you have lifecycle autotracking enabled for screen summary to have complete information.
+     */
+    fun screenEngagementAutotracking(screenEngagementAutotracking: Boolean): TrackerConfiguration {
+        this.screenEngagementAutotracking = screenEngagementAutotracking
+        return this
+    }
+
+    /**
      * Whether to enable automatic tracking of background and foreground transitions. 
      * The Foreground library must be installed.
      */
@@ -344,6 +359,7 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
             .screenContext(screenContext)
             .deepLinkContext(deepLinkContext)
             .screenViewAutotracking(screenViewAutotracking)
+            .screenEngagementAutotracking(screenEngagementAutotracking)
             .lifecycleAutotracking(lifecycleAutotracking)
             .installAutotracking(installAutotracking)
             .exceptionAutotracking(exceptionAutotracking)
@@ -395,6 +411,7 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
         if (jsonObject.has("screenContext")) { _screenContext = jsonObject.getBoolean("screenContext") }
         if (jsonObject.has("deepLinkContext")) { _deepLinkContext = jsonObject.getBoolean("deepLinkContext") }
         if (jsonObject.has("screenViewAutotracking")) { _screenViewAutotracking = jsonObject.getBoolean("screenViewAutotracking") }
+        if (jsonObject.has("screenEngagementAutotracking")) { _screenEngagementAutotracking = jsonObject.getBoolean("screenEngagementAutotracking") }
         if (jsonObject.has("lifecycleAutotracking")) { _lifecycleAutotracking = jsonObject.getBoolean("lifecycleAutotracking") }
         if (jsonObject.has("installAutotracking")) { _installAutotracking = jsonObject.getBoolean("installAutotracking") }
         if (jsonObject.has("exceptionAutotracking")) { _exceptionAutotracking = jsonObject.getBoolean("exceptionAutotracking") }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
@@ -272,7 +272,7 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
     }
 
     /**
-     * Whether enable tracking the screen end event and the screen summary context entity.
+     * Whether to enable tracking the screen end event and the screen summary context entity.
      * Make sure that you have lifecycle autotracking enabled for screen summary to have complete information.
      */
     fun screenEngagementAutotracking(screenEngagementAutotracking: Boolean): TrackerConfiguration {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ListItemView.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ListItemView.kt
@@ -16,7 +16,7 @@ import com.snowplowanalytics.core.constants.TrackerConstants
 
 /**
  * Event tracking the view of an item in a list.
- * If screen engagement tracking is enabled, the list item view events will be aggregated into a `screen_summary` entity.
+ * If screen engagement tracking is enabled, the list item view events will be aggregated into a `screen_summary` entity and won't be sent as separate events to the collector.
  *
  * Schema: `iglu:com.snowplowanalytics.mobile/list_item_view/jsonschema/1-0-0`
  */

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ListItemView.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ListItemView.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import com.snowplowanalytics.core.constants.TrackerConstants
+
+/**
+ * Event tracking the view of an item in a list.
+ * If screen engagement tracking is enabled, the list item view events will be aggregated into a `screen_summary` entity.
+ *
+ * Schema: `iglu:com.snowplowanalytics.mobile/list_item_view/jsonschema/1-0-0`
+ */
+class ListItemView (
+    /** Index of the item in the list. */
+    var index: Int,
+    /** Total number of items in the list. */
+    var itemsCount: Int?
+) : AbstractSelfDescribing() {
+
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_LIST_ITEM_VIEW
+
+    override val dataPayload: Map<String, Any?>
+        get() {
+            return mapOf(
+                "index" to index,
+                "items_count" to itemsCount
+            )
+        }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScrollChanged.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScrollChanged.kt
@@ -16,7 +16,7 @@ import com.snowplowanalytics.core.constants.TrackerConstants
 
 /**
  * Event tracked when a scroll view's scroll position changes.
- * If screen engagement tracking is enabled, the scroll changed events will be aggregated into a `screen_summary` entity.
+ * If screen engagement tracking is enabled, the scroll changed events will be aggregated into a `screen_summary` entity and won't be sent as separate events to the collector.
  *
  * Schema: `iglu:com.snowplowanalytics.mobile/scroll_changed/jsonschema/1-0-0`
  */

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScrollChanged.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScrollChanged.kt
@@ -22,9 +22,13 @@ import com.snowplowanalytics.core.constants.TrackerConstants
  */
 class ScrollChanged (
     /** Vertical scroll offset in pixels. */
-    var yOffset: Int,
+    var yOffset: Int? = null,
+    /** Horizontal scroll offset in pixels. */
+    var xOffset: Int? = null,
+    /** The width of the scroll view content in pixels. */
+    var contentWidth: Int? = null,
     /** The height of the scroll view content in pixels. */
-    var contentHeight: Int
+    var contentHeight: Int? = null
 ) : AbstractSelfDescribing() {
 
     override val schema: String
@@ -32,9 +36,11 @@ class ScrollChanged (
 
     override val dataPayload: Map<String, Any?>
         get() {
-            return mapOf(
-                "y_offset" to yOffset,
-                "content_height" to contentHeight
-            )
+            val data = mutableMapOf<String, Any?>()
+            yOffset?.let { data["y_offset"] = it }
+            xOffset?.let { data["x_offset"] = it }
+            contentWidth?.let { data["content_width"] = it }
+            contentHeight?.let { data["content_height"] = it }
+            return data
         }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScrollChanged.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScrollChanged.kt
@@ -25,9 +25,13 @@ class ScrollChanged (
     var yOffset: Int? = null,
     /** Horizontal scroll offset in pixels. */
     var xOffset: Int? = null,
-    /** The width of the scroll view content in pixels. */
+    /** The width of the scroll view in pixels. */
+    var viewWidth: Int? = null,
+    /** The height of the scroll view in pixels. */
+    var viewHeight: Int? = null,
+    /** The width of the content of the scroll view in pixels. */
     var contentWidth: Int? = null,
-    /** The height of the scroll view content in pixels. */
+    /** The height of the content of the scroll view in pixels. */
     var contentHeight: Int? = null
 ) : AbstractSelfDescribing() {
 
@@ -39,6 +43,8 @@ class ScrollChanged (
             val data = mutableMapOf<String, Any?>()
             yOffset?.let { data["y_offset"] = it }
             xOffset?.let { data["x_offset"] = it }
+            viewWidth?.let { data["view_width"] = it }
+            viewHeight?.let { data["view_height"] = it }
             contentWidth?.let { data["content_width"] = it }
             contentHeight?.let { data["content_height"] = it }
             return data

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScrollChanged.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/ScrollChanged.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.event
+
+import com.snowplowanalytics.core.constants.TrackerConstants
+
+/**
+ * Event tracked when a scroll view's scroll position changes.
+ * If screen engagement tracking is enabled, the scroll changed events will be aggregated into a `screen_summary` entity.
+ *
+ * Schema: `iglu:com.snowplowanalytics.mobile/scroll_changed/jsonschema/1-0-0`
+ */
+class ScrollChanged (
+    /** Vertical scroll offset in pixels. */
+    var yOffset: Int,
+    /** The height of the scroll view content in pixels. */
+    var contentHeight: Int
+) : AbstractSelfDescribing() {
+
+    override val schema: String
+        get() = TrackerConstants.SCHEMA_SCROLL_CHANGED
+
+    override val dataPayload: Map<String, Any?>
+        get() {
+            return mapOf(
+                "y_offset" to yOffset,
+                "content_height" to contentHeight
+            )
+        }
+}


### PR DESCRIPTION
Issue #654 

This PR adds screen engagement tracking to the tracker.

Screen engagement tracking is enabled by default. It can be disabled using the `TrackerConfiguration.screenEngagementAutotracking` configuration option.

It consists of the following events and entities:

* Screen summary entity.
* Screen end event.
* List item view event (optional).
* Scroll changed event (optional).

## Screen summary entity

The screen engagement information is attached in a `screen_summary` entity. The entity has information about the time spent on the screen in foreground and background.

It also contains information about the scroll depth on the screen – this is in the form of the last item in a list that the user reached in the screen out of all list items. It is updated using a `list_item_view` event, see below.

The screen summary entity is attached to the following events:

* foreground event
* background event
* screen end event

## Screen end event

The `screen_end` event is a new event that is tracked automatically before transitioning from one screen view to another screen view event. It does not have any properties, it's only tracked to contain the screen summary information.

In order to implement it, I added a `beforeEvents` function to the state machines. Using this function, the state machines can return a list of events to be tracked before another event. The new `ScreenSummaryStateMachine` returns the screen end event whenever a screen view event is tracked.

## List item view events

List item view events are tracked as the user scrolls through a list view on the screen. Whenever an item in the list is shown, the event should be tracked. It contains two information:

1. The index of the list item shown.
2. The total number of items in the list.

If screen engagement tracking is enabled, the list item view events are aggregated into the `screen_summary` entity. This means that they are not tracked individually, but the maximum index of viewed items and the total number of items are tracked in the entity on the next screen end or background/foreground event.

In JetPack compose app, list item view tracking can be implemented similarly as manual screen view tracking – by adding a `LaunchedEffect` to the list item component. I have updated the compose demo app to include this. The launched effect looks like this:

```kt
        LaunchedEffect(Unit, block = {
            val event = ListItemView(index, itemsCount)
            Snowplow.defaultTracker?.track(event)
        })
```

## Scroll changed events

Scroll changed events are similar to the list item view events. They are tracked when the position of a scroll view changes – when the user scrolls. In contrast with the list item view events, the scroll changed events track the position in pixels.

Users will need to implement them manually since we can't provide automatic tracking. In Android Activities, this is a matter of adding a listener for on scroll changed and tracking a `ScrollChanged` event with the current position. The event will be aggregated into the `screen_summary` entity and populate the properties `max_y_offset` and `content_height`.

## Iglu Central PR with schemas

Schemas for the new events and entity are not yet published on Iglu Central, they are [in review in this PR](https://github.com/snowplow/iglu-central/pull/1358).

## Demo

I have recorded a demo of [how the screen engagement tracking works here](https://snplow.atlassian.net/browse/PE-5762?focusedCommentId=70520).