### PR TITLE
Fix concurrent modification when creating TrackerEvent by copying the payload (close #692)

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerEvent.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/tracker/TrackerEvent.kt
@@ -43,8 +43,12 @@ class TrackerEvent @JvmOverloads constructor(event: Event, state: TrackerStateSn
     init {
         entities = event.entities.toMutableList()
         trueTimestamp = event.trueTimestamp
-        payload = HashMap(event.dataPayload)
-        
+        // NOTE: this code is a workaround since the types of the `Event.dataPayload` and `TrackerEvent.payload` don't match
+        // `Event` allows the values to be optional, while `TrackerEvent` does not.
+        // We should fix this in the next major version to unify the types.
+        // The `toMap()` is called in order to make a copy before calling HashMap as that can lead to concurrency issues, see #692
+        payload = HashMap(event.dataPayload.toMap())
+
         if (state != null) {
             this.state = state
         } else {


### PR DESCRIPTION
Issue #692 

This PR aims to address the exception thrown in the `TrackerEvent` when the payload is initialized by calling `HashMap()` which runs an iterator on the data. The iterator can raise an error in case the data is modified.

The fix is to copy to the `dataPayload` using `toMap()` which should help avoid problems with modification of the source data.

This is only a theoretical fix as I was unable to reproduce the issue.