### PR TITLE
Undeprecate PageView event

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/PageView.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/PageView.kt
@@ -16,7 +16,7 @@ import com.snowplowanalytics.core.constants.Parameters
 import com.snowplowanalytics.core.constants.TrackerConstants
 
 /**
- * A pageView event.
+ * A PageView event. This event has been designed for web trackers, and is not suitable for mobile apps.
  * @param pageUrl The page URL.
  */
 class PageView(pageUrl: String) : AbstractPrimitive() {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/PageView.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/event/PageView.kt
@@ -18,9 +18,7 @@ import com.snowplowanalytics.core.constants.TrackerConstants
 /**
  * A pageView event.
  * @param pageUrl The page URL.
- * @Deprecated This event has been designed for web trackers, and is not suitable for mobile apps.
  */
-@Deprecated("This event has been designed for web trackers, not suitable for mobile apps. Use `DeepLinkReceived` event to track deep-link received in the app.")
 class PageView(pageUrl: String) : AbstractPrimitive() {
     /** Page URL.  */
     private val pageUrl: String


### PR DESCRIPTION
The `PageView` event class was accidentally marked as deprecated during the migration to Kotlin for v5. This change reverses that.