### PR TITLE
Strip empty strings from optional media player entity fields

### DIFF
--- a/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/media/MediaEventAndEntitySerializationTest.kt
+++ b/snowplow-tracker/src/androidTest/java/com/snowplowanalytics/snowplow/media/MediaEventAndEntitySerializationTest.kt
@@ -94,6 +94,20 @@ class MediaEventAndEntitySerializationTest {
     }
 
     @Test
+    fun stripsEmptyStringValuesFromMediaPlayer() {
+        val entity = MediaPlayerEntity(
+            label = "",
+            playerType = "",
+            quality = "",
+        )
+
+        val data = entity.entity.map["data"] as? Map<*, *>
+        assertFalse(data?.containsKey("label") ?: true)
+        assertFalse(data?.containsKey("playerType") ?: true)
+        assertFalse(data?.containsKey("quality") ?: true)
+    }
+
+    @Test
     fun buildsMediaSessionEntity() {
         val date = Date()
         val timeTraveler = TimeTraveler()

--- a/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/media/entity/MediaPlayerEntity.kt
+++ b/snowplow-tracker/src/main/java/com/snowplowanalytics/snowplow/media/entity/MediaPlayerEntity.kt
@@ -80,7 +80,7 @@ data class MediaPlayerEntity @JvmOverloads constructor(
                 "playbackRate" to playbackRate,
                 "quality" to quality,
                 "volume" to volume
-            ).filter { it.value != null }
+            ).filter { it.value != null && it.value != "" }
         )
 
     internal fun update(player: MediaPlayerEntity) {


### PR DESCRIPTION
The media_player entity (iglu:com.snowplowanalytics.snowplow/media_player/jsonschema/2-0-0) can produce inconsistent values for optional string fields (label, playerType, quality). The .filter { it.value != null } predicate in MediaPlayerEntity.entity removes null entries but passes through empty strings. When callers supply "" where null is intended, the field is present but empty rather than absent, resulting in "" in the warehouse instead of NULL.
The dbt media player package treats "" and NULL as distinct values. When the same media content generates events with both representations, it produces different surrogate keys for media_identifier, causing merge conflicts and duplicate rows in aggregated models.

Fix
Expanded the .filter predicate in the entity getter from:
```
kotlin.filter { it.value != null }
```
to:
```
kotlin.filter { it.value != null && it.value != "" }
```

Empty strings are now filtered out alongside nulls, so optional string fields set to "" are omitted from the payload entirely.