### PR TITLE
Fix demo crash when using R8 full mode (close #652)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,3 +50,4 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=snowplow
 POM_DEVELOPER_NAME=Snowplow Analytics
+android.enableR8.fullMode=true

--- a/snowplow-demo-compose/build.gradle
+++ b/snowplow-demo-compose/build.gradle
@@ -20,7 +20,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/snowplow-demo-compose/build.gradle
+++ b/snowplow-demo-compose/build.gradle
@@ -61,6 +61,11 @@ dependencies {
     
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':snowplow-android-tracker')
+
+    implementation 'com.google.android.gms:play-services-appset:16.0.2'
+    implementation 'com.google.android.gms:play-services-ads:22.6.0'
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+    implementation "com.android.installreferrer:installreferrer:2.2"
     
     implementation "com.squareup.retrofit2:retrofit:2.9.0"
     implementation "com.squareup.retrofit2:converter-gson:2.0.0"

--- a/snowplow-demo-compose/proguard-rules.pro
+++ b/snowplow-demo-compose/proguard-rules.pro
@@ -19,3 +19,24 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Fixes R8 full mode bug
+# Also see https://github.com/square/retrofit/issues/3751
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+## Please add these rules to your existing keep rules in order to suppress warnings.
+## This is generated automatically by the Android Gradle plugin.
+#-dontwarn com.android.installreferrer.api.InstallReferrerClient$Builder
+#-dontwarn com.android.installreferrer.api.InstallReferrerClient
+#-dontwarn com.android.installreferrer.api.InstallReferrerStateListener
+#-dontwarn org.bouncycastle.jsse.BCSSLParameters
+#-dontwarn org.bouncycastle.jsse.BCSSLSocket
+#-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+#-dontwarn org.conscrypt.Conscrypt$Version
+#-dontwarn org.conscrypt.Conscrypt
+#-dontwarn org.conscrypt.ConscryptHostnameVerifier
+#-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+#-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+#-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/snowplow-demo-compose/proguard-rules.pro
+++ b/snowplow-demo-compose/proguard-rules.pro
@@ -20,23 +20,17 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# Fixes R8 full mode bug
+# Fixes R8 full mode crash
 # Also see https://github.com/square/retrofit/issues/3751
 -keep,allowobfuscation,allowshrinking interface retrofit2.Call
 -keep,allowobfuscation,allowshrinking class retrofit2.Response
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
-## Please add these rules to your existing keep rules in order to suppress warnings.
-## This is generated automatically by the Android Gradle plugin.
-#-dontwarn com.android.installreferrer.api.InstallReferrerClient$Builder
-#-dontwarn com.android.installreferrer.api.InstallReferrerClient
-#-dontwarn com.android.installreferrer.api.InstallReferrerStateListener
-#-dontwarn org.bouncycastle.jsse.BCSSLParameters
-#-dontwarn org.bouncycastle.jsse.BCSSLSocket
-#-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
-#-dontwarn org.conscrypt.Conscrypt$Version
-#-dontwarn org.conscrypt.Conscrypt
-#-dontwarn org.conscrypt.ConscryptHostnameVerifier
-#-dontwarn org.openjsse.javax.net.ssl.SSLParameters
-#-dontwarn org.openjsse.javax.net.ssl.SSLSocket
-#-dontwarn org.openjsse.net.ssl.OpenJSSE
+# Reflection for the appSetId
+-keep class com.google.android.gms.appset.AppSet { *; }
+-keep class com.google.android.gms.appset.AppSetIdInfo { *; }
+-keep class com.google.android.gms.internal.appset.zzr { *; }
+-keep class com.google.android.gms.tasks.Tasks { *; }
+
+# Reflection for the AAID (AndroidIdfa)
+-keep class com.google.android.gms.ads.identifier.** { *; }

--- a/snowplow-demo-compose/src/main/AndroidManifest.xml
+++ b/snowplow-demo-compose/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Snowplowandroidtracker">
+        <!-- Sample Ad Manager app ID: ca-app-pub-3940256099942544~3347511713 -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713"/>
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -24,5 +28,4 @@
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/snowplow-demo-kotlin/proguard-rules.pro
+++ b/snowplow-demo-kotlin/proguard-rules.pro
@@ -19,3 +19,12 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Reflection for the appSetId
+-keep class com.google.android.gms.appset.AppSet { *; }
+-keep class com.google.android.gms.appset.AppSetIdInfo { *; }
+-keep class com.google.android.gms.internal.appset.zzr { *; }
+-keep class com.google.android.gms.tasks.Tasks { *; }
+
+# Reflection for the AAID (AndroidIdfa)
+-keep class com.google.android.gms.ads.identifier.** { *; }

--- a/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/utils/TrackerEvents.kt
+++ b/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/utils/TrackerEvents.kt
@@ -49,31 +49,28 @@ object TrackerEvents {
     )
     
     fun trackAll(tracker: TrackerController) {
-        
-        
         trackDeepLink(tracker)
-        tracker.track(ScreenEnd())
-//        trackPageView(tracker)
-//        trackStructuredEvent(tracker)
-//        trackScreenView(tracker)
-//        trackTimings(tracker)
-//        trackSelfDescribingEvent(tracker)
-//        trackConsentGranted(tracker)
-//        trackConsentWithdrawn(tracker)
-//        trackMessageNotification(tracker)
-//
-//        // Ecommerce events
-//        trackAddToCart(tracker)
-//        trackRemoveFromCart(tracker)
-//        trackCheckoutStep(tracker)
-//        trackProductView(tracker)
-//        trackProductListView(tracker)
-//        trackProductListClick(tracker)
-//        trackPromotionView(tracker)
-//        trackPromotionClick(tracker)
-//        trackTransaction(tracker)
-//        trackTransactionError(tracker)
-//        trackRefund(tracker)
+        trackPageView(tracker)
+        trackStructuredEvent(tracker)
+        trackScreenView(tracker)
+        trackTimings(tracker)
+        trackSelfDescribingEvent(tracker)
+        trackConsentGranted(tracker)
+        trackConsentWithdrawn(tracker)
+        trackMessageNotification(tracker)
+
+        // Ecommerce events
+        trackAddToCart(tracker)
+        trackRemoveFromCart(tracker)
+        trackCheckoutStep(tracker)
+        trackProductView(tracker)
+        trackProductListView(tracker)
+        trackProductListClick(tracker)
+        trackPromotionView(tracker)
+        trackPromotionClick(tracker)
+        trackTransaction(tracker)
+        trackTransactionError(tracker)
+        trackRefund(tracker)
     }
 
     private fun trackDeepLink(tracker: TrackerController) {

--- a/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/utils/TrackerEvents.kt
+++ b/snowplow-demo-kotlin/src/main/java/com/snowplowanalytics/snowplowdemokotlin/utils/TrackerEvents.kt
@@ -49,28 +49,31 @@ object TrackerEvents {
     )
     
     fun trackAll(tracker: TrackerController) {
+        
+        
         trackDeepLink(tracker)
-        trackPageView(tracker)
-        trackStructuredEvent(tracker)
-        trackScreenView(tracker)
-        trackTimings(tracker)
-        trackSelfDescribingEvent(tracker)
-        trackConsentGranted(tracker)
-        trackConsentWithdrawn(tracker)
-        trackMessageNotification(tracker)
-
-        // Ecommerce events
-        trackAddToCart(tracker)
-        trackRemoveFromCart(tracker)
-        trackCheckoutStep(tracker)
-        trackProductView(tracker)
-        trackProductListView(tracker)
-        trackProductListClick(tracker)
-        trackPromotionView(tracker)
-        trackPromotionClick(tracker)
-        trackTransaction(tracker)
-        trackTransactionError(tracker)
-        trackRefund(tracker)
+        tracker.track(ScreenEnd())
+//        trackPageView(tracker)
+//        trackStructuredEvent(tracker)
+//        trackScreenView(tracker)
+//        trackTimings(tracker)
+//        trackSelfDescribingEvent(tracker)
+//        trackConsentGranted(tracker)
+//        trackConsentWithdrawn(tracker)
+//        trackMessageNotification(tracker)
+//
+//        // Ecommerce events
+//        trackAddToCart(tracker)
+//        trackRemoveFromCart(tracker)
+//        trackCheckoutStep(tracker)
+//        trackProductView(tracker)
+//        trackProductListView(tracker)
+//        trackProductListClick(tracker)
+//        trackPromotionView(tracker)
+//        trackPromotionClick(tracker)
+//        trackTransaction(tracker)
+//        trackTransactionError(tracker)
+//        trackRefund(tracker)
     }
 
     private fun trackDeepLink(tracker: TrackerController) {


### PR DESCRIPTION
For issue #652.

The crash in the Compose demo was caused by missing Retrofit classes when full R8 minification/shrinking is used. This PR adds ProGuard exemption rules for the relevant classes.

Also, dependencies for getting the appSetId and androidIdfa (AAID) platform context entity properties have been added to the Compose demo, along with ProGuard rules so that they still work with R8.