### PR TITLE
Add configurable limit for the maximum age and number of events in the event store and remove old events before sending (close #660)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreTest.kt
@@ -166,7 +166,7 @@ class EventStoreTest {
     @Throws(InterruptedException::class)
     fun testRemoveRangeOfEvents() {
         val eventStore = eventStore()
-        val idList: MutableList<Long?> = ArrayList()
+        val idList: MutableList<Long> = ArrayList()
         idList.add(eventStore.insertEvent(payload()))
         idList.add(eventStore.insertEvent(payload()))
         idList.add(eventStore.insertEvent(payload()))

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockEventStore.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockEventStore.kt
@@ -38,7 +38,7 @@ class MockEventStore : EventStore {
         }
     }
 
-    override fun removeEvents(ids: MutableList<Long?>): Boolean {
+    override fun removeEvents(ids: MutableList<Long>): Boolean {
         var result = true
         for (id in ids) {
             val removed = removeEvent(id!!)
@@ -60,11 +60,11 @@ class MockEventStore : EventStore {
         return db.size.toLong()
     }
 
-    override fun getEmittableEvents(queryLimit: Int): List<EmitterEvent?> {
+    override fun getEmittableEvents(queryLimit: Int): List<EmitterEvent> {
         synchronized(this) {
             val eventIds: MutableList<Long> = ArrayList()
             val eventPayloads: MutableList<String> = ArrayList()
-            var events: MutableList<EmitterEvent?> = ArrayList()
+            var events: MutableList<EmitterEvent> = ArrayList()
             for ((key, value) in db) {
                 val payloadCopy: Payload = TrackerPayload()
                 payloadCopy.addMap(value!!.map)

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockEventStore.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/MockEventStore.kt
@@ -19,6 +19,7 @@ import com.snowplowanalytics.snowplow.emitter.EmitterEvent
 import com.snowplowanalytics.snowplow.payload.TrackerPayload
 import java.util.ArrayList
 import java.util.HashMap
+import kotlin.time.Duration
 
 class MockEventStore : EventStore {
     var db = HashMap<Long, Payload?>()
@@ -80,5 +81,9 @@ class MockEventStore : EventStore {
             v("MockEventStore", "getEmittableEvents payloads: %s", eventPayloads)
             return events
         }
+    }
+
+    override fun removeOldEvents(maxSize: Long, maxAge: Duration) {
+        // "Not implemented in the mock event store"
     }
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
@@ -544,7 +544,7 @@ class Emitter(
         var successCount = 0
         var failedWillRetryCount = 0
         var failedWontRetryCount = 0
-        val removableEvents: MutableList<Long?> = ArrayList()
+        val removableEvents: MutableList<Long> = ArrayList()
 
         for (res in results) {
             if (res.isSuccessful) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterConfigurationInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterConfigurationInterface.kt
@@ -15,6 +15,7 @@ package com.snowplowanalytics.core.emitter
 import com.snowplowanalytics.snowplow.emitter.BufferOption
 import com.snowplowanalytics.snowplow.emitter.EventStore
 import com.snowplowanalytics.snowplow.network.RequestCallback
+import kotlin.time.Duration
 
 interface EmitterConfigurationInterface {
     /**
@@ -71,4 +72,16 @@ interface EmitterConfigurationInterface {
      * If disabled, events that failed to be sent will be dropped regardless of other configuration (such as the customRetryForStatusCodes).
      */
     var retryFailedRequests: Boolean
+
+    /**
+     * Limit for the maximum duration of how long events should be kept in the event store if they fail to be sent.
+     * Defaults to 30 days.
+     */
+    var maxEventStoreAge: Duration
+
+    /**
+     * Limit for the maximum number of unsent events to keep in the event store.
+     * Defaults to 1000.
+     */
+    var maxEventStoreSize: Long
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterControllerImpl.kt
@@ -21,6 +21,7 @@ import com.snowplowanalytics.snowplow.controller.EmitterController
 import com.snowplowanalytics.snowplow.emitter.BufferOption
 import com.snowplowanalytics.snowplow.emitter.EventStore
 import com.snowplowanalytics.snowplow.network.RequestCallback
+import kotlin.time.Duration
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 class EmitterControllerImpl(serviceProvider: ServiceProviderInterface) :
@@ -89,6 +90,20 @@ class EmitterControllerImpl(serviceProvider: ServiceProviderInterface) :
         set(value) {
             dirtyConfig.retryFailedRequests = value
             emitter.retryFailedRequests = value
+        }
+
+    override var maxEventStoreAge: Duration
+        get() = emitter.maxEventStoreAge
+        set(value) {
+            dirtyConfig.maxEventStoreAge = value
+            emitter.maxEventStoreAge = value
+        }
+
+    override var maxEventStoreSize: Long
+        get() = emitter.maxEventStoreSize
+        set(value) {
+            dirtyConfig.maxEventStoreSize = value
+            emitter.maxEventStoreSize = value
         }
 
     override val dbCount: Long

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterDefaults.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterDefaults.kt
@@ -18,6 +18,8 @@ import com.snowplowanalytics.snowplow.network.Protocol
 
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 object EmitterDefaults {
     var httpMethod = HttpMethod.POST
@@ -34,4 +36,6 @@ object EmitterDefaults {
     var serverAnonymisation = false
     var retryFailedRequests = true
     var timeUnit = TimeUnit.SECONDS
+    var maxEventStoreAge = 30.toDuration(DurationUnit.DAYS)
+    var maxEventStoreSize: Long = 1000
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/storage/SQLiteEventStore.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/storage/SQLiteEventStore.kt
@@ -135,7 +135,7 @@ class SQLiteEventStore(context: Context, private val namespace: String) : EventS
         return retval == 1
     }
 
-    override fun removeEvents(ids: MutableList<Long?>): Boolean {
+    override fun removeEvents(ids: MutableList<Long>): Boolean {
         if (ids.isEmpty()) {
             return false
         }
@@ -215,12 +215,12 @@ class SQLiteEventStore(context: Context, private val namespace: String) : EventS
         }
     }
 
-    override fun getEmittableEvents(queryLimit: Int): List<EmitterEvent?> {
+    override fun getEmittableEvents(queryLimit: Int): List<EmitterEvent> {
         if (!databaseOpen) {
             return emptyList<EmitterEvent>()
         }
         insertWaitingEventsIfReady()
-        val events = ArrayList<EmitterEvent?>()
+        val events = ArrayList<EmitterEvent>()
 
         // FIFO Pattern for sending events
         for (eventMetadata in getDescEventsInRange(queryLimit)) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -244,6 +244,8 @@ class ServiceProvider(
             emitter.serverAnonymisation = emitterConfiguration.serverAnonymisation
             emitter.requestHeaders = networkConfiguration.requestHeaders
             emitter.retryFailedRequests = emitterConfiguration.retryFailedRequests
+            emitter.maxEventStoreAge = emitterConfiguration.maxEventStoreAge
+            emitter.maxEventStoreSize = emitterConfiguration.maxEventStoreSize
         }
         
         val emitter = Emitter(

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/EventStore.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/EventStore.kt
@@ -36,7 +36,7 @@ interface EventStore {
      * @param ids the events' identifiers in the store.
      * @return a boolean of success to remove.
      */
-    fun removeEvents(ids: MutableList<Long?>): Boolean
+    fun removeEvents(ids: MutableList<Long>): Boolean
 
     /**
      * Empties the store of all the events.
@@ -54,5 +54,5 @@ interface EventStore {
      * Returns a list of [EmitterEvent] objects which contain events and related IDs.
      * @return EmitterEvent objects containing eventIds and event payloads.
      */
-    fun getEmittableEvents(queryLimit: Int): List<EmitterEvent?>
+    fun getEmittableEvents(queryLimit: Int): List<EmitterEvent>
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/EventStore.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/emitter/EventStore.kt
@@ -13,6 +13,7 @@
 package com.snowplowanalytics.snowplow.emitter
 
 import com.snowplowanalytics.snowplow.payload.Payload
+import kotlin.time.Duration
 
 /**
  * The component that persists and buffers events before sending.
@@ -55,4 +56,11 @@ interface EventStore {
      * @return EmitterEvent objects containing eventIds and event payloads.
      */
     fun getEmittableEvents(queryLimit: Int): List<EmitterEvent>
+
+    /**
+     * Remove events older than `maxAge` seconds and keep only the latest `maxSize` events.
+     * @param maxSize the maximum number of events to keep.
+     * @param maxAge the maximum age of events to keep.
+     */
+    fun removeOldEvents(maxSize: Long, maxAge: Duration)
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/RequestResult.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/RequestResult.kt
@@ -23,7 +23,7 @@ import java.util.*
 class RequestResult(
     val statusCode: Int,
     val oversize: Boolean,
-    val eventIds: List<Long?>
+    val eventIds: List<Long>
 ) {
     /**
      * @return the requests success status


### PR DESCRIPTION
Issue #660 

The event store is currently unbounded meaning that if events fail to be sent to the collector, they are never removed from the event store. This can lead to it growing endlessly (if for instance an ad blocker blocks the collector domain) which is likely to have an impact on the app.

We should add configurable limits to the event store so that old events are removed. We could have two such limits:

* maximum event store size – in case the number of events surpasses this threshold, oldest events will be removed until we are under the threshold. Default could be 1000.
* maximum event age – in case there are events older than this threshold, we should remove them. Default could be 30 days.

The implementation in this PR adds these limits and enforces them before each emit attempt. They are enforced by running a single SQL statement which should be relatively efficient.

In addition, this PR removes some unnecessary optional types in the event store interface.