### PR TITLE
Add Subject config flag to avoid WindowManager bug

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Subject.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/Subject.kt
@@ -180,22 +180,12 @@ class Subject(context: Context, config: SubjectConfigurationInterface?) {
             standardPairs[Parameters.COLOR_DEPTH] = depth.toString()
         }
 
-    var useContextResourcesScreenResolution: Boolean? = false
-        /**
-         * Whether to get the size from the context resources or not.
-         * By default this is false, the size is obtained from WindowManager.
-         *
-         * @param useContextResourcesScreenResolution
-         */
-        set(useContextResourcesScreenResolution) {
-            if (useContextResourcesScreenResolution == null) {
-                return
-            }
-
-            field = useContextResourcesScreenResolution
-        }
+    /**
+     * Whether to get the size from the context resources or not.
+     * By default this is false, the size is obtained from WindowManager.
+     */
+    var useContextResourcesScreenResolution: Boolean = false
     
-
     init {
         setDefaultTimezone()
         setDefaultLanguage()
@@ -212,7 +202,6 @@ class Subject(context: Context, config: SubjectConfigurationInterface?) {
             config.screenResolution?.let { screenResolution = it }
             config.screenViewPort?.let { screenViewPort = it }
             config.colorDepth?.let { colorDepth = it }
-            config.useContextResourcesScreenResolution?.let { useContextResourcesScreenResolution = it }
         }
         v(TAG, "Subject created successfully.")
     }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/SubjectConfigurationInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/SubjectConfigurationInterface.kt
@@ -25,4 +25,5 @@ interface SubjectConfigurationInterface {
     var screenResolution: Size?
     var screenViewPort: Size?
     var colorDepth: Int?
+    var useContextResourcesScreenResolution: Boolean?
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/SubjectConfigurationInterface.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/SubjectConfigurationInterface.kt
@@ -25,5 +25,5 @@ interface SubjectConfigurationInterface {
     var screenResolution: Size?
     var screenViewPort: Size?
     var colorDepth: Int?
-    var useContextResourcesScreenResolution: Boolean?
+    var useContextResourcesScreenResolution: Boolean
 }

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/SubjectControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/SubjectControllerImpl.kt
@@ -92,7 +92,7 @@ class SubjectControllerImpl  // Constructors
             subject.colorDepth = colorDepth
         }
 
-    override var useContextResourcesScreenResolution: Boolean?
+    override var useContextResourcesScreenResolution: Boolean
         get() = subject.useContextResourcesScreenResolution
         set(useContextResourcesScreenResolution) {
             dirtyConfig.useContextResourcesScreenResolution = useContextResourcesScreenResolution

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/SubjectControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/SubjectControllerImpl.kt
@@ -92,6 +92,13 @@ class SubjectControllerImpl  // Constructors
             subject.colorDepth = colorDepth
         }
 
+    override var useContextResourcesScreenResolution: Boolean?
+        get() = subject.useContextResourcesScreenResolution
+        set(useContextResourcesScreenResolution) {
+            dirtyConfig.useContextResourcesScreenResolution = useContextResourcesScreenResolution
+            subject.useContextResourcesScreenResolution = useContextResourcesScreenResolution
+        }
+
     // Private methods
     private val subject: Subject
         get() = serviceProvider.getOrMakeSubject()

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/SubjectConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/SubjectConfiguration.kt
@@ -76,6 +76,11 @@ open class SubjectConfiguration() : Configuration, SubjectConfigurationInterface
     override var colorDepth: Int?
         get() = _colorDepth ?: sourceConfig?.colorDepth
         set(value) { _colorDepth = value }
+
+    private var _useContextResourcesScreenResolution: Boolean? = null
+    override var useContextResourcesScreenResolution: Boolean?
+        get() = _useContextResourcesScreenResolution ?: sourceConfig?.useContextResourcesScreenResolution
+        set(value) { _useContextResourcesScreenResolution = value }
     
     // Builder methods
     
@@ -168,6 +173,17 @@ open class SubjectConfiguration() : Configuration, SubjectConfigurationInterface
         return this
     }
 
+    /**
+     * Set this flag to true to define the default screen resolution (at tracker initialization)
+     * based on the context's Resources display metrics, rather than the deprecated WindowManager. 
+     * NB: the height value will be smaller using Resources as it doesn't include the menu bar.
+     * Defaults to false.
+     */
+    fun useContextResourcesScreenResolution(useContextResourcesScreenResolution: Boolean?): SubjectConfiguration {
+        this.useContextResourcesScreenResolution = useContextResourcesScreenResolution
+        return this
+    }
+
     // Copyable
     override fun copy(): SubjectConfiguration {
         return SubjectConfiguration()
@@ -181,6 +197,7 @@ open class SubjectConfiguration() : Configuration, SubjectConfigurationInterface
             .screenResolution(screenResolution)
             .screenViewPort(screenViewPort)
             .colorDepth(colorDepth)
+            .useContextResourcesScreenResolution(useContextResourcesScreenResolution)
     }
 
     // JSON Formatter

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/SubjectConfiguration.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/configuration/SubjectConfiguration.kt
@@ -78,8 +78,8 @@ open class SubjectConfiguration() : Configuration, SubjectConfigurationInterface
         set(value) { _colorDepth = value }
 
     private var _useContextResourcesScreenResolution: Boolean? = null
-    override var useContextResourcesScreenResolution: Boolean?
-        get() = _useContextResourcesScreenResolution ?: sourceConfig?.useContextResourcesScreenResolution
+    override var useContextResourcesScreenResolution: Boolean
+        get() = _useContextResourcesScreenResolution ?: sourceConfig?.useContextResourcesScreenResolution ?: false
         set(value) { _useContextResourcesScreenResolution = value }
     
     // Builder methods
@@ -179,7 +179,7 @@ open class SubjectConfiguration() : Configuration, SubjectConfigurationInterface
      * NB: the height value will be smaller using Resources as it doesn't include the menu bar.
      * Defaults to false.
      */
-    fun useContextResourcesScreenResolution(useContextResourcesScreenResolution: Boolean?): SubjectConfiguration {
+    fun useContextResourcesScreenResolution(useContextResourcesScreenResolution: Boolean): SubjectConfiguration {
         this.useContextResourcesScreenResolution = useContextResourcesScreenResolution
         return this
     }


### PR DESCRIPTION
For issue #657.

This bug occurs during tracker initialisation when a) an Android application context from a dependency injection framework is passed in, and b) the Android StrictMode rule `detectIncorrectContextUse()` is set for the app.

That rule is violated when creating `Subject`, in `Subject.setDefaultScreenResolution()`, because it uses a deprecated method, via `WindowManager`, to fetch the screen size. The resolution set there in Subject is added to the payload as the "res" property, which eventually becomes the "dvce_screenwidth/height" columns.

The current preferred way is `DisplayManager` or from the `context.resources`. We already use the context Resources to get the screen resolution for the mobile/platform context entity.

Unfortunately, `WindowManager` gives a different answer from `DisplayManager`/`Resources`. The old way includes the menu bar at the top of the screen but that's not included anymore. Changing how Subject fetches the size is therefore a breaking change.

This PR adds a new flag to `SubjectConfiguration`. When set to true (false is default), the default Subject screen size is obtained from the context Resources and `WindowManager` is not accessed - meaning no StrictMode violation.

Currently, the flag is set up just like the other Subject properties. This doesn't seem necessary since it's only used in Subject initialisation. `SubjectController` doesn't really need it, but it inherits from `SubjectConfigurationInterface`. Anyway, it's Friday evening and this fix works.