### PR TITLE
Updates to internal emitter

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
@@ -120,8 +120,7 @@ class StateManagerTest {
     fun testScreenStateMachine() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val eventStore = MockEventStore()
-        val builder = { emitter: Emitter -> emitter.eventStore = eventStore }
-        val emitter = Emitter(context, "http://snowplow-fake-url.com", builder)
+        val emitter = Emitter("namespace", eventStore, context, "http://snowplow-fake-url.com")
         val trackerBuilder = { tracker: Tracker ->
             tracker.screenContext = true
             tracker.sessionContext = false
@@ -216,8 +215,7 @@ class StateManagerTest {
     fun testLifecycleStateMachine() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val eventStore = MockEventStore()
-        val builder = { emitter: Emitter -> emitter.eventStore = eventStore }
-        val emitter = Emitter(context, "http://snowplow-fake-url.com", builder)
+        val emitter = Emitter("namespace", eventStore, context, "http://snowplow-fake-url.com")
         val trackerBuilder = { tracker: Tracker ->
             tracker.lifecycleAutotracking = true
             tracker.base64Encoded = false
@@ -290,8 +288,7 @@ class StateManagerTest {
     fun testDeepLinkStateMachine() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val eventStore = MockEventStore()
-        val builder = { emitter: Emitter -> emitter.eventStore = eventStore }
-        val emitter = Emitter(context, "http://snowplow-fake-url.com", builder)
+        val emitter = Emitter("namespace", eventStore, context, "http://snowplow-fake-url.com")
         val trackerBuilder = { tracker: Tracker ->
             tracker.deepLinkContext = true
             tracker.base64Encoded = false

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
@@ -57,13 +57,9 @@ class TrackerTest {
             
             val emitter = Companion.tracker!!.emitter
             val eventStore = emitter.eventStore
-            if (eventStore != null) {
-                val isClean = eventStore.removeAllEvents()
-                Log.i("TrackerTest", "EventStore cleaned: $isClean")
-                Log.i("TrackerTest", "Events in the store: " + eventStore.size())
-            } else {
-                Log.i("TrackerTest", "EventStore null")
-            }
+            val isClean = eventStore.removeAllEvents()
+            Log.i("TrackerTest", "EventStore cleaned: $isClean")
+            Log.i("TrackerTest", "Events in the store: " + eventStore.size())
             emitter.shutdown(30)
             Companion.tracker!!.close()
             Log.i("TrackerTest", "Tracker closed")
@@ -85,7 +81,7 @@ class TrackerTest {
             emitter.emptyLimit = 0
         }
         val emitter = Emitter(
-            context, "testUrl", builder
+            "myNamespace", null, context, "testUrl", builder
         )
         val subject = Subject(
             context, null
@@ -136,7 +132,7 @@ class TrackerTest {
     fun testEmitterUpdate() {
         val tracker = tracker
         Assert.assertNotNull(tracker!!.emitter)
-        tracker.emitter = Emitter(context, "test", null)
+        tracker.emitter = Emitter(tracker.namespace, null, context, "test", null)
         Assert.assertNotNull(tracker.emitter)
     }
 
@@ -193,7 +189,7 @@ class TrackerTest {
                 emitterArg.requestSecurity = Protocol.HTTP
             }
         try {
-            emitter = Emitter(context, getMockServerURI(mockWebServer)!!, builder)
+            emitter = Emitter(namespace, null, context, getMockServerURI(mockWebServer)!!, builder)
         } catch (e: Exception) {
             e.printStackTrace()
             Assert.fail("Exception on Emitter creation")
@@ -211,10 +207,8 @@ class TrackerTest {
         Companion.tracker =
             Tracker(emitter!!, namespace, "testTrackWithNoContext", null, context, trackerBuilder)
         val eventStore = emitter.eventStore
-        if (eventStore != null) {
-            val isClean = eventStore.removeAllEvents()
-            Log.i("testTrackSelfDescribingEvent", "EventStore clean: $isClean")
-        }
+        val isClean = eventStore.removeAllEvents()
+        Log.i("testTrackSelfDescribingEvent", "EventStore clean: $isClean")
         Log.i("testTrackSelfDescribingEvent", "Send SelfDescribing event")
         val sdj = SelfDescribingJson("iglu:foo/bar/jsonschema/1-0-0")
         val sdEvent = SelfDescribing(sdj)
@@ -255,7 +249,7 @@ class TrackerTest {
                 emitterArg.requestSecurity = Protocol.HTTP
             }
         try {
-            emitter = Emitter(context, getMockServerURI(mockWebServer)!!, emitterBuilder)
+            emitter = Emitter(namespace, null, context, getMockServerURI(mockWebServer)!!, emitterBuilder)
         } catch (e: Exception) {
             e.printStackTrace()
             Assert.fail("Exception on Emitter creation")
@@ -313,7 +307,7 @@ class TrackerTest {
         val mockWebServer = getMockServer(1)
         val builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
         val emitter = Emitter(
-            context, getMockServerURI(mockWebServer)!!, builder
+            namespace, null, context, getMockServerURI(mockWebServer)!!, builder
         )
         val trackerBuilder = { tracker: Tracker ->
             tracker.base64Encoded = false
@@ -330,7 +324,7 @@ class TrackerTest {
         val eventId = Companion.tracker!!.track(ScreenView("name"))
         Assert.assertNull(eventId)
         val req = mockWebServer.takeRequest(2, TimeUnit.SECONDS)
-        Assert.assertEquals(0, Companion.tracker!!.emitter.eventStore!!.size())
+        Assert.assertEquals(0, Companion.tracker!!.emitter.eventStore.size())
         Assert.assertNull(req)
         mockWebServer.shutdown()
     }
@@ -345,7 +339,7 @@ class TrackerTest {
         val mockWebServer = getMockServer(1)
         val builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
         val emitter = Emitter(
-            context, getMockServerURI(mockWebServer)!!, builder
+            namespace, null, context, getMockServerURI(mockWebServer)!!, builder
         )
         val trackerBuilder = { tracker: Tracker ->
             tracker.base64Encoded = false
@@ -373,7 +367,7 @@ class TrackerTest {
         TestUtils.createSessionSharedPreferences(context, namespace)
         val builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
         val emitter = Emitter(
-            context, "fake-uri", builder
+            namespace, null, context, "fake-uri", builder
         )
         val trackerBuilder = { tracker: Tracker ->
             tracker.base64Encoded = false
@@ -422,7 +416,7 @@ class TrackerTest {
             Thread.getDefaultUncaughtExceptionHandler().javaClass
         )
         val emitter = Emitter(
-            context, "com.acme", null
+            namespace, null, context, "com.acme", null
         )
         val trackerBuilder = { tracker: Tracker ->
             tracker.base64Encoded = false
@@ -450,7 +444,7 @@ class TrackerTest {
             Thread.getDefaultUncaughtExceptionHandler().javaClass
         )
         val emitter = Emitter(
-            context, "com.acme", null
+            namespace, null, context, "com.acme", null
         )
         val trackerBuilder = { tracker: Tracker ->
             tracker.base64Encoded = false
@@ -475,7 +469,7 @@ class TrackerTest {
     @Test
     fun testStartsNewSessionWhenChangingAnonymousTracking() {
         val emitterBuilder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
-        val emitter = Emitter(context, "fake-uri", emitterBuilder)
+        val emitter = Emitter("ns", null, context, "fake-uri", emitterBuilder)
         emitter.pauseEmit()
         
         val trackerBuilder = { tracker: Tracker ->

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
@@ -91,7 +91,6 @@ class TrackerTest {
             tracker.platform = DevicePlatform.InternetOfThings
             tracker.base64Encoded = false
             tracker.logLevel = LogLevel.VERBOSE
-            tracker.threadCount = 1
             tracker.sessionContext = false
             tracker.platformContextEnabled = false
             tracker.geoLocationContext = false
@@ -121,7 +120,6 @@ class TrackerTest {
         Assert.assertNotNull(tracker.emitter)
         Assert.assertNotNull(tracker.subject)
         Assert.assertEquals(LogLevel.VERBOSE, tracker.logLevel)
-        Assert.assertEquals(2, tracker.threadCount.toLong())
         Assert.assertFalse(tracker.exceptionAutotracking)
         Assert.assertTrue(tracker.lifecycleAutotracking)
         Assert.assertTrue(tracker.installAutotracking)

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/EmitterTest.kt
@@ -33,23 +33,23 @@ class EmitterTest {
     @Test
     fun testHttpMethodSet() {
         var builder = { emitter: Emitter -> emitter.httpMethod = HttpMethod.GET }
-        var emitter = Emitter(context, "com.acme", builder)
+        var emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(HttpMethod.GET, emitter.httpMethod)
         builder = { emitter1: Emitter -> emitter1.httpMethod = HttpMethod.POST }
-        emitter = Emitter(context, "com.acme", builder)
+        emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(HttpMethod.POST, emitter.httpMethod)
     }
 
     @Test
     fun testBufferOptionSet() {
         var builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
-        var emitter = Emitter(context, "com.acme", builder)
+        var emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(BufferOption.Single, emitter.bufferOption)
         builder = { emitter1: Emitter -> emitter1.bufferOption = BufferOption.SmallGroup }
-        emitter = Emitter(context, "com.acme", builder)
+        emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(BufferOption.SmallGroup, emitter.bufferOption)
         builder = { emitter2: Emitter -> emitter2.bufferOption = BufferOption.LargeGroup }
-        emitter = Emitter(context, "com.acme", builder)
+        emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(BufferOption.LargeGroup, emitter.bufferOption)
     }
 
@@ -61,7 +61,7 @@ class EmitterTest {
                 override fun onFailure(successCount: Int, failureCount: Int) {}
             }
         }
-        val emitter = Emitter(context, "com.acme", builder)
+        val emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertNotNull(emitter.requestCallback)
     }
 
@@ -73,14 +73,14 @@ class EmitterTest {
             emitter.httpMethod = HttpMethod.GET
             emitter.requestSecurity = Protocol.HTTP
         }
-        var emitter = Emitter(context, uri, builder)
+        var emitter = Emitter("ns", MockEventStore(), context, uri, builder)
         Assert.assertEquals("http://$uri/i", emitter.emitterUri)
         builder = { emitter1: Emitter ->
             emitter1.bufferOption = BufferOption.SmallGroup
             emitter1.httpMethod = HttpMethod.POST
             emitter1.requestSecurity = Protocol.HTTP
         }
-        emitter = Emitter(context, uri, builder)
+        emitter = Emitter("ns", MockEventStore(), context, uri, builder)
         Assert.assertEquals(
             "http://$uri/com.snowplowanalytics.snowplow/tp2",
             emitter.emitterUri
@@ -90,59 +90,59 @@ class EmitterTest {
             emitter2.httpMethod = HttpMethod.GET
             emitter2.requestSecurity = Protocol.HTTPS
         }
-        emitter = Emitter(context, uri, builder)
+        emitter = Emitter("ns", MockEventStore(), context, uri, builder)
         Assert.assertEquals("https://$uri/i", emitter.emitterUri)
         builder = { emitter3: Emitter ->
             emitter3.bufferOption = BufferOption.SmallGroup
             emitter3.httpMethod = HttpMethod.POST
             emitter3.requestSecurity = Protocol.HTTPS
         }
-        emitter = Emitter(context, uri, builder)
+        emitter = Emitter("ns", MockEventStore(), context, uri, builder)
         Assert.assertEquals("https://$uri/com.snowplowanalytics.snowplow/tp2", emitter.emitterUri)
     }
 
     @Test
     fun testSecuritySet() {
         var builder = { emitter: Emitter -> emitter.requestSecurity = Protocol.HTTP }
-        var emitter = Emitter(context, "com.acme", builder)
+        var emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(Protocol.HTTP, emitter.requestSecurity)
         builder = { emitter1: Emitter -> emitter1.requestSecurity = Protocol.HTTPS }
-        emitter = Emitter(context, "com.acme", builder)
+        emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(Protocol.HTTPS, emitter.requestSecurity)
     }
 
     @Test
     fun testTickSet() {
         val builder = { emitter: Emitter -> emitter.emitterTick = 0 }
-        val emitter = Emitter(context, "com.acme", builder)
+        val emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(0, emitter.emitterTick.toLong())
     }
 
     @Test
     fun testEmptyLimitSet() {
         val builder = { emitter: Emitter -> emitter.emptyLimit = 0 }
-        val emitter = Emitter(context, "com.acme", builder)
+        val emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(0, emitter.emptyLimit.toLong())
     }
 
     @Test
     fun testSendLimitSet() {
         val builder = { emitter: Emitter -> emitter.emitRange = 200 }
-        val emitter = Emitter(context, "com.acme", builder)
+        val emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(200, emitter.emitRange.toLong())
     }
 
     @Test
     fun testByteLimitGetSet() {
         val builder = { emitter: Emitter -> emitter.byteLimitGet = 20000 }
-        val emitter = Emitter(context, "com.acme", builder)
+        val emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(20000, emitter.byteLimitGet)
     }
 
     @Test
     fun testByteLimitPostSet() {
         val builder = { emitter: Emitter -> emitter.byteLimitPost = 25000 }
-        val emitter = Emitter(context, "com.acme", builder)
+        val emitter = Emitter("ns", MockEventStore(), context, "com.acme", builder)
         Assert.assertEquals(25000, emitter.byteLimitPost)
     }
 
@@ -159,10 +159,9 @@ class EmitterTest {
             emitter.emitRange = 200
             emitter.byteLimitGet = 20000
             emitter.byteLimitPost = 25000
-            emitter.eventStore = MockEventStore()
             emitter.timeUnit = TimeUnit.MILLISECONDS
         }
-        val emitter = Emitter(context, uri, builder)
+        val emitter = Emitter("ns", MockEventStore(), context, uri, builder)
         Assert.assertFalse(emitter.emitterStatus)
         Assert.assertEquals(BufferOption.Single, emitter.bufferOption)
         Assert.assertEquals("http://$uri/com.snowplowanalytics.snowplow/tp2", emitter.emitterUri)
@@ -201,11 +200,10 @@ class EmitterTest {
             emitter1.emitRange = 200
             emitter1.byteLimitGet = 20000
             emitter1.byteLimitPost = 50000
-            emitter1.eventStore = MockEventStore()
             emitter1.timeUnit = TimeUnit.MILLISECONDS
             emitter1.customPostPath = "com.acme.company/tpx"
         }
-        val customPathEmitter = Emitter(context, uri, builder)
+        val customPathEmitter = Emitter("ns", MockEventStore(), context, uri, builder)
         Assert.assertEquals("com.acme.company/tpx", customPathEmitter.customPostPath)
         Assert.assertEquals("http://$uri/com.acme.company/tpx", customPathEmitter.emitterUri)
         customPathEmitter.shutdown()
@@ -237,7 +235,7 @@ class EmitterTest {
         Assert.assertEquals(1, networkConnection.previousResults.size.toLong())
         Assert.assertEquals(1, networkConnection.previousResults[0].size.toLong())
         Assert.assertTrue(networkConnection.previousResults[0][0].isSuccessful)
-        Assert.assertEquals(0, emitter.eventStore!!.size())
+        Assert.assertEquals(0, emitter.eventStore.size())
         emitter.flush()
     }
 
@@ -255,7 +253,7 @@ class EmitterTest {
         Assert.assertEquals(1, networkConnection.previousResults.size.toLong())
         Assert.assertEquals(1, networkConnection.previousResults[0].size.toLong())
         Assert.assertFalse(networkConnection.previousResults[0][0].isSuccessful)
-        Assert.assertEquals(1, emitter.eventStore!!.size())
+        Assert.assertEquals(1, emitter.eventStore.size())
         emitter.flush()
     }
 
@@ -272,7 +270,7 @@ class EmitterTest {
             Thread.sleep(600)
             i++
         }
-        Assert.assertEquals(0, emitter.eventStore!!.size())
+        Assert.assertEquals(0, emitter.eventStore.size())
         var totEvents = 0
         for (results in networkConnection.previousResults) {
             for (result in results) {
@@ -297,7 +295,7 @@ class EmitterTest {
             Thread.sleep(600)
             i++
         }
-        Assert.assertEquals(2, emitter.eventStore!!.size())
+        Assert.assertEquals(2, emitter.eventStore.size())
         for (results in networkConnection.previousResults) {
             for (result in results) {
                 Assert.assertFalse(result.isSuccessful)
@@ -321,7 +319,7 @@ class EmitterTest {
         Assert.assertEquals(1, networkConnection.previousResults.size.toLong())
         Assert.assertEquals(1, networkConnection.previousResults[0].size.toLong())
         Assert.assertTrue(networkConnection.previousResults[0][0].isSuccessful)
-        Assert.assertEquals(0, emitter.eventStore!!.size())
+        Assert.assertEquals(0, emitter.eventStore.size())
         emitter.flush()
     }
 
@@ -337,7 +335,7 @@ class EmitterTest {
         Assert.assertEquals(false, emitter.emitterStatus)
         Assert.assertEquals(0, networkConnection.sendingCount().toLong())
         Assert.assertEquals(0, networkConnection.previousResults.size.toLong())
-        Assert.assertEquals(1, emitter.eventStore!!.size())
+        Assert.assertEquals(1, emitter.eventStore.size())
         
         emitter.resumeEmit()
         var i = 0
@@ -348,15 +346,14 @@ class EmitterTest {
         Assert.assertEquals(1, networkConnection.previousResults.size.toLong())
         Assert.assertEquals(1, networkConnection.previousResults[0].size.toLong())
         Assert.assertTrue(networkConnection.previousResults[0][0].isSuccessful)
-        Assert.assertEquals(0, emitter.eventStore!!.size())
+        Assert.assertEquals(0, emitter.eventStore.size())
         emitter.flush()
     }
 
     @Test
     @Throws(InterruptedException::class)
     fun testUpdatesNetworkConnectionWhileRunning() {
-        val builder = { emitter: Emitter -> emitter.eventStore = MockEventStore() }
-        val emitter = Emitter(context, "com.acme", builder)
+        val emitter = Emitter("ns", MockEventStore(), context, "com.acme")
         emitter.flush()
         Thread.sleep(100)
         Assert.assertTrue(emitter.emitterStatus) // is running
@@ -378,7 +375,7 @@ class EmitterTest {
         }
         Assert.assertEquals(1, networkConnection.previousResults.size.toLong())
         Assert.assertFalse(networkConnection.previousResults[0][0].isSuccessful)
-        Assert.assertEquals(0, emitter.eventStore!!.size())
+        Assert.assertEquals(0, emitter.eventStore.size())
         emitter.flush()
     }
 
@@ -395,14 +392,14 @@ class EmitterTest {
         // no events in queue since they were dropped because retrying is disabled for 500
         emitter.add(generatePayloads(1)[0])
         Thread.sleep(1000)
-        Assert.assertEquals(0, emitter.eventStore!!.size())
+        Assert.assertEquals(0, emitter.eventStore.size())
         
         networkConnection.statusCode = 403
         emitter.add(generatePayloads(1)[0])
         Thread.sleep(1000)
 
         // event still in queue because retrying is enabled for 403
-        Assert.assertEquals(1, emitter.eventStore!!.size())
+        Assert.assertEquals(1, emitter.eventStore.size())
         Assert.assertEquals(2, networkConnection.previousResults.size.toLong())
         emitter.flush()
     }
@@ -417,14 +414,14 @@ class EmitterTest {
         // no events in queue since they were dropped because retrying is disabled
         emitter.add(generatePayloads(1)[0])
         Thread.sleep(1000)
-        Assert.assertEquals(0, emitter.eventStore!!.size())
+        Assert.assertEquals(0, emitter.eventStore.size())
 
         emitter.retryFailedRequests = true
         emitter.add(generatePayloads(1)[0])
         Thread.sleep(1000)
 
         // event still in queue because retrying is enabled
-        Assert.assertEquals(1, emitter.eventStore!!.size())
+        Assert.assertEquals(1, emitter.eventStore.size())
         Assert.assertEquals(2, networkConnection.previousResults.size.toLong())
         emitter.flush()
     }
@@ -441,13 +438,13 @@ class EmitterTest {
 
         // all events waiting in queue
         Assert.assertEquals(0, networkConnection.previousResults.size)
-        Assert.assertEquals(9, emitter.eventStore!!.size())
+        Assert.assertEquals(9, emitter.eventStore.size())
 
         emitter.add(generatePayloads(1)[0])
         Thread.sleep(1000)
 
         // all events sent
-        Assert.assertEquals(0, emitter.eventStore!!.size())
+        Assert.assertEquals(0, emitter.eventStore.size())
         Assert.assertEquals(1, networkConnection.previousResults.size)
         emitter.flush()
     }
@@ -463,7 +460,7 @@ class EmitterTest {
             emitter.add(payload)
         }
         Thread.sleep(500)
-        Assert.assertEquals(20, emitter.eventStore!!.size())
+        Assert.assertEquals(20, emitter.eventStore.size())
         emitter.resumeEmit()
         Thread.sleep(500)
 
@@ -478,7 +475,7 @@ class EmitterTest {
             emitter.add(payload)
         }
         Thread.sleep(500)
-        Assert.assertEquals(40, emitter.eventStore!!.size())
+        Assert.assertEquals(40, emitter.eventStore.size())
         emitter.resumeEmit()
 
         Thread.sleep(500)
@@ -497,7 +494,7 @@ class EmitterTest {
             emitter.add(payload)
         }
         Thread.sleep(500)
-        Assert.assertEquals(2, emitter.eventStore!!.size())
+        Assert.assertEquals(2, emitter.eventStore.size())
         emitter.resumeEmit()
 
         Thread.sleep(500)
@@ -519,11 +516,10 @@ class EmitterTest {
             emitter.emitRange = 200
             emitter.byteLimitGet = 20000
             emitter.byteLimitPost = 25000
-            emitter.eventStore = MockEventStore()
             emitter.timeUnit = TimeUnit.SECONDS
             emitter.tlsVersions = EnumSet.of(TLSVersion.TLSv1_2)
         }
-        return Emitter(context, "com.acme", builder)
+        return Emitter("ns", MockEventStore(), context, "com.acme", builder)
     }
 
     // Service methods

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/LoggingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/LoggingTest.kt
@@ -53,7 +53,7 @@ class LoggingTest {
     fun setUp() {
         mockLoggerDelegate = MockLoggerDelegate()
         val builder = { emitter: Emitter -> emitter.bufferOption = BufferOption.Single }
-        emitter = Emitter(ApplicationProvider.getApplicationContext(), "http://localhost", builder)
+        emitter = Emitter("namespace", null, ApplicationProvider.getApplicationContext(), "http://localhost", builder)
         networkConfig = NetworkConfiguration("http://localhost", HttpMethod.POST)
     }
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.kt
@@ -210,7 +210,7 @@ class SessionTest {
         cleanSharedPreferences(context, TrackerConstants.SNOWPLOW_SESSION_VARS + "_tracker")
         
         val emitter = Emitter(
-            context, "", null
+            "tracker", null, context, "", null
         )
         val trackerBuilder = { tracker: Tracker ->
             tracker.sessionContext = true
@@ -249,7 +249,7 @@ class SessionTest {
     fun testBackgroundTimeSmallerThanBackgroundTimeoutDoesntCauseNewSession() {
         cleanSharedPreferences(context, TrackerConstants.SNOWPLOW_SESSION_VARS + "_tracker")
         val emitter = Emitter(
-            context, "", null
+            "tracker", null, context, "", null
         )
         val trackerBuilder = { tracker: Tracker ->
             tracker.sessionContext = true
@@ -331,7 +331,7 @@ class SessionTest {
         cleanSharedPreferences(context, TrackerConstants.SNOWPLOW_SESSION_VARS + "_tracker1")
         cleanSharedPreferences(context, TrackerConstants.SNOWPLOW_SESSION_VARS + "_tracker2")
         val emitter = Emitter(
-            context, "", null
+            "ns", null, context, "", null
         )
         val trackerBuilder = { tracker: Tracker ->
             tracker.sessionContext = true

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
@@ -53,9 +53,9 @@ class EventSendingTest {
             if (tracker == null) return
             val emitter = tracker!!.emitter
             tracker!!.close()
-            val isClean = emitter.eventStore!!.removeAllEvents()
+            val isClean = emitter.eventStore.removeAllEvents()
             Log.i("TrackerTest", "Tracker closed - EventStore cleaned: $isClean")
-            Log.i("TrackerTest", "Events in the store: " + emitter.eventStore!!.size())
+            Log.i("TrackerTest", "Events in the store: " + emitter.eventStore.size())
         } catch (e: IllegalStateException) {
             Log.i("TrackerTest", "Tracker already closed.")
         }
@@ -204,7 +204,7 @@ class EventSendingTest {
             emitter.emptyLimit = 0
             emitter.emitRange = 1
         }
-        val emitter = Emitter(InstrumentationRegistry.getInstrumentation().targetContext, uri, builder)
+        val emitter = Emitter(ns, null, InstrumentationRegistry.getInstrumentation().targetContext, uri, builder)
         val subject = Subject(InstrumentationRegistry.getInstrumentation().targetContext, null)
         
         if (tracker != null) tracker!!.close()
@@ -225,7 +225,7 @@ class EventSendingTest {
             InstrumentationRegistry.getInstrumentation().targetContext,
             trackerBuilder
         )
-        emitter.eventStore!!.removeAllEvents()
+        emitter.eventStore.removeAllEvents()
         return tracker!!
     }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterDefaults.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterDefaults.kt
@@ -29,7 +29,7 @@ object EmitterDefaults {
     var emptyLimit = 5
     var byteLimitGet: Long = 40000
     var byteLimitPost: Long = 40000
-    var emitTimeout = 5
+    var emitTimeout = 30
     var threadPoolSize = 15
     var serverAnonymisation = false
     var retryFailedRequests = true

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Executor.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Executor.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.Future
 object Executor {
     private var executor: ExecutorService? = null
     
-    var threadCount = 2 // Minimum amount of threads.
+    var threadCount = EmitterDefaults.threadPoolSize
         /**
          * Changes the amount of threads the scheduler will be able to use.
          *

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -236,7 +236,6 @@ class ServiceProvider(
             emitter.emitTimeout = networkConfiguration.timeout
             emitter.emitRange = emitterConfiguration.emitRange
             emitter.bufferOption = emitterConfiguration.bufferOption
-            emitter.eventStore = emitterConfiguration.eventStore
             emitter.byteLimitPost = emitterConfiguration.byteLimitPost
             emitter.byteLimitGet = emitterConfiguration.byteLimitGet
             emitter.threadPoolSize = emitterConfiguration.threadPoolSize
@@ -247,7 +246,13 @@ class ServiceProvider(
             emitter.retryFailedRequests = emitterConfiguration.retryFailedRequests
         }
         
-        val emitter = Emitter(context, endpoint, builder)
+        val emitter = Emitter(
+            namespace = namespace,
+            eventStore = emitterConfiguration.eventStore,
+            context = context,
+            collectorUri = endpoint,
+            builder = builder
+        )
         if (emitterConfiguration.isPaused) {
             emitter.pauseEmit()
         }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -390,10 +390,6 @@ class Tracker(
         
         emitter.flush()
         
-        // Setting the emitter namespace has a side-effect of creating a SQLiteEventStore,
-        // unless an EventStore was already provided through EmitterConfiguration
-        emitter.namespace = namespace
-        
         trackerVersionSuffix?.let {
             val suffix = it.replace("[^A-Za-z0-9.-]".toRegex(), "")
             if (suffix.isNotEmpty()) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -20,7 +20,6 @@ import com.snowplowanalytics.core.emitter.Executor.execute
 import com.snowplowanalytics.core.gdpr.Gdpr
 import com.snowplowanalytics.core.screenviews.ScreenState
 import com.snowplowanalytics.core.screenviews.ScreenStateMachine
-import com.snowplowanalytics.core.screenviews.ScreenSummaryState
 import com.snowplowanalytics.core.screenviews.ScreenSummaryStateMachine
 import com.snowplowanalytics.core.session.ProcessObserver.Companion.initialize
 import com.snowplowanalytics.core.session.Session
@@ -127,17 +126,6 @@ class Tracker(
         set(timeout) {
             if (!builderFinished) {
                 field = timeout
-            }
-        }
-
-    /**
-     * This configuration option is not published in the TrackerConfiguration class.
-     * Create a Tracker directly, not via the Snowplow interface, to configure threadCount.
-     */
-    var threadCount: Int = TrackerDefaults.threadCount
-        set(threadCount) {
-            if (!builderFinished) {
-                field = max(threadCount, 2)
             }
         }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
@@ -361,7 +361,7 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
      * @return a RequestResult
      */
     private fun requestSender(request: okhttp3.Request): Int {
-        return try {
+        try {
             Logger.v(TAG, "Sending request: %s", request)
             TrafficStats.setThreadStatsTag(TRAFFIC_STATS_TAG)
             val resp = client?.newCall(request)?.execute()
@@ -369,10 +369,10 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
                 resp.body?.close()
                 return resp.code
             }
-            -1
+            return -1
         } catch (e: IOException) {
             Logger.e(TAG, "Request sending failed: %s", e.toString())
-            -1
+            return -1
         }
     }
 


### PR DESCRIPTION
**Change default emit timeout from 5 seconds to 30 seconds (#658)**
The default timeout for the whole request duration in emitter was set to 5 seconds. This is far from being sufficient on mobile and is a likely cause of the large number of duplicate event reports that we have seen. On slow connections, the request may easily take more than 5 seconds, especially if the phone is switching between cellular and wifi connections.

I have changed it to 30s as we already have a 15s timeout for connection and 15s timeout for read response in the okhttp client config. On iOS, we don't change the default request timeouts which are set to 60 seconds.

**Update Emitter constructor to accept namespace and event store and make them immutable**
Similar to the change on iOS, this moves the namespace and event store to the constructor of the Emitter. This enables removing some optional and makes the properties immutable and safer.

**Fix returning error from network connection requests**
This is a fix for a bug that prevented us returning an error value to the emitter when executing a request.

**Remove unused threadCount property from Tracker**
Minor update that just removes an unused property in the tracker which confused me (there is a similar one in the emitter config).

**Set default thread count in Executor to match the default thread pool size in the Emitter**
Updates the default thread count in Executor to match the default thread pool size in emitter config. The thread count in Executor is controlled by the thread pool size in the emitter.