### PR TITLE
Fix concurrent emitter race condition during ServiceProvider reset

### DIFF
--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/core/emitter/Emitter.kt
@@ -293,6 +293,7 @@ class Emitter(
     /**
      * Whether to anonymise server-side user identifiers including the `network_userid` and `user_ipaddress`
      */
+    @Volatile
     var serverAnonymisation: Boolean = EmitterDefaults.serverAnonymisation
         /**
          * Updates the server anonymisation setting for the Emitter.
@@ -503,6 +504,11 @@ class Emitter(
      * + Otherwise will attempt to emit again
      */
     private fun attemptEmit(networkConnection: NetworkConnection?) {
+        if (!isRunning.get()) {
+            Logger.d(TAG, "Emitter loop stopping: emitter has been shut down.")
+            return
+        }
+        
         if (isEmittingPaused.get()) {
             Logger.d(TAG, "Emitter paused.")
             isRunning.compareAndSet(true, false)

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/network/OkHttpNetworkConnection.kt
@@ -49,6 +49,7 @@ class OkHttpNetworkConnection private constructor(builder: OkHttpNetworkConnecti
     override val httpMethod: HttpMethod
     private val emitTimeout: Int
     private val customPostPath: String?
+    @Volatile
     var serverAnonymisation: Boolean
     private val requestHeaders: Map<String, String>?
     private var client: OkHttpClient? = null


### PR DESCRIPTION
## Problem

When `ServiceProvider.reset()` is triggered by a remote config update, the **old** emitter's `attemptEmit()` loop continues running after `shutdown()` because:

1. `shutdown()` is graceful — already-running tasks complete.
2. `attemptEmit()` never checks `isRunning` as a loop gate — it recurses until the EventStore is drained, regardless of shutdown state.
3. `serverAnonymisation` is a plain `var` with no memory visibility guarantees across threads.

The old and new emitters then both read from the same `SQLiteEventStore`, causing duplicate/conflicting HTTP requests — one with `SP-Anonymous: *` and one without.

## Fix

Three targeted changes:

### 1. `isRunning` gate in `attemptEmit()` (`Emitter.kt`)

Added an `isRunning.get()` check at the very top of `attemptEmit()`, before any EventStore reads or network calls. Once `shutdown()` sets `isRunning` to `false`, the next recursive `attemptEmit()` call exits immediately instead of continuing to drain the EventStore.

### 2. `@Volatile` on `Emitter.serverAnonymisation` (`Emitter.kt`)

The field is written from the app thread (via `EmitterControllerImpl`) and read from the Executor thread pool. Without `@Volatile`, the JVM does not guarantee the Executor thread sees the updated value.

### 3. `@Volatile` on `OkHttpNetworkConnection.serverAnonymisation` (`OkHttpNetworkConnection.kt`)

Same cross-thread visibility issue. `buildPostRequest()` / `buildGetRequest()` read this field on the Executor thread to decide whether to add the `SP-Anonymous: *` header.

## What this does NOT change

`Executor.shutdown()` remains a graceful `shutdown()` (not `shutdownNow()`). The `isRunning` gate is sufficient to prevent new batches, and in-flight HTTP requests completing harmlessly is preferable to interrupting them — events are only removed from the EventStore after successful send confirmation, so they would be retried by the new emitter regardless.