### PR TITLE
Handle exceptions raised by the Executor during initialization of the thread pool for emitter (close #694)

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/internal/emitter/storage/EventStoreTest.kt
@@ -122,7 +122,7 @@ class EventStoreTest {
     @Throws(InterruptedException::class)
     fun testInsertPayload() {
         val eventStore = eventStore()
-        val id = eventStore.insertEvent(payload())
+        val id = eventStore.insertEvent(payload())!!
         val lastRowId = eventStore.lastInsertedRowId
         val event = eventStore.getEvent(id)
         Assert.assertEquals(id, lastRowId)
@@ -153,7 +153,7 @@ class EventStoreTest {
     @Throws(InterruptedException::class)
     fun testRemoveIndividualEvent() {
         val eventStore = eventStore()
-        val id = eventStore.insertEvent(payload())
+        val id = eventStore.insertEvent(payload())!!
         var res = eventStore.removeEvent(id)
         Assert.assertEquals(0, eventStore.size())
         Assert.assertTrue(res)
@@ -169,9 +169,9 @@ class EventStoreTest {
     fun testRemoveRangeOfEvents() {
         val eventStore = eventStore()
         val idList: MutableList<Long> = ArrayList()
-        idList.add(eventStore.insertEvent(payload()))
-        idList.add(eventStore.insertEvent(payload()))
-        idList.add(eventStore.insertEvent(payload()))
+        idList.add(eventStore.insertEvent(payload())!!)
+        idList.add(eventStore.insertEvent(payload())!!)
+        idList.add(eventStore.insertEvent(payload())!!)
         Assert.assertEquals(3, idList.size.toLong())
         Assert.assertEquals(3, eventStore.size())
         var res = eventStore.removeEvents(idList)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
@@ -248,7 +248,7 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
                 request,
                 userAgent
             ) else buildPostRequest(request, userAgent)
-            futures.add(Executor.futureCallable(getRequestCallable(okHttpRequest)))
+            Executor.futureCallable(getRequestCallable(okHttpRequest))?.let { futures.add(it) }
         }
         Logger.d(TAG, "Request Futures: %s", futures.size)
 


### PR DESCRIPTION
Issue #694 

Adds exception handling in the `Executor.futureCallable` function that could raise `RejectedExecutionException` errors as raised in the issue.

Also removes a few `!!` because they make me uneasy.