### PR TITLE
Fix wrong screen entity info assigned for screen end event and in case events are tracked right before screen view (close #673)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/tracker/TrackerTest.kt
@@ -383,17 +383,14 @@ class TrackerTest {
         }
         Companion.tracker = Tracker(emitter, namespace, "myAppId", context = context, builder = trackerBuilder)
         val screenState = Companion.tracker!!.getScreenState()
-        Assert.assertNotNull(screenState)
-        var screenStateMapWrapper: Map<String, Any?> = screenState!!.getCurrentScreen(true).map
-        var screenStateMap = screenStateMapWrapper[Parameters.DATA] as Map<String?, Any?>?
-        Assert.assertEquals("Unknown", screenStateMap!![Parameters.SCREEN_NAME])
+        Assert.assertNull(screenState)
 
         // Send screenView
         var screenView = ScreenView("screen1")
         val screenId = screenView.dataPayload["id"] as String?
         val eventId1 = Companion.tracker!!.track(screenView)
-        screenStateMapWrapper = Companion.tracker!!.getScreenState()!!.getCurrentScreen(true).map
-        screenStateMap = screenStateMapWrapper[Parameters.DATA] as Map<String?, Any?>?
+        val screenStateMapWrapper = Companion.tracker!!.getScreenState()!!.getCurrentScreen(true).map
+        val screenStateMap = screenStateMapWrapper[Parameters.DATA] as Map<*, *>?
         Assert.assertEquals("screen1", screenStateMap!![Parameters.SCREEN_NAME])
         Assert.assertEquals(screenId, screenStateMap[Parameters.SCREEN_ID])
 

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/media/TestMediaController.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/media/TestMediaController.kt
@@ -16,6 +16,7 @@ package com.snowplowanalytics.snowplow.media
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.snowplowanalytics.core.emitter.Executor
 import com.snowplowanalytics.core.media.MediaSchemata.eventSchema
 import com.snowplowanalytics.core.media.MediaSchemata.playerSchema
 import com.snowplowanalytics.core.media.MediaSchemata.sessionSchema
@@ -73,6 +74,7 @@ class TestMediaController {
         tracker = null
         removeAllTrackers()
         trackedEvents.clear()
+        Executor.shutdown()
     }
 
     // --- MEDIA PLAYER EVENT TESTS

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screen/ScreenViewAutotrackingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screen/ScreenViewAutotrackingTest.kt
@@ -61,10 +61,10 @@ class ScreenViewAutotrackingTest {
         NotificationCenter.postNotification("SnowplowScreenView", mapOf(
             "event" to ScreenView(name = "Screen2").activityClassName("Screen2")
         ))
-        Thread.sleep(2000)
+        Thread.sleep(500)
 
-        val numberOfScreenViews = eventSink.trackedEvents.filter { it.schema == TrackerConstants.SCHEMA_SCREEN_VIEW }
-        Assert.assertEquals(2, numberOfScreenViews.size)
+        val numberOfScreenViews = eventSink.trackedEvents.filter { it.schema == TrackerConstants.SCHEMA_SCREEN_VIEW }.size
+        Assert.assertEquals(2, numberOfScreenViews)
     }
 
     // --- PRIVATE

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screen/ScreenViewAutotrackingTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screen/ScreenViewAutotrackingTest.kt
@@ -16,6 +16,7 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.emitter.Executor
 import com.snowplowanalytics.core.utils.NotificationCenter
 import com.snowplowanalytics.snowplow.Snowplow
 import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
@@ -27,7 +28,6 @@ import com.snowplowanalytics.snowplow.network.HttpMethod
 import com.snowplowanalytics.snowplow.util.EventSink
 import org.junit.After
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
@@ -38,6 +38,7 @@ class ScreenViewAutotrackingTest {
     @After
     fun tearDown() {
         removeAllTrackers()
+        Executor.shutdown()
     }
 
     // --- TESTS

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenStateMachineTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenStateMachineTest.kt
@@ -16,6 +16,7 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.emitter.Executor
 import com.snowplowanalytics.snowplow.Snowplow
 import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
 import com.snowplowanalytics.snowplow.configuration.Configuration
@@ -41,6 +42,7 @@ class ScreenStateMachineTest {
     @After
     fun tearDown() {
         removeAllTrackers()
+        Executor.shutdown()
     }
 
     // --- TESTS

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
@@ -16,6 +16,7 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.snowplowanalytics.core.constants.TrackerConstants
+import com.snowplowanalytics.core.emitter.Executor
 import com.snowplowanalytics.core.screenviews.ScreenSummaryState
 import com.snowplowanalytics.snowplow.Snowplow
 import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
@@ -48,6 +49,7 @@ class ScreenSummaryStateMachineTest {
     @After
     fun tearDown() {
         removeAllTrackers()
+        Executor.shutdown()
     }
 
     // --- TESTS

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/screenviews/ScreenSummaryStateMachineTest.kt
@@ -21,11 +21,9 @@ import com.snowplowanalytics.snowplow.Snowplow
 import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
 import com.snowplowanalytics.snowplow.configuration.Configuration
 import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration
-import com.snowplowanalytics.snowplow.configuration.PluginConfiguration
 import com.snowplowanalytics.snowplow.controller.TrackerController
 import com.snowplowanalytics.snowplow.event.*
 import com.snowplowanalytics.snowplow.network.HttpMethod
-import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 import com.snowplowanalytics.snowplow.util.EventSink
 import com.snowplowanalytics.snowplow.util.TimeTraveler
 import org.junit.After
@@ -94,9 +92,14 @@ class ScreenSummaryStateMachineTest {
         val events = eventSink.trackedEvents
         Assert.assertEquals(3, events.size)
 
-        val screenSummary = getScreenSummary(events.find { it.schema == TrackerConstants.SCHEMA_SCREEN_END })
+        val screenEnd = events.find { it.schema == TrackerConstants.SCHEMA_SCREEN_END }
+        val screenSummary = getScreenSummary(screenEnd)
         Assert.assertEquals(10.0, screenSummary?.get("foreground_sec"))
         Assert.assertEquals(0.0, screenSummary?.get("background_sec"))
+
+        // should have the screen name of the first screen view
+        val screenEndScreen = screenEnd?.entities?.find { it.map["schema"] == TrackerConstants.SCHEMA_SCREEN }
+        Assert.assertEquals("Screen 1", (screenEndScreen?.map?.get("data") as? Map<*, *>)?.get("name"))
     }
 
     @Test

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/FocalMeterConfigurationTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/FocalMeterConfigurationTest.kt
@@ -16,6 +16,7 @@ package com.snowplowanalytics.snowplow.tracker
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.snowplowanalytics.core.emitter.Executor
 import com.snowplowanalytics.snowplow.Snowplow
 import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
 import com.snowplowanalytics.snowplow.configuration.*
@@ -36,6 +37,7 @@ class FocalMeterConfigurationTest {
     @After
     fun tearDown() {
         removeAllTrackers()
+        Executor.shutdown()
     }
 
     // --- TESTS

--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/PluginsTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/PluginsTest.kt
@@ -15,6 +15,7 @@ package com.snowplowanalytics.snowplow.tracker
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.snowplowanalytics.core.emitter.Executor
 import com.snowplowanalytics.snowplow.Snowplow
 import com.snowplowanalytics.snowplow.Snowplow.removeAllTrackers
 import com.snowplowanalytics.snowplow.configuration.Configuration
@@ -38,6 +39,7 @@ class PluginsTest {
     @After
     fun tearDown() {
         removeAllTrackers()
+        Executor.shutdown()
     }
 
     // --- TESTS

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenState.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenState.kt
@@ -21,63 +21,25 @@ import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 import com.snowplowanalytics.snowplow.payload.TrackerPayload
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
-class ScreenState : State {
-    private var name: String
-    private var type: String? = null
-    private var id: String
-    var previousName: String? = null
-        private set
-    var previousId: String? = null
-        private set
-    var previousType: String? = null
-        private set
-    private var transitionType: String? = null
-    private var fragmentClassName: String? = null
-    private var fragmentTag: String? = null
-    var activityClassName: String? = null
-    var activityTag: String? = null
+class ScreenState(
+    val name: String = "Unknown",
+    val type: String? = null,
+    val id: String = uUIDString(),
+    val transitionType: String? = null,
+    val fragmentClassName: String? = null,
+    val fragmentTag: String? = null,
+    val activityClassName: String? = null,
+    val activityTag: String? = null,
+    val previousScreenState: ScreenState? = null
+) : State {
 
-    init {
-        id = uUIDString()
-        name = "Unknown"
-    }
+    val previousName: String?
+        get() { return previousScreenState?.name }
+    val previousId: String?
+        get() { return previousScreenState?.id }
+    val previousType: String?
+        get() { return previousScreenState?.type }
 
-    @Synchronized
-    fun updateScreenState(id: String?, name: String, type: String?, transitionType: String?) {
-        populatePreviousFields()
-        this.name = name
-        this.type = type
-        this.transitionType = transitionType
-        if (id != null) {
-            this.id = id
-        } else {
-            this.id = uUIDString()
-        }
-    }
-
-    @Synchronized
-    fun updateScreenState(
-        id: String,
-        name: String,
-        type: String?,
-        transitionType: String?,
-        fragmentClassName: String?,
-        fragmentTag: String?,
-        activityClassName: String?,
-        activityTag: String?
-    ) {
-        this.updateScreenState(id, name, type, transitionType)
-        this.fragmentClassName = fragmentClassName
-        this.fragmentTag = fragmentTag
-        this.activityClassName = activityClassName
-        this.activityTag = activityTag
-    }
-
-    private fun populatePreviousFields() {
-        previousName = name
-        previousType = type
-        previousId = id
-    }
 
     fun getCurrentScreen(debug: Boolean): SelfDescribingJson {
         // this creates a screen context from screen state

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/screenviews/ScreenStateMachine.kt
@@ -54,27 +54,19 @@ class ScreenStateMachine : StateMachineInterface {
         get() = emptyList()
 
     override fun transition(event: Event, state: State?): State? {
-        val screenView = event as? ScreenView
-        val screenState: ScreenState? = if (state != null) {
-            // - Screen (SV) Screen
-            state as? ScreenState
-        } else {
-            // - Init (SV) Screen
-            ScreenState()
-        }
-        screenView?.let {
-            screenState?.updateScreenState(
-                it.id,
-                it.name,
-                it.type,
-                it.transitionType,
-                it.fragmentClassName,
-                it.fragmentTag,
-                it.activityClassName,
-                it.activityTag
+        return (event as? ScreenView)?.let { screenView ->
+            ScreenState(
+                id = screenView.id,
+                name = screenView.name,
+                type = screenView.type,
+                transitionType = screenView.transitionType,
+                fragmentClassName = screenView.fragmentClassName,
+                fragmentTag = screenView.fragmentTag,
+                activityClassName = screenView.activityClassName,
+                activityTag = screenView.activityTag,
+                previousScreenState = state as? ScreenState
             )
         }
-        return screenState
     }
 
     override fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson>? {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Tracker.kt
@@ -71,12 +71,7 @@ class Tracker(
     
     fun getScreenState(): ScreenState? {
         val state = stateManager.trackerState.getState(ScreenStateMachine.ID)
-            ?: // Legacy initialization
-            return ScreenState()
-
-        return if (state is ScreenState) {
-            state
-        } else null
+        return state as? ScreenState
     }
     
     private var trackerVersion = BuildConfig.TRACKER_LABEL
@@ -333,8 +328,9 @@ class Tracker(
         override fun apply(data: Map<String, Any>) {
             if (screenViewAutotracking) {
                 val event = data["event"] as? ScreenView?
-                event?.let { event ->
-                    getScreenState()?.let { state ->
+                if (event != null) {
+                    val state = getScreenState()
+                    if (state != null) {
                         // don't track if screen view is for the same activity as the last one
                         if (
                             event.activityClassName?.isEmpty() != false ||
@@ -343,7 +339,9 @@ class Tracker(
                         ) {
                             track(event)
                         }
-                    } ?: track(event)
+                    } else {
+                        track(event)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Issue #673 

Due to a bug in how the screen state is updated in the tracker, the screen end event is assigned the wrong information – instead of referring to the previous screen name and ID, it contains information of the subsequent screen.

This bug is not only limited to screen end events but may also appear in case an event is tracked right before a screen view event – the event will be assigned the next screen view instead of the one used when it was tracked.