### PR TITLE
ci(implement): add label_trigger + allowed_bots so dispatcher-created issues actually run

### DIFF
--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -60,6 +60,14 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The `implement` label on this issue IS the trigger. Without
+          # this the action looks for `@claude` in the body, finds
+          # nothing, and exits silently.
+          label_trigger: implement
+          # The dispatching issue is authored by the snowplow-claude-review
+          # GitHub App. Without this opt-in the action filters bot-authored
+          # events to prevent recursion.
+          allowed_bots: '*'
           additional_permissions: |
             actions: read
           claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(./gradlew:*),Bash(gradle:*)"'


### PR DESCRIPTION
## Diagnosis

A recent dispatch ([run 26395866251](https://github.com/snowplow/snowplow-android-tracker/actions/runs/26395866251)) labelled an issue and the workflow completed *successfully* without producing a PR. The Claude Code action logged:

\`\`\`
No trigger was met for @claude
Actor is a GitHub App: snowplow-claude-review[bot]
Context prompt: NO PROMPT
Trigger result: false
No trigger found, skipping remaining steps
\`\`\`

Two of \`anthropics/claude-code-action@v1\`'s defaults caused this:

1. **Default trigger is \`@claude\` in the issue body.** Our dispatcher doesn't include that string — the design is that the \`implement\` label IS the signal.
2. **Bot-authored events are filtered out by default** (anti-recursion safety). Our dispatcher authenticates as the \`snowplow-claude-review\` App, so its issues come from a bot actor.

## Fix

Two new inputs from the [action's usage docs](https://github.com/anthropics/claude-code-action/blob/v1/docs/usage.md):

\`\`\`yaml
label_trigger: implement
allowed_bots: '*'
\`\`\`

\`label_trigger\` tells the action the label IS the trigger condition (no \`@claude\` in the body needed). \`allowed_bots: '*'\` opts in to bot-created events, which is exactly the dispatcher's purpose.

## Test plan

- [ ] Lint: yamllint + actionlint (clean).
- [ ] Re-dispatch the original implement run that produced the empty success. Confirm the action picks up the issue, drafts the change, opens a PR.

## Same fix needed on six other repos

The other six repos (\`signals-monorepo\`, \`snowplow-signals-{python,typescript}-sdk\`, \`snowplow-{javascript,ios,flutter}-tracker\`) all share this workflow shape and will hit the same issue. Doing each as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)