### PR TITLE
Set serverAnonymisation more quickly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -17,11 +17,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
+        
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
@@ -30,7 +31,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: Run Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/data/Tracking.kt
+++ b/snowplow-demo-compose/src/main/java/com/snowplowanalytics/snowplowdemocompose/data/Tracking.kt
@@ -20,7 +20,7 @@ object Tracking {
     @Composable
     fun setup(namespace: String) : TrackerController {
         // Replace this collector endpoint with your own
-        val networkConfig = NetworkConfiguration("https://23a6-82-26-43-253.ngrok.io", HttpMethod.POST)
+        val networkConfig = NetworkConfiguration("http://192.168.0.20:9090", HttpMethod.POST)
         val trackerConfig = TrackerConfiguration("appID")
             .logLevel(LogLevel.DEBUG)
             .screenViewAutotracking(false)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
@@ -197,9 +197,7 @@ class Emitter(
     var bufferOption: BufferOption = EmitterDefaults.bufferOption
         /**
          * Whether the buffer should send events instantly or after the buffer has reached
-         * its limit. By default, this is set to BufferOption Default.
-         *
-         * @param option Set the BufferOption enum to Instant to send events upon creation.
+         * its limit.
          */
         set(option) {
             if (!isRunning.get()) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
@@ -303,19 +303,8 @@ class Emitter(
          */
         set(serverAnonymisation) {
             field = serverAnonymisation
-            if (!isCustomNetworkConnection && builderFinished) {
-                networkConnection = emitTimeout?.let {
-                    OkHttpNetworkConnectionBuilder(uri, context)
-                        .method(httpMethod)
-                        .tls(tlsVersions)
-                        .emitTimeout(it)
-                        .customPostPath(customPostPath)
-                        .client(client)
-                        .cookieJar(cookieJar)
-                        .serverAnonymisation(serverAnonymisation)
-                        .requestHeaders(requestHeaders)
-                        .build()
-                }
+            if (!isCustomNetworkConnection && builderFinished && networkConnection is OkHttpNetworkConnection) {
+                (networkConnection as OkHttpNetworkConnection).serverAnonymisation = true
             }
         }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
@@ -302,7 +302,7 @@ class Emitter(
         set(serverAnonymisation) {
             field = serverAnonymisation
             if (!isCustomNetworkConnection && builderFinished && networkConnection is OkHttpNetworkConnection) {
-                (networkConnection as OkHttpNetworkConnection).serverAnonymisation = true
+                (networkConnection as OkHttpNetworkConnection).serverAnonymisation = serverAnonymisation
             }
         }
 

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
@@ -48,7 +48,7 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
     override val httpMethod: HttpMethod
     private val emitTimeout: Int
     private val customPostPath: String?
-    private val serverAnonymisation: Boolean
+    var serverAnonymisation: Boolean
     private val requestHeaders: Map<String, String>?
     private var client: OkHttpClient? = null
     private val uriBuilder: Uri.Builder


### PR DESCRIPTION
For issue #688 

Currently, when `serverAnonymisation` is set in the `Emitter`, the whole `OkHttpNetworkConnection` is recreated. This is slow, so there can be a delay in setting the anonymising `SP-Anonymous` header.

This change sets the `serverAnonymisation` directly in `OkHttpNetworkConnection`. Now the opposite is true - some events tracked just before the flag was set can end up with the `SP-Anonymous` header if they're still being processed when the change is made.

NB: the CI tests for API 30 are currently failing due to flakiness. This is a known problem and will be addressed in a future PR.