### PR TITLE
Enable lifecycle autotracking by default (close #651)

### DIFF
--- a/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/data/Tracking.kt
+++ b/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/data/Tracking.kt
@@ -24,7 +24,6 @@ object Tracking {
         val trackerConfig = TrackerConfiguration("appID")
             .logLevel(LogLevel.DEBUG)
             .screenViewAutotracking(false)
-            .lifecycleAutotracking(true)
         val emitterConfig = EmitterConfiguration().bufferOption(BufferOption.Single)
 
         return Snowplow.createTracker(
@@ -48,7 +47,8 @@ object Tracking {
                                 entities: List<SelfDescribingJson>? = null,
     ) {
         LaunchedEffect(Unit, block = {
-            val event = ScreenView(screenName).entities(entities)
+            val event = ScreenView(screenName)
+            entities?.let { event.entities(it) }
             Snowplow.defaultTracker?.track(event)
         })
     }

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/StateManagerTest.kt
@@ -125,6 +125,7 @@ class StateManagerTest {
             tracker.screenContext = true
             tracker.sessionContext = false
             tracker.platformContextEnabled = false
+            tracker.lifecycleAutotracking = false
             tracker.base64Encoded = false
             tracker.logLevel = LogLevel.VERBOSE
         }
@@ -294,6 +295,7 @@ class StateManagerTest {
             tracker.base64Encoded = false
             tracker.sessionContext = false
             tracker.platformContextEnabled = false
+            tracker.lifecycleAutotracking = false
         }
         val tracker = Tracker(emitter, "namespace", "appId", context = context, builder = trackerBuilder)
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
@@ -263,6 +263,7 @@ class TrackerTest {
             tracker.geoLocationContext = false
             tracker.installAutotracking = false
             tracker.screenViewAutotracking = false
+            tracker.lifecycleAutotracking = false
         }
         Companion.tracker =
             Tracker(emitter!!, namespace, "testTrackWithNoContext", context = context, builder = trackerBuilder)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerConfigurationInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerConfigurationInterface.kt
@@ -89,7 +89,8 @@ interface TrackerConfigurationInterface {
 
     /**
      * Whether enable automatic tracking of background and foreground transitions.
-     * @apiNote It needs the Foreground library installed.
+     * Enabled by default.
+     * @apiNote It needs the androidx.lifecycle-extensions library installed.
      */
     var lifecycleAutotracking: Boolean
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerDefaults.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerDefaults.kt
@@ -32,7 +32,7 @@ object TrackerDefaults {
     var applicationContext = true
     var exceptionAutotracking = true
     var diagnosticAutotracking = false
-    var lifecycleAutotracking = false
+    var lifecycleAutotracking = true
     var screenViewAutotracking = true
     var screenEngagementAutotracking = true
     var installAutotracking = true

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerDefaults.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerDefaults.kt
@@ -22,7 +22,6 @@ object TrackerDefaults {
     var logLevel = LogLevel.OFF
     var foregroundTimeout: Long = 1800 // 30 minutes
     var backgroundTimeout: Long = 1800 // 30 minutes
-    var threadCount = 10
     var timeUnit = TimeUnit.SECONDS
     var sessionContext = true
     var geoLocationContext = false

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/TrackerConfiguration.kt
@@ -40,7 +40,7 @@ import java.util.*
  *  - deepLinkContext: true
  *  - screenViewAutotracking: true
  *  - screenEngagementAutotracking: true
- *  - lifecycleAutotracking: false
+ *  - lifecycleAutotracking: true
  *  - installAutotracking: true
  *  - exceptionAutotracking: true
  *  - diagnosticAutotracking: false
@@ -290,8 +290,9 @@ open class TrackerConfiguration : TrackerConfigurationInterface, Configuration {
     }
 
     /**
-     * Whether to enable automatic tracking of background and foreground transitions. 
-     * The Foreground library must be installed.
+     * Whether to enable automatic tracking of background and foreground transitions.
+     * Enabled by default.
+     * The androidx.lifecycle-extensions library must be installed.
      */
     fun lifecycleAutotracking(lifecycleAutotracking: Boolean): TrackerConfiguration {
         this.lifecycleAutotracking = lifecycleAutotracking


### PR DESCRIPTION
Issue #651

Up to the v5 version of the tracker, lifecycle autotracking is not enabled by default. However, lifecycle events are crucial to understand the usage of the app and user engagement. It is not possible to calculate screen time without knowing whether the app is in foreground or background.

As we are introducing screen engagement tracking in the v6 version which will be enabled by default, we should also enable lifecycle tracking by default.