### PR TITLE
Handle errors when fetching screen resolution in Subject (close #657)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SubjectTest.kt
@@ -18,7 +18,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.snowplowanalytics.core.tracker.Logger.updateLogLevel
 import com.snowplowanalytics.core.tracker.Subject
 import com.snowplowanalytics.snowplow.Snowplow.createTracker
-import com.snowplowanalytics.snowplow.network.HttpMethod
 import com.snowplowanalytics.snowplow.util.Size
 import org.junit.Assert
 import org.junit.Test
@@ -129,6 +128,14 @@ class SubjectTest {
         Assert.assertNull(subject.getSubject(true)["duid"])
         Assert.assertNull(subject.getSubject(true)["tnuid"])
         Assert.assertNull(subject.getSubject(true)["ip"])
+    }
+
+    @Test
+    fun testSetsScreenResolutionAutomaticaly() {
+        val subject = createSubject()
+        Assert.assertNotNull(subject.screenResolution)
+        Assert.assertTrue((subject.screenResolution?.width ?: 0) > 0)
+        Assert.assertTrue((subject.screenResolution?.height ?: 0) > 0)
     }
 
     // Helper Methods

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Subject.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Subject.kt
@@ -13,8 +13,6 @@
 package com.snowplowanalytics.core.tracker
 
 import android.content.Context
-import android.graphics.Point
-import android.view.WindowManager
 import com.snowplowanalytics.core.constants.Parameters
 import com.snowplowanalytics.core.tracker.Logger.v
 import com.snowplowanalytics.snowplow.util.Size
@@ -225,11 +223,9 @@ class Subject(context: Context, config: SubjectConfigurationInterface?) {
      * @param context the android context
      */
     private fun setDefaultScreenResolution(context: Context) {
-        val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
-        val display = windowManager?.defaultDisplay
-        val size = Point()
-        display?.getSize(size)
-        screenResolution = (Size(size.x, size.y))
+        val width = context.resources.displayMetrics.widthPixels
+        val height = context.resources.displayMetrics.heightPixels
+        screenResolution = (Size(width, height))
     }
 
     /**


### PR DESCRIPTION
I was unable to replicate the bug reported in #657. However, the stack trace is pretty clear about the problem, which is WindowManager being used with an Application (not Activity) context. The `defaultDisplay()` and `getSize()` methods are deprecated also.

This PR replaces WindowManager with a more suitable way of fetching the screen resolution in `Subject`.