### PR TITLE
Proposal/Attempt to remove library desugaring

### DIFF
--- a/snowplow-demo-java/build.gradle
+++ b/snowplow-demo-java/build.gradle
@@ -34,7 +34,6 @@ android {
     }
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -52,6 +51,4 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.google.code.gson:gson:2.9.0'
-
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.9'
 }

--- a/snowplow-demo-java/src/main/java/com/snowplowanalytics/snowplowtrackerdemojava/Demo.java
+++ b/snowplow-demo-java/src/main/java/com/snowplowanalytics/snowplowtrackerdemojava/Demo.java
@@ -336,7 +336,10 @@ public class Demo extends Activity implements LoggerDelegate {
         gcConfiguration.add("ruleSetExampleTag", new GlobalContext(Collections.singletonList(new SelfDescribingJson(SCHEMA_IDENTIFY, pairs))));
 
         PluginConfiguration plugin = new PluginConfiguration("myPlugin");
-        plugin.afterTrack(null, event -> System.out.printf("Tracked event with %d entities%n", event.getEntities().size()));
+        plugin.afterTrack(null, (event) -> {
+            System.out.printf("Tracked event with %d entities%n", event.getEntities().size());
+            return null;
+        });
 
         Snowplow.createTracker(getApplicationContext(),
                 namespace,

--- a/snowplow-tracker/build.gradle
+++ b/snowplow-tracker/build.gradle
@@ -67,8 +67,6 @@ android {
     }
 
     compileOptions {
-        coreLibraryDesugaringEnabled true
-
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
@@ -91,8 +89,6 @@ dependencies {
     implementation 'androidx.preference:preference:1.2.1'
     compileOnly "androidx.lifecycle:lifecycle-extensions:$project.archLifecycleVersion"
     compileOnly "com.android.installreferrer:installreferrer:2.2"
-
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.9'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/statemachine/PluginStateMachine.kt
@@ -59,7 +59,7 @@ class PluginStateMachine(
     }
 
     override fun entities(event: InspectableEvent, state: State?): List<SelfDescribingJson> {
-        return entitiesConfiguration?.closure?.apply(event) ?: emptyList()
+        return entitiesConfiguration?.closure?.invoke(event) ?: emptyList()
     }
 
     override fun payloadValues(event: InspectableEvent, state: State?): Map<String, Any>? {
@@ -67,11 +67,11 @@ class PluginStateMachine(
     }
 
     override fun afterTrack(event: InspectableEvent) {
-        afterTrackConfiguration?.closure?.accept(event)
+        afterTrackConfiguration?.closure?.invoke(event)
     }
 
     override fun filter(event: InspectableEvent, state: State?): Boolean? {
-        return filterConfiguration?.closure?.apply(event)
+        return filterConfiguration?.closure?.invoke(event)
     }
 
     override fun eventsBefore(event: Event): List<Event>? {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/FocalMeterConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/FocalMeterConfiguration.kt
@@ -19,7 +19,6 @@ import com.snowplowanalytics.snowplow.entity.ClientSessionEntity
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
-import java.util.function.Function
 
 /**
  * This configuration tells the tracker to send requests with the user ID in session context entity
@@ -31,7 +30,7 @@ import java.util.function.Function
  */
 class FocalMeterConfiguration(
     val kantarEndpoint: String,
-    val processUserId: Function<String, String>? = null,
+    val processUserId: ((String) -> String)? = null,
 ) : Configuration, PluginAfterTrackCallable, PluginIdentifiable {
     private val TAG = FocalMeterConfiguration::class.java.simpleName
 
@@ -45,7 +44,7 @@ class FocalMeterConfiguration(
             val session = event.entities.find { it is ClientSessionEntity } as? ClientSessionEntity
             session?.userId?.let { newUserId ->
                 if (shouldUpdate(newUserId)) {
-                    val processedUserId = processUserId?.apply(newUserId) ?: newUserId
+                    val processedUserId = processUserId?.invoke(newUserId) ?: newUserId
                     makeRequest(processedUserId)
                 }
             }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PluginConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/PluginConfiguration.kt
@@ -15,8 +15,6 @@ package com.snowplowanalytics.snowplow.configuration
 import com.snowplowanalytics.core.statemachine.PluginStateMachine
 import com.snowplowanalytics.snowplow.payload.SelfDescribingJson
 import com.snowplowanalytics.snowplow.tracker.InspectableEvent
-import java.util.function.Consumer
-import java.util.function.Function
 
 /**
  * Provides a block closure to be called after events are tracked.
@@ -27,7 +25,7 @@ import java.util.function.Function
  */
 class PluginAfterTrackConfiguration(
     val schemas: List<String>? = null,
-    val closure: Consumer<InspectableEvent>
+    val closure: (InspectableEvent) -> Unit?
 )
 
 /**
@@ -38,7 +36,7 @@ class PluginAfterTrackConfiguration(
  */
 class PluginFilterConfiguration(
     val schemas: List<String>? = null,
-    val closure: Function<InspectableEvent, Boolean>
+    val closure: (InspectableEvent) -> Boolean
 )
 
 /**
@@ -50,7 +48,7 @@ class PluginFilterConfiguration(
  */
 class PluginEntitiesConfiguration(
     val schemas: List<String>? = null,
-    val closure: Function<InspectableEvent, List<SelfDescribingJson>>
+    val closure: (InspectableEvent) -> List<SelfDescribingJson>
 )
 
 /**
@@ -121,7 +119,7 @@ interface PluginConfigurationInterface : PluginIdentifiable, PluginEntitiesCalla
 /**
  * Configuration for a custom tracker plugin.
  * Enables you to add closures to be called when and after events are tracked in the tracker.
- * 
+ *
  * @property identifier Unique identifier of the plugin within the tracker.
  */
 class PluginConfiguration(
@@ -139,7 +137,7 @@ class PluginConfiguration(
      */
     fun entities(
         schemas: List<String>? = null,
-        closure: Function<InspectableEvent, List<SelfDescribingJson>>
+        closure: (InspectableEvent) -> List<SelfDescribingJson>
     ) {
         entitiesConfiguration = PluginEntitiesConfiguration(
             schemas = schemas,
@@ -156,7 +154,7 @@ class PluginConfiguration(
      */
     fun afterTrack(
         schemas: List<String>? = null,
-        closure: Consumer<InspectableEvent>
+        closure: (InspectableEvent) -> Unit?
     ): PluginConfiguration {
         afterTrackConfiguration = PluginAfterTrackConfiguration(
             schemas = schemas,
@@ -173,7 +171,7 @@ class PluginConfiguration(
      */
     fun filter(
         schemas: List<String>? = null,
-        closure: Function<InspectableEvent, Boolean>
+        closure: (InspectableEvent) -> Boolean
     ): PluginConfiguration {
         filterConfiguration = PluginFilterConfiguration(
             schemas = schemas,


### PR DESCRIPTION
We observed crashes with devices running Android API 23. 
Initialization of FocalMeterConfiguration would crash.

A thread (https://github.com/snowplow/snowplow-android-tracker/issues/601) in the issue tracker suggested to use of coreLibraryDesugaring but we believe there might be a different option : Remove usage of java.util.function.* in order to get rid of library desugaring.

I'm not sure how to entirely test this but can this be looked at ?

Many thanks,