### PR TITLE
Send correct install referrer timestamps (close #687)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/InstallReferrerDetails.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/InstallReferrerDetails.kt
@@ -42,8 +42,8 @@ class InstallReferrerDetails(
     "iglu:com.android.installreferrer.api/referrer_details/jsonschema/1-0-0",
     mapOf(
         "installReferrer" to installReferrer,
-        "referrerClickTimestamp" to if (referrerClickTimestamp > 0) { Util.getDateTimeFromTimestamp(referrerClickTimestamp) } else { null },
-        "installBeginTimestamp" to if (installBeginTimestamp > 0) { Util.getDateTimeFromTimestamp(installBeginTimestamp) } else { null },
+        "referrerClickTimestamp" to if (referrerClickTimestamp > 0) { Util.getDateTimeFromTimestamp(referrerClickTimestamp * 1000) } else { null },
+        "installBeginTimestamp" to if (installBeginTimestamp > 0) { Util.getDateTimeFromTimestamp(installBeginTimestamp * 1000) } else { null },
         "googlePlayInstantParam" to googlePlayInstantParam,
     )
 ) {

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/Util.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/utils/Util.kt
@@ -44,6 +44,9 @@ object Util {
         return System.currentTimeMillis().toString()
     }
 
+    /**
+     * Converts a timestamp in milliseconds to a DateTime.
+     */
     @JvmStatic
     fun getDateTimeFromTimestamp(timestamp: Long): String {
         val date = Date(timestamp)


### PR DESCRIPTION
For issue #687 

The Android InstallReferrer library returns timestamps in seconds, but the tracker expects milliseconds. This change fixes it so that the correct timestamp strings are sent.

NB: the CI tests for API 30 are currently failing due to flakiness. This is a known problem and will be addressed in a future PR.