### PR TITLE
Add missing flush API (close #679)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/FlushTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/tracker/integration/FlushTest.kt
@@ -1,0 +1,49 @@
+package com.snowplowanalytics.snowplow.tracker.integration
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.snowplowanalytics.snowplow.Snowplow
+import com.snowplowanalytics.snowplow.configuration.EmitterConfiguration
+import com.snowplowanalytics.snowplow.configuration.NetworkConfiguration
+import com.snowplowanalytics.snowplow.emitter.BufferOption
+import com.snowplowanalytics.snowplow.event.ScreenView
+import com.snowplowanalytics.snowplow.network.HttpMethod
+import com.snowplowanalytics.snowplow.tracker.MockNetworkConnection
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FlushTest {
+
+    @Test
+    fun testFlushEventsViaTracker() {
+        val networkConnection = MockNetworkConnection(HttpMethod.GET, 200)
+        val networkConfig = NetworkConfiguration(networkConnection)
+        val emitterConfig = EmitterConfiguration().bufferOption(BufferOption.SmallGroup)
+
+        val tracker = Snowplow.createTracker(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            "flush" + Math.random().toString(),
+            networkConfig,
+            emitterConfig
+        )
+        
+        tracker.track(ScreenView("screenName"))
+        Thread.sleep(200)
+        Assert.assertEquals(0, networkConnection.countRequests())
+        
+        tracker.emitter.flush()
+
+        var counter = 0
+        while (networkConnection.countRequests() == 0) {
+            Thread.sleep(500)
+            counter++
+            if (counter > 10) {
+                return
+            }
+        }
+
+        Assert.assertEquals(1, networkConnection.countRequests())
+    }
+}

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterControllerImpl.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/EmitterControllerImpl.kt
@@ -129,6 +129,10 @@ class EmitterControllerImpl(serviceProvider: ServiceProviderInterface) :
         emitter.resumeEmit()
     }
 
+    override fun flush() {
+        emitter.flush()
+    }
+
     // Private methods
     private val dirtyConfig: EmitterConfiguration
         get() = serviceProvider.emitterConfiguration

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/EmitterController.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/controller/EmitterController.kt
@@ -40,4 +40,9 @@ interface EmitterController : EmitterConfigurationInterface {
      * The emitter will resume emitting events again.
      */
     fun resume()
+
+    /**
+     * Flush all stored events.
+     */
+    fun flush()
 }


### PR DESCRIPTION
For issue #679

Exposes the Emitter `flush()` method