### PR TITLE
Add an option to override platform context properties

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
@@ -128,7 +128,7 @@ class StateManagerTest {
             tracker.base64Encoded = false
             tracker.logLevel = LogLevel.VERBOSE
         }
-        val tracker = Tracker(emitter, "namespace", "appId", null, context, trackerBuilder)
+        val tracker = Tracker(emitter, "namespace", "appId", context = context, builder = trackerBuilder)
 
         // Send events
         tracker.track(Timing("category", "variable", 123))
@@ -221,7 +221,7 @@ class StateManagerTest {
             tracker.base64Encoded = false
             tracker.logLevel = LogLevel.VERBOSE
         }
-        val tracker = Tracker(emitter, "namespace", "appId", null, context, trackerBuilder)
+        val tracker = Tracker(emitter, "namespace", "appId", context = context, builder = trackerBuilder)
 
         // Send events
         tracker.track(Timing("category", "variable", 123))
@@ -295,7 +295,7 @@ class StateManagerTest {
             tracker.sessionContext = false
             tracker.platformContextEnabled = false
         }
-        val tracker = Tracker(emitter, "namespace", "appId", null, context, trackerBuilder)
+        val tracker = Tracker(emitter, "namespace", "appId", context = context, builder = trackerBuilder)
 
         // Send events
         tracker.track(Timing("category", "variable", 123))

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
@@ -102,7 +102,7 @@ class TrackerTest {
             tracker.installAutotracking = installTracking
             tracker.applicationContext = true
         }
-        Companion.tracker = Tracker(emitter, "myNamespace", "myAppId", null, context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, "myNamespace", "myAppId", context = context, builder = trackerBuilder)
         return Companion.tracker
     }
 
@@ -203,7 +203,7 @@ class TrackerTest {
             tracker.screenViewAutotracking = false
         }
         Companion.tracker =
-            Tracker(emitter!!, namespace, "testTrackWithNoContext", null, context, trackerBuilder)
+            Tracker(emitter!!, namespace, "testTrackWithNoContext", context = context, builder = trackerBuilder)
         val eventStore = emitter.eventStore
         val isClean = eventStore.removeAllEvents()
         Log.i("testTrackSelfDescribingEvent", "EventStore clean: $isClean")
@@ -265,7 +265,7 @@ class TrackerTest {
             tracker.screenViewAutotracking = false
         }
         Companion.tracker =
-            Tracker(emitter!!, namespace, "testTrackWithNoContext", null, context, trackerBuilder)
+            Tracker(emitter!!, namespace, "testTrackWithNoContext", context = context, builder = trackerBuilder)
         
         Log.i("testTrackWithNoContext", "Send ScreenView event")
         Companion.tracker!!.track(ScreenView("name"))
@@ -317,7 +317,7 @@ class TrackerTest {
             tracker.exceptionAutotracking = false
             tracker.screenViewAutotracking = false
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", context = context, builder = trackerBuilder)
         Companion.tracker!!.pauseEventTracking()
         val eventId = Companion.tracker!!.track(ScreenView("name"))
         Assert.assertNull(eventId)
@@ -351,7 +351,7 @@ class TrackerTest {
             tracker.foregroundTimeout = 5
             tracker.backgroundTimeout = 5
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", context = context, builder = trackerBuilder)
         Assert.assertNotNull(Companion.tracker!!.session)
         Companion.tracker!!.resumeSessionChecking()
         Thread.sleep(2000)
@@ -380,7 +380,7 @@ class TrackerTest {
             tracker.foregroundTimeout = 5
             tracker.backgroundTimeout = 5
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", context = context, builder = trackerBuilder)
         val screenState = Companion.tracker!!.getScreenState()
         Assert.assertNotNull(screenState)
         var screenStateMapWrapper: Map<String, Any?> = screenState!!.getCurrentScreen(true).map
@@ -423,7 +423,7 @@ class TrackerTest {
             tracker.exceptionAutotracking = true
             tracker.screenViewAutotracking = false
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", context = context, builder = trackerBuilder)
         Assert.assertTrue(Companion.tracker!!.exceptionAutotracking)
         Assert.assertEquals(
             ExceptionHandler::class.java,
@@ -451,7 +451,7 @@ class TrackerTest {
             tracker.exceptionAutotracking = false
             tracker.screenViewAutotracking = false
         }
-        Companion.tracker = Tracker(emitter, namespace, "myAppId", null, context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, namespace, "myAppId", context = context, builder = trackerBuilder)
         val handler1 = ExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler(handler1)
         Assert.assertEquals(
@@ -481,7 +481,7 @@ class TrackerTest {
             tracker.foregroundTimeout = 5
             tracker.backgroundTimeout = 5
         }
-        Companion.tracker = Tracker(emitter, "ns", "myAppId", null, context, trackerBuilder)
+        Companion.tracker = Tracker(emitter, "ns", "myAppId", context = context, builder = trackerBuilder)
         
         Companion.tracker!!.track(Structured("c", "a"))
         val sessionIdStart = Companion.tracker!!.session!!.state!!.sessionId

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/LoggingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/LoggingTest.kt
@@ -72,8 +72,8 @@ class LoggingTest {
             "namespace",
             "myAppId",
             null,
-            ApplicationProvider.getApplicationContext(),
-            trackerBuilder
+            context = ApplicationProvider.getApplicationContext(),
+            builder = trackerBuilder
         )
         Assert.assertTrue(mockLoggerDelegate!!.capturedLogs.contains("Session checking has been resumed. (debug)"))
         Assert.assertTrue(mockLoggerDelegate!!.capturedLogs.contains("Tracker created successfully. (verbose)"))
@@ -107,8 +107,8 @@ class LoggingTest {
             "namespace",
             "myAppId",
             null,
-            ApplicationProvider.getApplicationContext(),
-            trackerBuilder
+            context = ApplicationProvider.getApplicationContext(),
+            builder = trackerBuilder
         )
         Assert.assertTrue(mockLoggerDelegate!!.capturedLogs.contains("Session checking has been resumed. (debug)"))
         Assert.assertFalse(mockLoggerDelegate!!.capturedLogs.contains("Tracker created successfully. (verbose)"))
@@ -141,8 +141,8 @@ class LoggingTest {
             "namespace",
             "myAppId",
             null,
-            ApplicationProvider.getApplicationContext(),
-            trackerBuilder
+            context = ApplicationProvider.getApplicationContext(),
+            builder = trackerBuilder
         )
         Assert.assertFalse(mockLoggerDelegate!!.capturedLogs.contains("Session checking has been resumed. (debug)"))
         Assert.assertFalse(mockLoggerDelegate!!.capturedLogs.contains("Tracker created successfully. (verbose)"))

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/SessionTest.kt
@@ -218,7 +218,7 @@ class SessionTest {
             tracker.foregroundTimeout = 100
             tracker.backgroundTimeout = 2
         }
-        val tracker = Tracker(emitter, "tracker", "app", null, context, trackerBuilder)
+        val tracker = Tracker(emitter, "tracker", "app", context = context, builder = trackerBuilder)
         val session = tracker.session
         
         getSessionContext(session, "event_1", timestamp, false)
@@ -257,7 +257,7 @@ class SessionTest {
             tracker.foregroundTimeout = 100
             tracker.backgroundTimeout = 2
         }
-        val tracker = Tracker(emitter, "tracker", "app", null, context, trackerBuilder)
+        val tracker = Tracker(emitter, "tracker", "app", context = context, builder = trackerBuilder)
         val session = tracker.session
         getSessionContext(session, "event_1", timestamp, false)
         var sessionState = session!!.state
@@ -338,8 +338,8 @@ class SessionTest {
             tracker.foregroundTimeout = 20
             tracker.backgroundTimeout = 20
         }
-        val tracker1 = Tracker(emitter, "tracker1", "app", null, context, trackerBuilder)
-        val tracker2 = Tracker(emitter, "tracker2", "app", null, context, trackerBuilder)
+        val tracker1 = Tracker(emitter, "tracker1", "app", context = context, builder = trackerBuilder)
+        val tracker2 = Tracker(emitter, "tracker2", "app", context = context, builder = trackerBuilder)
         val session1 = tracker1.session
         val session2 = tracker2.session
         session1!!.getSessionContext("session1-fake-id1", timestamp, false)
@@ -364,7 +364,7 @@ class SessionTest {
         val id2 = session2.state!!.sessionId
 
         // Recreate tracker2
-        val tracker2b = Tracker(emitter, "tracker2", "app", null, context, trackerBuilder)
+        val tracker2b = Tracker(emitter, "tracker2", "app", context = context, builder = trackerBuilder)
         tracker2b.session!!.getSessionContext("session2b-fake-id3", timestamp, false)
         val initialValue2b = tracker2b.session!!.sessionIndex?.toLong()
         val previousId2b = tracker2b.session!!.state!!.previousSessionId

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/EventSendingTest.kt
@@ -222,8 +222,8 @@ class EventSendingTest {
             ns,
             "myAppId",
             null,
-            InstrumentationRegistry.getInstrumentation().targetContext,
-            trackerBuilder
+            context = InstrumentationRegistry.getInstrumentation().targetContext,
+            builder = trackerBuilder
         )
         emitter.eventStore.removeAllEvents()
         return tracker!!

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
@@ -32,6 +32,7 @@ import com.snowplowanalytics.snowplow.tracker.PlatformContextRetriever
  * @param deviceInfoMonitor Device monitor for fetching platform information
  * @param properties List of properties of the platform context to track
  * @param retriever Overrides for retrieving property values
+ * @param context Android context
  */
 class PlatformContext(
     private val platformDictUpdateFrequency: Long = 1000,

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/PlatformContext.kt
@@ -21,6 +21,7 @@ import com.snowplowanalytics.core.utils.Util.addToMap
 import com.snowplowanalytics.core.utils.Util.mapHasKeys
 import com.snowplowanalytics.snowplow.configuration.PlatformContextProperty
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
+import com.snowplowanalytics.snowplow.tracker.PlatformContextRetriever
 
 /**
  * PlatformContext manages device information that is sent as context along with events.
@@ -29,13 +30,16 @@ import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
  * @param platformDictUpdateFrequency Minimal gap between subsequent updates of mobile platform information in milliseconds
  * @param networkDictUpdateFrequency Minimal gap between subsequent updates of network platform information in milliseconds
  * @param deviceInfoMonitor Device monitor for fetching platform information
+ * @param properties List of properties of the platform context to track
+ * @param retriever Overrides for retrieving property values
  */
 class PlatformContext(
-    private val platformDictUpdateFrequency: Long,
-    private val networkDictUpdateFrequency: Long,
-    private val deviceInfoMonitor: DeviceInfoMonitor,
-    private val platformContextProperties: List<PlatformContextProperty>?,
-    private val context: Context
+    private val platformDictUpdateFrequency: Long = 1000,
+    private val networkDictUpdateFrequency: Long = (10 * 1000).toLong(),
+    private val deviceInfoMonitor: DeviceInfoMonitor = DeviceInfoMonitor(),
+    private val properties: List<PlatformContextProperty>? = null,
+    private val retriever: PlatformContextRetriever = PlatformContextRetriever(),
+    private val context: Context,
 ) {
     private val pairs: MutableMap<String, Any> = HashMap()
     private var lastUpdatedEphemeralPlatformDict: Long = 0
@@ -44,14 +48,6 @@ class PlatformContext(
     init {
         setPlatformDict()
     }
-
-    /**
-     * Initializes PlatformContext with default update intervals – 1s for updating platform information and 10s for updating network information.
-     *
-     * @param context the Android context
-     */
-    constructor(platformContextProperties: List<PlatformContextProperty>?,
-                context: Context) : this(1000, (10 * 1000).toLong(), DeviceInfoMonitor(), platformContextProperties, context)
 
     fun getMobileContext(userAnonymisation: Boolean): SelfDescribingJson? {
         updateEphemeralDictsIfNecessary()
@@ -90,41 +86,40 @@ class PlatformContext(
     }
 
     private fun setPlatformDict() {
-        addToMap(Parameters.OS_TYPE, deviceInfoMonitor.osType, pairs)
-        addToMap(Parameters.OS_VERSION, deviceInfoMonitor.osVersion, pairs)
-        addToMap(Parameters.DEVICE_MODEL, deviceInfoMonitor.deviceModel, pairs)
-        addToMap(Parameters.DEVICE_MANUFACTURER, deviceInfoMonitor.deviceVendor, pairs)
+        addToMap(Parameters.OS_TYPE, fromRetrieverOr(retriever.osType) { deviceInfoMonitor.osType }, pairs)
+        addToMap(Parameters.OS_VERSION, fromRetrieverOr(retriever.osVersion) { deviceInfoMonitor.osVersion }, pairs)
+        addToMap(Parameters.DEVICE_MODEL, fromRetrieverOr(retriever.deviceModel) { deviceInfoMonitor.deviceModel }, pairs)
+        addToMap(Parameters.DEVICE_MANUFACTURER, fromRetrieverOr(retriever.deviceVendor) { deviceInfoMonitor.deviceVendor }, pairs)
         // Carrier
         if (shouldTrack(PlatformContextProperty.CARRIER)) {
             addToMap(
-                Parameters.CARRIER, deviceInfoMonitor.getCarrier(
-                    context
-                ), pairs
+                Parameters.CARRIER, fromRetrieverOr(retriever.carrier) { deviceInfoMonitor.getCarrier(context) },
+                pairs
             )
         }
         // Physical memory
         if (shouldTrack(PlatformContextProperty.PHYSICAL_MEMORY)) {
             addToMap(
-                Parameters.PHYSICAL_MEMORY, deviceInfoMonitor.getPhysicalMemory(
-                    context
-                ), pairs
+                Parameters.PHYSICAL_MEMORY,
+                fromRetrieverOr(retriever.physicalMemory) { deviceInfoMonitor.getPhysicalMemory(context) },
+                pairs
             )
         }
         // Total storage
         if (shouldTrack(PlatformContextProperty.TOTAL_STORAGE)) {
-            addToMap(Parameters.TOTAL_STORAGE, deviceInfoMonitor.totalStorage, pairs)
+            addToMap(Parameters.TOTAL_STORAGE, fromRetrieverOr(retriever.totalStorage) { deviceInfoMonitor.totalStorage }, pairs)
         }
         // Resolution
         if (shouldTrack(PlatformContextProperty.RESOLUTION)) {
-            addToMap(Parameters.MOBILE_RESOLUTION, deviceInfoMonitor.getResolution(context), pairs)
+            addToMap(Parameters.MOBILE_RESOLUTION, fromRetrieverOr(retriever.resolution) { deviceInfoMonitor.getResolution(context) }, pairs)
         }
         // Scale
         if (shouldTrack(PlatformContextProperty.SCALE)) {
-            addToMap(Parameters.MOBILE_SCALE, deviceInfoMonitor.getScale(context), pairs)
+            addToMap(Parameters.MOBILE_SCALE, fromRetrieverOr(retriever.scale) { deviceInfoMonitor.getScale(context) }, pairs)
         }
         // Language
         if (shouldTrack(PlatformContextProperty.LANGUAGE)) {
-            addToMap(Parameters.MOBILE_LANGUAGE, deviceInfoMonitor.language?.take(8), pairs)
+            addToMap(Parameters.MOBILE_LANGUAGE, (fromRetrieverOr(retriever.language) { deviceInfoMonitor.language })?.take(8), pairs)
         }
 
         setEphemeralPlatformDict()
@@ -140,9 +135,9 @@ class PlatformContext(
             val currentIdfa = pairs[Parameters.ANDROID_IDFA]
             if (currentIdfa == null || currentIdfa.toString().isEmpty()) {
                 addToMap(
-                    Parameters.ANDROID_IDFA, deviceInfoMonitor.getAndroidIdfa(
-                        context
-                    ), pairs
+                    Parameters.ANDROID_IDFA,
+                    fromRetrieverOr(retriever.androidIdfa) { deviceInfoMonitor.getAndroidIdfa(context) },
+                    pairs
                 )
             }
         }
@@ -150,29 +145,25 @@ class PlatformContext(
         val trackBatState = shouldTrack(PlatformContextProperty.BATTERY_STATE)
         val trackBatLevel = shouldTrack(PlatformContextProperty.BATTERY_LEVEL)
         if (trackBatState || trackBatLevel) {
-            val batteryInfo = deviceInfoMonitor.getBatteryStateAndLevel(
-                context
-            )
-            if (batteryInfo != null) {
-                if (trackBatState) { addToMap(Parameters.BATTERY_STATE, batteryInfo.first, pairs) }
-                if (trackBatLevel) { addToMap(Parameters.BATTERY_LEVEL, batteryInfo.second, pairs) }
-            }
+            val batteryInfo = deviceInfoMonitor.getBatteryStateAndLevel(context)
+            if (trackBatState) { addToMap(Parameters.BATTERY_STATE, fromRetrieverOr(retriever.batteryState) { batteryInfo?.first }, pairs) }
+            if (trackBatLevel) { addToMap(Parameters.BATTERY_LEVEL, fromRetrieverOr(retriever.batteryLevel) { batteryInfo?.second }, pairs) }
         }
         // Memory
         if (shouldTrack(PlatformContextProperty.SYSTEM_AVAILABLE_MEMORY)) {
             addToMap(
-                Parameters.SYSTEM_AVAILABLE_MEMORY, deviceInfoMonitor.getSystemAvailableMemory(
-                    context
-                ), pairs
+                Parameters.SYSTEM_AVAILABLE_MEMORY,
+                fromRetrieverOr(retriever.systemAvailableMemory) { deviceInfoMonitor.getSystemAvailableMemory(context) },
+                pairs
             )
         }
         // Storage
         if (shouldTrack(PlatformContextProperty.AVAILABLE_STORAGE)) {
-            addToMap(Parameters.AVAILABLE_STORAGE, deviceInfoMonitor.availableStorage, pairs)
+            addToMap(Parameters.AVAILABLE_STORAGE, fromRetrieverOr(retriever.availableStorage) { deviceInfoMonitor.availableStorage }, pairs)
         }
         // Is portrait
         if (shouldTrack(PlatformContextProperty.IS_PORTRAIT)) {
-            addToMap(Parameters.IS_PORTRAIT, deviceInfoMonitor.getIsPortrait(context), pairs)
+            addToMap(Parameters.IS_PORTRAIT, fromRetrieverOr(retriever.isPortrait) { deviceInfoMonitor.getIsPortrait(context) }, pairs)
         }
     }
 
@@ -187,14 +178,14 @@ class PlatformContext(
         if (trackType) {
             addToMap(
                 Parameters.NETWORK_TYPE,
-                deviceInfoMonitor.getNetworkType(networkInfo),
+                fromRetrieverOr(retriever.networkType) { deviceInfoMonitor.getNetworkType(networkInfo) },
                 pairs
             )
         }
         if (trackTech) {
             addToMap(
                 Parameters.NETWORK_TECHNOLOGY,
-                deviceInfoMonitor.getNetworkTechnology(networkInfo),
+                fromRetrieverOr(retriever.networkTechnology) { deviceInfoMonitor.getNetworkTechnology(networkInfo) },
                 pairs
             )
         }
@@ -215,29 +206,45 @@ class PlatformContext(
             TrackerConstants.SNOWPLOW_GENERAL_VARS,
             Context.MODE_PRIVATE
         )
-        val appSetId = generalPref.getString(Parameters.APP_SET_ID, null)
-        val appSetIdScope = generalPref.getString(Parameters.APP_SET_ID_SCOPE, null)
+        val appSetId = fromRetrieverOr(retriever.appSetId) { generalPref.getString(Parameters.APP_SET_ID, null) }
+        val appSetIdScope = fromRetrieverOr(retriever.appSetIdScope) { generalPref.getString(Parameters.APP_SET_ID_SCOPE, null) }
 
         if (appSetId != null && appSetIdScope != null) {
             if (trackId) { addToMap(Parameters.APP_SET_ID, appSetId, pairs) }
             if (trackScope) { addToMap(Parameters.APP_SET_ID_SCOPE, appSetIdScope, pairs) }
         } else {
             Executor.execute(TAG) {
-                deviceInfoMonitor.getAppSetIdAndScope(context)?.let {
-                    if (trackId) { addToMap(Parameters.APP_SET_ID, it.first, pairs) }
-                    if (trackScope) { addToMap(Parameters.APP_SET_ID_SCOPE, it.second, pairs) }
+                val preferences = generalPref.edit()
+                var edited = false
 
-                    generalPref.edit()
-                        .putString(Parameters.APP_SET_ID, it.first)
-                        .putString(Parameters.APP_SET_ID_SCOPE, it.second)
-                        .apply()
+                val appSetIdAndScope = deviceInfoMonitor.getAppSetIdAndScope(context)
+                val id = fromRetrieverOr(retriever.appSetId) {
+                    val id = appSetIdAndScope?.first
+                    preferences.putString(Parameters.APP_SET_ID, id)
+                    edited = true
+                    id
                 }
+                val scope = fromRetrieverOr(retriever.appSetIdScope) {
+                    val scope = appSetIdAndScope?.second
+                    preferences.putString(Parameters.APP_SET_ID_SCOPE, scope)
+                    edited = true
+                    scope
+                }
+
+                if (trackId) { addToMap(Parameters.APP_SET_ID, id, pairs) }
+                if (trackScope) { addToMap(Parameters.APP_SET_ID_SCOPE, scope, pairs) }
+
+                if (edited) { preferences.apply() }
             }
         }
     }
 
     private fun shouldTrack(property: PlatformContextProperty): Boolean {
-        return platformContextProperties?.contains(property) ?: true
+        return properties?.contains(property) ?: true
+    }
+
+    private fun <T> fromRetrieverOr(f1: (() -> T)?, f2: () -> T): T {
+        return if (f1 == null) { f2() } else { f1.invoke() }
     }
 
     companion object {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/ServiceProvider.kt
@@ -302,12 +302,13 @@ class ServiceProvider(
         }
         
         val tracker = Tracker(
-            emitter,
-            namespace,
-            trackerConfiguration.appId,
-            trackerConfiguration.platformContextProperties,
-            context,
-            builder
+            emitter = emitter,
+            namespace = namespace,
+            appId = trackerConfiguration.appId,
+            platformContextProperties = trackerConfiguration.platformContextProperties,
+            platformContextRetriever = trackerConfiguration.platformContextRetriever,
+            context = context,
+            builder = builder
         )
         
         if (trackerConfiguration.isPaused) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -45,7 +45,6 @@ import com.snowplowanalytics.snowplow.util.Basis
 import java.util.*
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.math.max
 
 /**
  * Builds a Tracker object which is used to send events to a Snowplow Collector.
@@ -60,7 +59,8 @@ class Tracker(
     emitter: Emitter,
     val namespace: String,
     var appId: String,
-    platformContextProperties: List<PlatformContextProperty>?,
+    platformContextProperties: List<PlatformContextProperty>? = null,
+    platformContextRetriever: PlatformContextRetriever? = null,
     context: Context,
     builder: ((Tracker) -> Unit)? = null) {
     private var builderFinished = false
@@ -88,7 +88,11 @@ class Tracker(
     val dataCollection: Boolean
         get() = _dataCollection.get()
 
-    private val platformContextManager = PlatformContext(platformContextProperties, context)
+    private val platformContextManager = PlatformContext(
+        properties = platformContextProperties,
+        retriever = platformContextRetriever ?: PlatformContextRetriever(),
+        context = context
+    )
 
     var emitter: Emitter = emitter
         set(emitter) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -52,6 +52,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @param emitter Emitter to which events will be sent
  * @param namespace Identifier for the Tracker instance
  * @param appId Application ID
+ * @param platformContextProperties List of properties of the platform context to track
+ * @param platformContextRetriever Overrides for retrieving property values
  * @param context The Android application context
  * @param builder A closure to set Tracker configuration
  */

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
@@ -13,12 +13,12 @@
 package com.snowplowanalytics.snowplow.configuration
 
 import com.snowplowanalytics.core.tracker.Logger
-import com.snowplowanalytics.core.tracker.PlatformContext
 import com.snowplowanalytics.core.tracker.TrackerConfigurationInterface
 import com.snowplowanalytics.core.tracker.TrackerDefaults
 import com.snowplowanalytics.snowplow.tracker.DevicePlatform
 import com.snowplowanalytics.snowplow.tracker.LogLevel
 import com.snowplowanalytics.snowplow.tracker.LoggerDelegate
+import com.snowplowanalytics.snowplow.tracker.PlatformContextRetriever
 import org.json.JSONObject
 import java.util.*
 
@@ -165,6 +165,15 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
     open var platformContextProperties: List<PlatformContextProperty>?
         get() = _platformContextProperties ?: sourceConfig?.platformContextProperties
         set(value) { _platformContextProperties = value }
+
+    private var _platformContextRetriever: PlatformContextRetriever? = null
+    /**
+     * Set of callbacks to be used to retrieve properties of the platform context.
+     * Overrides the tracker implementation for setting the properties.
+     */
+    open var platformContextRetriever: PlatformContextRetriever?
+        get() = _platformContextRetriever ?: sourceConfig?.platformContextRetriever
+        set(value) { _platformContextRetriever = value }
 
     // Builder methods
     
@@ -345,6 +354,15 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
         return this
     }
 
+    /**
+     * Set of callbacks to be used to retrieve properties of the platform context.
+     * Overrides the tracker implementation for setting the properties.
+     */
+    fun platformContextRetriever(platformContextRetriever: PlatformContextRetriever?): TrackerConfiguration {
+        this.platformContextRetriever = platformContextRetriever
+        return this
+    }
+
     // Copyable
     override fun copy(): Configuration {
         return TrackerConfiguration(appId)
@@ -367,6 +385,7 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
             .userAnonymisation(userAnonymisation)
             .trackerVersionSuffix(trackerVersionSuffix)
             .platformContextProperties(platformContextProperties)
+            .platformContextRetriever(platformContextRetriever)
     }
 
     /**

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/PlatformContextRetriever.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/PlatformContextRetriever.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ * Copyright (c) 2015-present Snowplow Analytics Ltd. All rights reserved.
  *
  * This program is licensed to you under the Apache License Version 2.0,
  * and you may not use this file except in compliance with the Apache License Version 2.0.
@@ -16,63 +16,103 @@ package com.snowplowanalytics.snowplow.tracker
  * Overrides for the values for properties of the platform context.
  */
 data class PlatformContextRetriever(
-    /// Operating system type (e.g., ios, tvos, watchos, osx, android)
+    /**
+     * Operating system type (e.g., ios, tvos, watchos, osx, android).
+     */
     var osType: (() -> String)? = null,
 
-    /// The current version of the operating system
+    /*
+     * The current version of the operating system.
+     */
     var osVersion: (() -> String)? = null,
 
-    /// The manufacturer of the product/hardware
+    /**
+     * The manufacturer of the product/hardware.
+     */
     var deviceVendor: (() -> String)? = null,
 
-    /// The end-user-visible name for the end product
+    /**
+     * The end-user-visible name for the end product.
+     */
     var deviceModel: (() -> String)? = null,
 
-    /// The carrier of the SIM inserted in the device
+    /**
+     * The carrier of the SIM inserted in the device.
+     */
     var carrier: (() -> String?)? = null,
 
-    /// Type of network the device is connected to
+    /**
+     * Type of network the device is connected to.
+     */
     var networkType: (() -> String?)? = null,
 
-    /// Radio access technology that the device is using
+    /**
+     * Radio access technology that the device is using.
+     */
     var networkTechnology: (() -> String?)? = null,
 
-    /// Advertising identifier on Android
+    /**
+     * Advertising identifier on Android.
+     */
     var androidIdfa: (() -> String?)? = null,
 
-    /// Bytes of storage remaining
+    /**
+     * Bytes of storage remaining.
+     */
     var availableStorage: (() -> Long?)? = null,
 
-    /// Total size of storage in bytes
+    /**
+     * Total size of storage in bytes.
+     */
     var totalStorage: (() -> Long?)? = null,
 
-    /// Total physical system memory in bytes
+    /**
+     * Total physical system memory in bytes.
+     */
     var physicalMemory: (() -> Long?)? = null,
 
-    /// Available memory on the system in bytes (Android only)
+    /**
+     * Available memory on the system in bytes (Android only).
+     */
     var systemAvailableMemory: (() -> Long?)? = null,
 
-    /// Remaining battery level as an integer percentage of total battery capacity
+    /**
+     * Remaining battery level as an integer percentage of total battery capacity.
+     */
     var batteryLevel: (() -> Int?)? = null,
 
-    /// Battery state for the device
+    /**
+     * Battery state for the device
+     */
     var batteryState: (() -> String?)? = null,
 
-    /// A Boolean indicating whether the device orientation is portrait (either upright or upside down)
+    /**
+     * A Boolean indicating whether the device orientation is portrait (either upright or upside down).
+     */
     var isPortrait: (() -> Boolean?)? = null,
 
-    /// Screen resolution in pixels. Arrives in the form of WIDTHxHEIGHT (e.g., 1200x900). Doesn't change when device orientation changes
+    /**
+     * Screen resolution in pixels. Arrives in the form of WIDTHxHEIGHT (e.g., 1200x900). Doesn't change when device orientation changes.
+     */
     var resolution: (() -> String?)? = null,
 
-    /// Scale factor used to convert logical coordinates to device coordinates of the screen (uses UIScreen.scale on iOS)
+    /**
+     * Scale factor used to convert logical coordinates to device coordinates of the screen (uses UIScreen.scale on iOS).
+     */
     var scale: (() -> Float?)? = null,
 
-    /// System language currently used on the device (ISO 639)
+    /**
+     * System language currently used on the device (ISO 639).
+     */
     var language: (() -> String)? = null,
 
-    /// Android vendor ID scoped to the set of apps published under the same Google Play developer account (see https://developer.android.com/training/articles/app-set-id)
+    /**
+     * Android vendor ID scoped to the set of apps published under the same Google Play developer account (see https://developer.android.com/training/articles/app-set-id).
+     */
     var appSetId: (() -> String)? = null,
 
-    /// Scope of the `appSetId`. Can be scoped to the app or to a developer account on an app store (all apps from the same developer on the same device will have the same ID)
+    /**
+     * Scope of the `appSetId`. Can be scoped to the app or to a developer account on an app store (all apps from the same developer on the same device will have the same ID).
+     */
     var appSetIdScope: (() -> String)? = null
 )

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/PlatformContextRetriever.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/tracker/PlatformContextRetriever.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015-2023 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.tracker
+
+/**
+ * Overrides for the values for properties of the platform context.
+ */
+data class PlatformContextRetriever(
+    /// Operating system type (e.g., ios, tvos, watchos, osx, android)
+    var osType: (() -> String)? = null,
+
+    /// The current version of the operating system
+    var osVersion: (() -> String)? = null,
+
+    /// The manufacturer of the product/hardware
+    var deviceVendor: (() -> String)? = null,
+
+    /// The end-user-visible name for the end product
+    var deviceModel: (() -> String)? = null,
+
+    /// The carrier of the SIM inserted in the device
+    var carrier: (() -> String?)? = null,
+
+    /// Type of network the device is connected to
+    var networkType: (() -> String?)? = null,
+
+    /// Radio access technology that the device is using
+    var networkTechnology: (() -> String?)? = null,
+
+    /// Advertising identifier on Android
+    var androidIdfa: (() -> String?)? = null,
+
+    /// Bytes of storage remaining
+    var availableStorage: (() -> Long?)? = null,
+
+    /// Total size of storage in bytes
+    var totalStorage: (() -> Long?)? = null,
+
+    /// Total physical system memory in bytes
+    var physicalMemory: (() -> Long?)? = null,
+
+    /// Available memory on the system in bytes (Android only)
+    var systemAvailableMemory: (() -> Long?)? = null,
+
+    /// Remaining battery level as an integer percentage of total battery capacity
+    var batteryLevel: (() -> Int?)? = null,
+
+    /// Battery state for the device
+    var batteryState: (() -> String?)? = null,
+
+    /// A Boolean indicating whether the device orientation is portrait (either upright or upside down)
+    var isPortrait: (() -> Boolean?)? = null,
+
+    /// Screen resolution in pixels. Arrives in the form of WIDTHxHEIGHT (e.g., 1200x900). Doesn't change when device orientation changes
+    var resolution: (() -> String?)? = null,
+
+    /// Scale factor used to convert logical coordinates to device coordinates of the screen (uses UIScreen.scale on iOS)
+    var scale: (() -> Float?)? = null,
+
+    /// System language currently used on the device (ISO 639)
+    var language: (() -> String)? = null,
+
+    /// Android vendor ID scoped to the set of apps published under the same Google Play developer account (see https://developer.android.com/training/articles/app-set-id)
+    var appSetId: (() -> String)? = null,
+
+    /// Scope of the `appSetId`. Can be scoped to the app or to a developer account on an app store (all apps from the same developer on the same device will have the same ID)
+    var appSetIdScope: (() -> String)? = null
+)


### PR DESCRIPTION
Issue #667 

This PR adds a way to override properties of the platform context using a `PlatformContextRetriever` object with callbacks for each property.

This will enable us to set the platform context properties (mostly the IDFA) from our wrapper trackers (React Native and Flutter). Using these override callbacks, it'd be possible to pass values from JS or Dart for the properties.