### PR TITLE
Catch more generic exceptions for InstallReferrer (close #647)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/InstallReferrerDetails.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/InstallReferrerDetails.kt
@@ -14,7 +14,6 @@
 package com.snowplowanalytics.core.tracker
 
 import android.content.Context
-import android.os.RemoteException
 import com.android.installreferrer.api.InstallReferrerClient
 import com.android.installreferrer.api.InstallReferrerStateListener
 import com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse
@@ -72,7 +71,7 @@ class InstallReferrerDetails(
                                     googlePlayInstantParam = response.googlePlayInstantParam
                                 )
                                 callback(referrer)
-                            } catch (_: RemoteException) {
+                            } catch (_: Throwable) {
                                 Logger.d(TAG, "Install referrer API remote exception.")
                                 callback(null)
                             }
@@ -99,7 +98,7 @@ class InstallReferrerDetails(
             })
         }
 
-        fun isInstallReferrerPackageAvailable(): Boolean {
+        private fun isInstallReferrerPackageAvailable(): Boolean {
             try {
                 Class.forName("com.android.installreferrer.api.InstallReferrerStateListener")
                 return true


### PR DESCRIPTION
For issue #647 

The `InstallReferrerDetails` class currently checks whether the InstallReferrer dependency is present or not, but if it is, then only catches `RemoteException`s. InstallReferrer below v1.1 doesn't have the `googlePlayInstantParam` property which causes a `NoSuchMethodError`.

Unfortunately the `googlePlayInstantParam` is the one required property for the `referrer_details` schema, so if InstallReferrer v1.0 is used it's not possible to add the entity at all.

This change catches exceptions generically, to include `NoSuchMethodError`.